### PR TITLE
A less magical fix for #24

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -242,7 +242,7 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
-     * Adds a FROM table and columns to the query.
+     * Adds a FROM element to the query; quotes the table name automatically.
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
      *
@@ -251,11 +251,25 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function from($spec)
     {
-        $this->from[] = array($this->quoter->quoteName($spec));
+        return $this->fromRaw($this->quoter->quoteName($spec));
+    }
+
+    /**
+     *
+     * Adds a raw unquoted FROM element to the query; useful for adding FROM
+     * elements that are functions.
+     *
+     * @param string $spec The table specification, e.g. "function_name()".
+     *
+     * @return self
+     *
+     */
+    public function fromRaw($spec)
+    {
+        $this->from[] = array($spec);
         $this->from_key ++;
         return $this;
     }
-
     /**
      *
      * Adds an aliased sub-select to the query.

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -81,7 +81,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
 
     /**
      *
-     * Adds a FROM table and columns to the query.
+     * Adds a FROM element to the query; quotes the table name automatically.
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
      *
@@ -89,6 +89,18 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      */
     public function from($spec);
+
+    /**
+     *
+     * Adds a raw unquoted FROM element to the query; useful for adding FROM
+     * elements that are functions.
+     *
+     * @param string $spec The table specification, e.g. "function_name()".
+     *
+     * @return self
+     *
+     */
+    public function fromRaw($spec);
 
     /**
      *

--- a/tests/src/QuoterTest.php
+++ b/tests/src/QuoterTest.php
@@ -47,25 +47,4 @@ class QuoterTest extends \PHPUnit_Framework_TestCase
         $expect = "*, *.*, `foo`.`bar`, CONCAT('foo.bar', \"baz.dib\") AS `zim`";
         $this->assertSame($expect, $actual);
     }
-
-    // no not quote with trailing parentheses
-    public function testIssue24()
-    {
-        $actual = $this->quoter->quoteName('foo()');
-        $this->assertSame('foo()', $actual);
-
-        $actual = $this->quoter->quoteName('foo(bar)');
-        $this->assertSame('foo(bar)', $actual);
-
-        $actual = $this->quoter->quoteName('foo.bar()');
-        $this->assertSame('`foo`.bar()', $actual);
-
-        $actual = $this->quoter->quoteName('foo().bar');
-        $this->assertSame('foo().`bar`', $actual);
-
-        $sql = "schema.foo(), schema.foo('foo.bar', baz.dib, zim)";
-        $actual = $this->quoter->quoteNamesIn($sql);
-        $expect = "`schema`.foo(), `schema`.foo('foo.bar', `baz`.`dib`, zim)";
-        $this->assertSame($expect, $actual);
-    }
 }


### PR DESCRIPTION
This replaces the intention-divining logic in the Quoter with a more straightforward `Select::fromRaw()` method. Using this method means the name will not be quoted.
