### PR TITLE
Alternative key-cols-by-alias logic

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -233,7 +233,11 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function addCol($key, $val)
     {
-        $this->cols[] = array($key, $val);
+        if (is_int($key)) {
+            $this->cols[] = $val;
+        } else {
+            $this->cols[$val] = $key;
+        }
     }
 
     /**
@@ -588,12 +592,11 @@ class Select extends AbstractQuery implements SelectInterface
         }
 
         $cols = array();
-        foreach ($this->cols as $colspec) {
-            list($key, $val) = $colspec;
+        foreach ($this->cols as $key => $val) {
             if (is_int($key)) {
                 $cols[] = $this->quoter->quoteNamesIn($val);
             } else {
-                $cols[] = $this->quoter->quoteNamesIn("$key AS $val");
+                $cols[] = $this->quoter->quoteNamesIn("$val AS $key");
             }
         }
 

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -233,11 +233,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function addCol($key, $val)
     {
-        if (is_int($key)) {
-            $this->cols[] = $this->quoter->quoteNamesIn($val);
-        } else {
-            $this->cols[] = $this->quoter->quoteNamesIn("$key AS $val");
-        }
+        $this->cols[] = array($key, $val);
     }
 
     /**
@@ -591,7 +587,17 @@ class Select extends AbstractQuery implements SelectInterface
             throw new Exception('No columns in the SELECT.');
         }
 
-        return $this->indentCsv($this->cols);
+        $cols = array();
+        foreach ($this->cols as $colspec) {
+            list($key, $val) = $colspec;
+            if (is_int($key)) {
+                $cols[] = $this->quoter->quoteNamesIn($val);
+            } else {
+                $cols[] = $this->quoter->quoteNamesIn("$key AS $val");
+            }
+        }
+
+        return $this->indentCsv($cols);
     }
 
     /**

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -233,10 +233,27 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function addCol($key, $val)
     {
-        if (is_int($key)) {
-            $this->cols[] = $val;
-        } else {
+        if (is_string($key)) {
+            // [col => alias]
             $this->cols[$val] = $key;
+        } else {
+            $this->addColWithAlias($val);
+        }
+    }
+
+    protected function addColWithAlias($spec)
+    {
+        $parts = explode(' ', $spec);
+        $count = count($parts);
+        if ($count == 2) {
+            // "col alias"
+            $this->cols[$parts[1]] = $parts[0];
+        } elseif ($count == 3 && strtoupper($parts[1]) == 'AS') {
+            // "col AS alias"
+            $this->cols[$parts[2]] = $parts[0];
+        } else {
+            // no recognized alias
+            $this->cols[] = $spec;
         }
     }
 

--- a/tests/src/Common/SelectTest.php
+++ b/tests/src/Common/SelectTest.php
@@ -534,4 +534,40 @@ class SelectTest extends AbstractQueryTest
         $actual = $this->query->getBindValues();
         $this->assertSame($expect, $actual);
     }
+
+    public function testAddColWithAlias()
+    {
+        $this->query->cols(array(
+            'foo',
+            'bar',
+            'table.noalias',
+            'col1 as alias1',
+            'col2 alias2',
+            'table.proper' => 'alias_proper',
+            'legacy invalid as alias still works',
+            'overwrite as alias1',
+        ));
+
+        // add separately to make sure we don't overwrite sequential keys
+        $this->query->cols(array(
+            'baz',
+            'dib',
+        ));
+
+        $actual = $this->query->__toString();
+
+        $expect = '
+            SELECT
+                foo,
+                bar,
+                <<table>>.<<noalias>>,
+                overwrite AS <<alias1>>,
+                col2 AS <<alias2>>,
+                <<table>>.<<proper>> AS <<alias_proper>>,
+                legacy invalid AS <<alias still works>>,
+                baz,
+                dib
+        ';
+        $this->assertSameSql($expect, $actual);
+    }
 }


### PR DESCRIPTION
@mbrevda there were some issues with your PR:
- did not address "col alias" (i.e., space as AS, which is allowed)
- it looked like it might overwrite sequential keys on subsequent calls to cols() but I did not test it
- the test itself looked backwards to me; it should be "col AS alias"

I have added the "key $cols by the alias when present" functionality in an alternative fashion in this PR. There is one "gotcha" and it is that later uses of the same alias name will overwrite earlier uses; I can see where this would be unexpected behavior at the PHP level (previously it would have resulted in an SQL error). 
