### PR TITLE
String build

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -115,15 +115,6 @@ abstract class AbstractQuery
 
     /**
      * 
-     * The statement being built.
-     * 
-     * @var string
-     * 
-     */
-    protected $stm;
-    
-    /**
-     * 
      * The suffix to use when quoting identifier names.
      * 
      * @var string
@@ -140,9 +131,7 @@ abstract class AbstractQuery
      * 
      * @param string $quote_name_suffix The suffix to use when quoting
      * identifier names.
-     * 
-     * @return null
-     * 
+     *
      */
     public function __construct($quote_name_prefix, $quote_name_suffix)
     {
@@ -261,16 +250,18 @@ abstract class AbstractQuery
 
     /**
      * 
-     * Returns the flags as a space-separated string.
+     * Builds the flags as a space-separated string.
      *
      * @return string
      * 
      */
     protected function buildFlags()
     {
-        if ($this->flags) {
-            $this->stm .= ' ' . implode(' ', array_keys($this->flags));
+        if (! $this->flags) {
+            return ''; // not applicable
         }
+
+        return ' ' . implode(' ', array_keys($this->flags));
     }
 
     /**
@@ -533,16 +524,18 @@ abstract class AbstractQuery
 
     /**
      *
-     * Appends the `WHERE` clause to the statement.
+     * Builds the `WHERE` clause of the statement.
      *
-     * @return null
+     * @return string
      *
      */
     protected function buildWhere()
     {
-        if ($this->where) {
-            $this->stm .= PHP_EOL . 'WHERE' . $this->indent($this->where);
+        if (! $this->where) {
+            return ''; // not applicable
         }
+
+        return PHP_EOL . 'WHERE' . $this->indent($this->where);
     }
 
     /**
@@ -622,14 +615,14 @@ abstract class AbstractQuery
 
     /**
      *
-     * Appends the insert columns and values to the statement.
+     * Builds the inserted columns and values of the statement.
      *
-     * @return null
+     * @return string
      *
      */
     protected function buildValuesForInsert()
     {
-        $this->stm .= ' ('
+        return ' ('
             . $this->indentCsv(array_keys($this->values))
             . PHP_EOL . ') VALUES ('
             . $this->indentCsv(array_values($this->values))
@@ -638,9 +631,9 @@ abstract class AbstractQuery
 
     /**
      *
-     * Appends the update columns and values to the statement.
+     * Builds the updated columns and values of the statement.
      *
-     * @return null
+     * @return string
      *
      */
     protected function buildValuesForUpdate()
@@ -649,7 +642,7 @@ abstract class AbstractQuery
         foreach ($this->values as $col => $value) {
             $values[] = "{$col} = {$value}";
         }
-        $this->stm .= PHP_EOL . 'SET' . $this->indentCsv($values);
+        return PHP_EOL . 'SET' . $this->indentCsv($values);
     }
 
     /**
@@ -671,23 +664,25 @@ abstract class AbstractQuery
 
     /**
      *
-     * Appends the `ORDER BY ...` clause to the statement.
+     * Builds the `ORDER BY ...` clause of the statement.
      *
-     * @return null
+     * @return string
      *
      */
     protected function buildOrderBy()
     {
-        if ($this->order_by) {
-            $this->stm .= PHP_EOL . 'ORDER BY' . $this->indentCsv($this->order_by);
+        if (! $this->order_by) {
+            return ''; // not applicable
         }
+
+        return PHP_EOL . 'ORDER BY' . $this->indentCsv($this->order_by);
     }
 
     /**
      *
-     * Appends the `LIMIT ... OFFSET` clause to the statement.
+     * Builds the `LIMIT ... OFFSET` clause of the statement.
      *
-     * @return null
+     * @return string
      *
      */
     protected function buildLimit()
@@ -696,13 +691,16 @@ abstract class AbstractQuery
         $has_offset = $this instanceof LimitOffsetInterface;
 
         if ($has_offset && $this->limit) {
-            $this->stm .= PHP_EOL . "LIMIT {$this->limit}";
+            $clause = PHP_EOL . "LIMIT {$this->limit}";
             if ($this->offset) {
-                $this->stm .= " OFFSET {$this->offset}";
+                $clause .= " OFFSET {$this->offset}";
             }
+            return $clause;
         } elseif ($has_limit && $this->limit) {
-            $this->stm .= PHP_EOL . "LIMIT {$this->limit}";
+            return PHP_EOL . "LIMIT {$this->limit}";
         }
+
+        return ''; // not applicable
     }
 
     /**
@@ -727,15 +725,17 @@ abstract class AbstractQuery
 
     /**
      *
-     * Appends the `RETURNING` clause to the statement.
+     * Builds the `RETURNING` clause of the statement.
      *
-     * @return null
+     * @return string
      *
      */
     protected function buildReturning()
     {
-        if ($this->returning) {
-            $this->stm .= PHP_EOL . 'RETURNING' . $this->indentCsv($this->returning);
+        if (! $this->returning) {
+            return ''; // not applicable
         }
+
+        return PHP_EOL . 'RETURNING' . $this->indentCsv($this->returning);
     }
 }

--- a/src/Common/Delete.php
+++ b/src/Common/Delete.php
@@ -57,7 +57,10 @@ class Delete extends AbstractQuery implements DeleteInterface
         return 'DELETE'
             . $this->buildFlags()
             . $this->buildFrom()
-            . $this->buildWhere();
+            . $this->buildWhere()
+            . $this->buildOrderBy()
+            . $this->buildLimit()
+            . $this->buildReturning();
     }
     
     /**

--- a/src/Common/Delete.php
+++ b/src/Common/Delete.php
@@ -54,23 +54,22 @@ class Delete extends AbstractQuery implements DeleteInterface
      */
     protected function build()
     {
-        $this->stm = 'DELETE';
-        $this->buildFlags();
-        $this->buildFrom();
-        $this->buildWhere();
-        return $this->stm;
+        return 'DELETE'
+            . $this->buildFlags()
+            . $this->buildFrom()
+            . $this->buildWhere();
     }
     
     /**
      * 
      * Builds the FROM clause.
      *
-     * @return null
+     * @return string
      * 
      */
     protected function buildFrom()
     {
-        $this->stm .= " FROM {$this->from}";
+        return " FROM {$this->from}";
     }
 
     /**

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -58,7 +58,8 @@ class Insert extends AbstractQuery implements InsertInterface
         return 'INSERT'
             . $this->buildFlags()
             . $this->buildInto()
-            . $this->buildValuesForInsert();
+            . $this->buildValuesForInsert()
+            . $this->buildReturning();
     }
     
     /**

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -55,23 +55,22 @@ class Insert extends AbstractQuery implements InsertInterface
      */
     protected function build()
     {
-        $this->stm = 'INSERT';
-        $this->buildFlags();
-        $this->buildInto();
-        $this->buildValuesForInsert();
-        return $this->stm;
+        return 'INSERT'
+            . $this->buildFlags()
+            . $this->buildInto()
+            . $this->buildValuesForInsert();
     }
     
     /**
      * 
      * Builds the INTO clause.
      * 
-     * @return null
+     * @return string
      * 
      */
     protected function buildInto()
     {
-        $this->stm .= " INTO " . $this->quoteName($this->into);
+        return " INTO " . $this->quoteName($this->into);
     }
     
     /**

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -507,92 +507,100 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function build()
     {
-        $this->stm = 'SELECT';
-        $this->buildFlags();
-        $this->buildCols();
-        $this->buildFrom(); // includes JOIN
-        $this->buildWhere();
-        $this->buildGroupBy();
-        $this->buildHaving();
-        $this->buildOrderBy();
-        $this->buildLimit();
-        $this->buildForUpdate();
-        return $this->stm;
+        return 'SELECT'
+            . $this->buildFlags()
+            . $this->buildCols()
+            . $this->buildFrom() // includes JOIN
+            . $this->buildWhere()
+            . $this->buildGroupBy()
+            . $this->buildHaving()
+            . $this->buildOrderBy()
+            . $this->buildLimit()
+            . $this->buildForUpdate();
     }
     
     /**
      * 
      * Builds the columns clause.
      * 
-     * @return null
+     * @return string
      * 
      */
     protected function buildCols()
     {
-        if ($this->cols) {
-            $this->stm .= $this->indentCsv($this->cols);
-            return;
+        if (! $this->cols) {
+            return ''; // not applicable
         }
+
+        return $this->indentCsv($this->cols);
     }
     
     /**
      * 
      * Builds the FROM clause.
      * 
-     * @return null
+     * @return string
      * 
      */
     protected function buildFrom()
     {
-        if ($this->from) {
-            $refs = array();
-            foreach ($this->from as $from) {
-                $refs[] = implode(PHP_EOL, $from);
-            }
-            $this->stm .= PHP_EOL . 'FROM' . $this->indentCsv($refs);
+        if (! $this->from) {
+            return ''; // not applicable
         }
+
+        $refs = array();
+        foreach ($this->from as $from) {
+            $refs[] = implode(PHP_EOL, $from);
+        }
+        return PHP_EOL . 'FROM' . $this->indentCsv($refs);
     }
     
     /**
      * 
      * Builds the GROUP BY clause.
      * 
-     * @return null
+     * @return string
      * 
      */
     protected function buildGroupBy()
     {
-        if ($this->group_by) {
-            $this->stm .= PHP_EOL . 'GROUP BY' . $this->indentCsv($this->group_by);
+        if (! $this->group_by) {
+            return ''; // not applicable
         }
+
+        return PHP_EOL . 'GROUP BY' . $this->indentCsv($this->group_by);
     }
     
     /**
      * 
      * Builds the HAVING clause.
      * 
-     * @return null
+     * @return string
      * 
      */
     protected function buildHaving()
     {
-        if ($this->having) {
-            $this->stm .= PHP_EOL . 'HAVING' . $this->indent($this->having);
+        if (! $this->having) {
+            return ''; // not applicable
         }
+
+        return PHP_EOL . 'HAVING' . $this->indent($this->having);
     }
     
     /**
      * 
      * Builds the FOR UPDATE clause.
      * 
-     * @return null
+     * @return string
      * 
      */
     protected function buildForUpdate()
     {
-        if ($this->for_update) {
-            $this->stm .= PHP_EOL . 'FOR UPDATE';
+        if (! $this->for_update) {
+            return ''; // not applicable
         }
+
+        return PHP_EOL . 'FOR UPDATE';
     }
 
     /**

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -54,12 +54,11 @@ class Update extends AbstractQuery implements UpdateInterface
      */
     protected function build()
     {
-        $this->stm = 'UPDATE';
-        $this->buildFlags();
-        $this->buildTable();
-        $this->buildValuesForUpdate();
-        $this->buildWhere();
-        return $this->stm;
+        return 'UPDATE'
+            . $this->buildFlags()
+            . $this->buildTable()
+            . $this->buildValuesForUpdate()
+            . $this->buildWhere();
     }
     
     /**
@@ -71,7 +70,7 @@ class Update extends AbstractQuery implements UpdateInterface
      */
     protected function buildTable()
     {
-        $this->stm .= " {$this->table}";
+        return " {$this->table}";
     }
 
     /**

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -58,7 +58,10 @@ class Update extends AbstractQuery implements UpdateInterface
             . $this->buildFlags()
             . $this->buildTable()
             . $this->buildValuesForUpdate()
-            . $this->buildWhere();
+            . $this->buildWhere()
+            . $this->buildOrderBy()
+            . $this->buildLimit()
+            . $this->buildReturning();
     }
     
     /**

--- a/src/Mysql/Delete.php
+++ b/src/Mysql/Delete.php
@@ -22,20 +22,6 @@ use Aura\Sql_Query\Common;
 class Delete extends Common\Delete implements Common\OrderByInterface, Common\LimitInterface
 {
     /**
-     * 
-     * Converts this query object to a string.
-     * 
-     * @return string
-     * 
-     */
-    protected function build()
-    {
-        return parent::build()
-            . $this->buildOrderBy()
-            . $this->buildLimit();
-    }
-
-    /**
      *
      * Adds or removes LOW_PRIORITY flag.
      *

--- a/src/Mysql/Delete.php
+++ b/src/Mysql/Delete.php
@@ -30,10 +30,9 @@ class Delete extends Common\Delete implements Common\OrderByInterface, Common\Li
      */
     protected function build()
     {
-        parent::build();
-        $this->buildOrderBy();
-        $this->buildLimit();
-        return $this->stm;
+        return parent::build()
+            . $this->buildOrderBy()
+            . $this->buildLimit();
     }
 
     /**

--- a/src/Mysql/Update.php
+++ b/src/Mysql/Update.php
@@ -30,10 +30,9 @@ class Update extends Common\Update implements Common\OrderByInterface, Common\Li
      */
     protected function build()
     {
-        parent::build();
-        $this->buildOrderBy();
-        $this->buildLimit();
-        return $this->stm;
+        return parent::build()
+            . $this->buildOrderBy()
+            . $this->buildLimit();
     }
 
     /**

--- a/src/Mysql/Update.php
+++ b/src/Mysql/Update.php
@@ -22,20 +22,6 @@ use Aura\Sql_Query\Common;
 class Update extends Common\Update implements Common\OrderByInterface, Common\LimitInterface
 {
     /**
-     * 
-     * Converts this query object to a string.
-     * 
-     * @return string
-     * 
-     */
-    protected function build()
-    {
-        return parent::build()
-            . $this->buildOrderBy()
-            . $this->buildLimit();
-    }
-
-    /**
      *
      * Adds or removes LOW_PRIORITY flag.
      *

--- a/src/Pgsql/Delete.php
+++ b/src/Pgsql/Delete.php
@@ -30,9 +30,8 @@ class Delete extends Common\Delete implements Common\ReturningInterface
      */
     protected function build()
     {
-        parent::build();
-        $this->buildReturning();
-        return $this->stm;
+        return parent::build()
+            . $this->buildReturning();
     }
 
     /**

--- a/src/Pgsql/Delete.php
+++ b/src/Pgsql/Delete.php
@@ -22,19 +22,6 @@ use Aura\Sql_Query\Common;
 class Delete extends Common\Delete implements Common\ReturningInterface
 {
     /**
-     * 
-     * Converts this query object to a string.
-     * 
-     * @return string
-     * 
-     */
-    protected function build()
-    {
-        return parent::build()
-            . $this->buildReturning();
-    }
-
-    /**
      *
      * Adds returning columns to the query.
      *

--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -30,9 +30,8 @@ class Insert extends Common\Insert implements Common\ReturningInterface
      */
     protected function build()
     {
-        parent::build();
-        $this->buildReturning();
-        return $this->stm;
+        return parent::build()
+            . $this->buildReturning();
     }
     
     /**

--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -23,19 +23,6 @@ class Insert extends Common\Insert implements Common\ReturningInterface
 {
     /**
      * 
-     * Builds this query object into a string.
-     * 
-     * @return string
-     * 
-     */
-    protected function build()
-    {
-        return parent::build()
-            . $this->buildReturning();
-    }
-    
-    /**
-     * 
      * Returns the proper name for passing to `PDO::lastInsertId()`.
      * 
      * @param string $col The last insert ID column.

--- a/src/Pgsql/Update.php
+++ b/src/Pgsql/Update.php
@@ -30,9 +30,8 @@ class Update extends Common\Update implements Common\ReturningInterface
      */
     protected function build()
     {
-        parent::build();
-        $this->buildReturning();
-        return $this->stm;
+        return parent::build()
+            . $this->buildReturning();
     }
 
     /**

--- a/src/Pgsql/Update.php
+++ b/src/Pgsql/Update.php
@@ -22,19 +22,6 @@ use Aura\Sql_Query\Common;
 class Update extends Common\Update implements Common\ReturningInterface
 {
     /**
-     * 
-     * Builds this query object into a string.
-     * 
-     * @return string
-     * 
-     */
-    protected function build()
-    {
-        return parent::build()
-            . $this->buildReturning();
-    }
-
-    /**
      *
      * Adds returning columns to the query.
      *

--- a/src/Sqlite/Delete.php
+++ b/src/Sqlite/Delete.php
@@ -22,20 +22,6 @@ use Aura\Sql_Query\Common;
 class Delete extends Common\Delete implements Common\OrderByInterface, Common\LimitOffsetInterface
 {
     /**
-     * 
-     * Builds this query object into a string.
-     * 
-     * @return string
-     * 
-     */
-    protected function build()
-    {
-        return parent::build()
-            . $this->buildOrderBy()
-            . $this->buildLimit();
-    }
-
-    /**
      *
      * Sets a limit count on the query.
      *

--- a/src/Sqlite/Delete.php
+++ b/src/Sqlite/Delete.php
@@ -30,10 +30,9 @@ class Delete extends Common\Delete implements Common\OrderByInterface, Common\Li
      */
     protected function build()
     {
-        parent::build();
-        $this->buildOrderBy();
-        $this->buildLimit();
-        return $this->stm;
+        return parent::build()
+            . $this->buildOrderBy()
+            . $this->buildLimit();
     }
 
     /**

--- a/src/Sqlite/Update.php
+++ b/src/Sqlite/Update.php
@@ -30,10 +30,9 @@ class Update extends Common\Update implements Common\OrderByInterface, Common\Li
      */
     protected function build()
     {
-        parent::build();
-        $this->buildOrderBy();
-        $this->buildLimit();
-        return $this->stm;
+        return parent::build()
+            . $this->buildOrderBy()
+            . $this->buildLimit();
     }
 
     /**

--- a/src/Sqlite/Update.php
+++ b/src/Sqlite/Update.php
@@ -22,20 +22,6 @@ use Aura\Sql_Query\Common;
 class Update extends Common\Update implements Common\OrderByInterface, Common\LimitOffsetInterface
 {
     /**
-     * 
-     * Builds this query object into a string.
-     * 
-     * @return string
-     * 
-     */
-    protected function build()
-    {
-        return parent::build()
-            . $this->buildOrderBy()
-            . $this->buildLimit();
-    }
-
-    /**
      *
      * Adds or removes OR ABORT flag.
      *

--- a/src/Sqlsrv/Select.php
+++ b/src/Sqlsrv/Select.php
@@ -22,34 +22,53 @@ use Aura\Sql_Query\Common;
 class Select extends Common\Select
 {
     /**
-     * 
-     * Builds the limit/offset equivalent portions of the statement.
-     * 
-     * @return null
-     * 
+     *
+     * Builds this query object into a string.
+     *
+     * @return string
+     *
+     */
+    protected function build()
+    {
+        return $this->applyLimit(parent::build());
+    }
+
+    /**
+     * @see build()
+     * @see applyLimit()
      */
     protected function buildLimit()
     {
-        // neither limit nor offset?
+        return ''; // limit equivalent will be applied by applyLimit()
+    }
+
+    /**
+     * 
+     * Modify the statement applying limit/offset equivalent portions to it.
+     *
+     * @param string $stm SQL statement
+     * @return string SQL statement with limit/offset applied
+     * 
+     */
+    protected function applyLimit($stm)
+    {
         if (! $this->limit && ! $this->offset) {
-            // no changes
-            return;
+            return $stm; // no limit or offset
         }
         
         // limit but no offset?
         if ($this->limit && ! $this->offset) {
             // use TOP in place
-            $this->stm = preg_replace(
+            return preg_replace(
                 '/^(SELECT( DISTINCT)?)/',
                 "$1 TOP {$this->limit}",
-                $this->stm
+                $stm
             );
-            return;
         }
         
         // both limit and offset. must have an ORDER clause to work; OFFSET is
         // a sub-clause of the ORDER clause. cannot use FETCH without OFFSET.
-        $this->stm .= PHP_EOL . "OFFSET {$this->offset} ROWS "
+        return $stm . PHP_EOL . "OFFSET {$this->offset} ROWS "
                     . "FETCH NEXT {$this->limit} ROWS ONLY";
     }
 }


### PR DESCRIPTION
This branch factors away `AbstractQuery::$stm` avoiding accumulation of state and the previously implied order in which `build_()` methods must be called; all `build_()` methods now return strings. (first commit - passing all unit tests)

I also factored away the driver-specific `build()` methods which are no longer necessary, since the `AbstractQuery` base class is responsible for all of the actual string-building; the only exception being the MS-SQL driver, which needs to manipulate the actual statement. (second commit - passing all unit tests)

You may or may not agree with the second commit - arguably, the driver-specific `build()` methods don't add anything, but you could argue that they provide clarity, as far as which portions of a statement is actually applicable to what driver. (I understand if you prefer not to pull the second commit.)

On a related note, MS-SQL 2012 and newer might benefit from having a dedicated driver - while `LIMIT` and `OFFSET` are still not supported, something [very similar](http://dbadiaries.com/new-t-sql-features-in-sql-server-2012-offset-and-fetch) is supported since the 2012 release and forward, and you could probably override `buildLimit()` and add support for that easily. (personally I don't care or need MS-SQL support.)
