### PR TITLE
convert ? placeholders in where()/having() to :_#_ named placeholders

### DIFF
--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -40,25 +40,6 @@ abstract class AbstractDmlQuery extends AbstractQuery
 
     /**
      *
-     * Gets the values to bind to placeholders, including any 'where' values
-     * (needed for INSERT and UPDATE).
-     *
-     * @return array
-     *
-     */
-    public function getBindValues()
-    {
-        $bind_values = parent::getBindValues();
-        $i = 1;
-        foreach ($this->bind_where as $val) {
-            $bind_values[$i] = $val;
-            $i ++;
-        }
-        return $bind_values;
-    }
-
-    /**
-     *
      * Sets one column value placeholder; if an optional second parameter is
      * passed, that value is bound to the placeholder.
      *

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -87,15 +87,6 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
-     * Bind values in the HAVING clause.
-     *
-     * @var array
-     *
-     */
-    protected $bind_having = array();
-
-    /**
-     *
      * The number of rows per page.
      *
      * @var int
@@ -144,28 +135,6 @@ class Select extends AbstractQuery implements SelectInterface
     public function getPaging()
     {
         return $this->paging;
-    }
-
-    /**
-     *
-     * Gets the values to bind to placeholders.
-     *
-     * @return array
-     *
-     */
-    public function getBindValues()
-    {
-        $bind_values = $this->bind_values;
-        $i = 1;
-        foreach ($this->bind_where as $val) {
-            $bind_values[$i] = $val;
-            $i ++;
-        }
-        foreach ($this->bind_having as $val) {
-            $bind_values[$i] = $val;
-            $i ++;
-        }
-        return $bind_values;
     }
 
     /**

--- a/tests/unit/src/Common/DeleteTest.php
+++ b/tests/unit/src/Common/DeleteTest.php
@@ -18,8 +18,8 @@ class DeleteTest extends AbstractQueryTest
         $expect = "
             DELETE FROM <<t1>>
             WHERE
-                foo = ?
-                AND baz = ?
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
         ";
 
@@ -27,8 +27,8 @@ class DeleteTest extends AbstractQueryTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -308,14 +308,14 @@ class SelectTest extends AbstractQueryTest
                 *
             WHERE
                 c1 = c2
-                AND c3 = ?
+                AND c3 = :_1_
         ';
 
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $actual = $this->query->getBindValues();
-        $expect = array(1 => 'foo');
+        $expect = array('_1_' => 'foo');
         $this->assertSame($expect, $actual);
     }
 
@@ -330,14 +330,14 @@ class SelectTest extends AbstractQueryTest
                 *
             WHERE
                 c1 = c2
-                OR c3 = ?
+                OR c3 = :_1_
         ';
 
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $actual = $this->query->getBindValues();
-        $expect = array(1 => 'foo');
+        $expect = array('_1_' => 'foo');
         $this->assertSame($expect, $actual);
     }
 
@@ -367,14 +367,14 @@ class SelectTest extends AbstractQueryTest
                 *
             HAVING
                 c1 = c2
-                AND c3 = ?
+                AND c3 = :_1_
         ';
 
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $actual = $this->query->getBindValues();
-        $expect = array(1 => 'foo');
+        $expect = array('_1_' => 'foo');
         $this->assertSame($expect, $actual);
     }
 
@@ -388,14 +388,14 @@ class SelectTest extends AbstractQueryTest
                 *
             HAVING
                 c1 = c2
-                OR c3 = ?
+                OR c3 = :_1_
         ';
 
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $actual = $this->query->getBindValues();
-        $expect = array(1 => 'foo');
+        $expect = array('_1_' => 'foo');
         $this->assertSame($expect, $actual);
     }
 
@@ -520,16 +520,16 @@ class SelectTest extends AbstractQueryTest
             SELECT
                 *
             WHERE
-                foo = ?
+                foo = :_2_
             HAVING
-                baz IN (?)
+                baz IN (:_1_)
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $expect = array(
-            1 => 'bar',
-            2 => array('dib', 'zim', 'gir'),
+            '_1_' => array('dib', 'zim', 'gir'),
+            '_2_' => 'bar',
         );
         $actual = $this->query->getBindValues();
         $this->assertSame($expect, $actual);

--- a/tests/unit/src/Common/UpdateTest.php
+++ b/tests/unit/src/Common/UpdateTest.php
@@ -28,8 +28,8 @@ class UpdateTest extends AbstractQueryTest
                 <<c4>> = NULL,
                 <<c5>> = NOW()
             WHERE
-                foo = ?
-                AND baz = ?
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
         ";
 
@@ -37,8 +37,8 @@ class UpdateTest extends AbstractQueryTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/unit/src/Mysql/DeleteTest.php
+++ b/tests/unit/src/Mysql/DeleteTest.php
@@ -10,8 +10,8 @@ class DeleteTest extends Common\DeleteTest
     protected $expected_sql_with_flag = "
         DELETE %s FROM <<t1>>
             WHERE
-                foo = ?
-                AND baz = ?
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
     ";
 
@@ -46,8 +46,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -66,8 +66,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -86,8 +86,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/unit/src/Mysql/UpdateTest.php
+++ b/tests/unit/src/Mysql/UpdateTest.php
@@ -16,8 +16,8 @@ class UpdateTest extends Common\UpdateTest
                 <<c4>> = NULL,
                 <<c5>> = NOW()
             WHERE
-                foo = ?
-                AND baz = ?
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             LIMIT 5
     ";
@@ -60,8 +60,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -84,8 +84,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/unit/src/Pgsql/DeleteTest.php
+++ b/tests/unit/src/Pgsql/DeleteTest.php
@@ -19,8 +19,8 @@ class DeleteTest extends Common\DeleteTest
         $expect = "
             DELETE FROM <<t1>>
             WHERE
-                foo = ?
-                AND baz = ?
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             RETURNING
                 foo,
@@ -31,8 +31,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/unit/src/Pgsql/UpdateTest.php
+++ b/tests/unit/src/Pgsql/UpdateTest.php
@@ -29,8 +29,8 @@ class UpdateTest extends Common\UpdateTest
                 <<c4>> = NULL,
                 <<c5>> = NOW()
             WHERE
-                foo = ?
-                AND baz = ?
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             RETURNING
                 c1,
@@ -41,8 +41,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/unit/src/Sqlite/DeleteTest.php
+++ b/tests/unit/src/Sqlite/DeleteTest.php
@@ -21,8 +21,8 @@ class DeleteTest extends Common\DeleteTest
         $expect = "
             DELETE FROM <<t1>>
             WHERE
-                foo = ?
-                AND baz = ?
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             ORDER BY
                 zim DESC
@@ -32,8 +32,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            1 => 'bar',
-            2 => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }


### PR DESCRIPTION
This is because PDO is touchy about numbering on `?` placeholders. If we have bound values `[:foo, :bar, ?, :baz]`, the ? placeholder is not number 1, it is number 3. As such it is nearly impossible to keep track of the numbering when values are bound out-of-order.

This PR modifies the code to do a braindead check on the where/having condition string to see if it has `?` placeholders, and replace them with named `:_#_` placeholders, where `#` is the current count of the `$bind_values` array. It eliminates the problem of keeping proper numbers on `?` placeholders.

@mbrevda and @mindplay-dk especially take note, and please review at your convenience. The vast majority of changes is in the tests, from `?` to `:_1_` etc.
