### PR TITLE
Fix quote issue with single character table alias

### DIFF
--- a/src/Quoter.php
+++ b/src/Quoter.php
@@ -276,7 +276,7 @@ class Quoter
             return $text;
         }
 
-        $word = "[a-z_][a-z0-9_]+";
+        $word = "[a-z_][a-z0-9_]*";
 
         $find = "/(\\b)($word)\\.($word)(\\b)/i";
 

--- a/tests/unit/src/QuoterTest.php
+++ b/tests/unit/src/QuoterTest.php
@@ -42,9 +42,9 @@ class QuoterTest extends \PHPUnit_Framework_TestCase
 
     public function testQuoteNamesIn()
     {
-        $sql = "*, *.*, foo.bar, CONCAT('foo.bar', \"baz.dib\") AS zim";
+        $sql = "*, *.*, f.bar, foo.bar, CONCAT('foo.bar', \"baz.dib\") AS zim";
         $actual = $this->quoter->quoteNamesIn($sql);
-        $expect = "*, *.*, `foo`.`bar`, CONCAT('foo.bar', \"baz.dib\") AS `zim`";
+        $expect = "*, *.*, `f`.`bar`, `foo`.`bar`, CONCAT('foo.bar', \"baz.dib\") AS `zim`";
         $this->assertSame($expect, $actual);
     }
 }


### PR DESCRIPTION
When a name contained a table alias of one character it wasn't getting quoted.
