### PR TITLE
Add ability to SELECT Max (field)

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -96,6 +96,14 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
+     * The column name for MAX
+     *
+     * @var string
+     */
+    protected $max;
+
+    /**
+     *
      * Returns this object as an SQL statement string.
      *
      * @return string An SQL statement string.
@@ -565,6 +573,7 @@ class Select extends AbstractQuery implements SelectInterface
         return 'SELECT'
             . $this->buildFlags()
             . $this->buildCols()
+            . $this->buildMax()
             . $this->buildFrom() // includes JOIN
             . $this->buildWhere()
             . $this->buildGroupBy()
@@ -585,8 +594,8 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function buildCols()
     {
-        if (! $this->cols) {
-            throw new Exception('No columns in the SELECT.');
+        if (! $this->cols && ! $this->max) {
+            throw new Exception('No columns or max in the SELECT.');
         }
 
         $cols = array();
@@ -671,6 +680,21 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
+     * Builds the MAX clause
+     *
+     * @return string
+     */
+    protected function buildMax()
+    {
+        if (! $this->max) {
+            return ''; // not applicable
+        }
+
+        return "MAX ($this->max)";
+    }
+
+    /**
+     *
      * Adds a WHERE condition to the query by AND. If the condition has
      * ?-placeholders, additional arguments to the method will be bound to
      * those placeholders sequentially.
@@ -749,5 +773,19 @@ class Select extends AbstractQuery implements SelectInterface
     public function orderBy(array $spec)
     {
         return $this->addOrderBy($spec);
+    }
+
+    /**
+     *
+     * Specifies column for Max
+     *
+     * @param $col
+     *
+     * @return self
+     */
+    public function max($col)
+    {
+        $this->max = $col;
+        return $this;
     }
 }

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -232,4 +232,15 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      */
     public function unionAll();
+
+    /**
+     *
+     * Will select max value from a specified column
+     *
+     * @param string $col name of the Column
+     *
+     * @return self
+     *
+     */
+    public function max($col);
 }

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -570,4 +570,20 @@ class SelectTest extends AbstractQueryTest
         ';
         $this->assertSameSql($expect, $actual);
     }
+
+    public function testMax()
+    {
+        $this->query->max('field');
+        $this->query->from('t1');
+
+        $actual = $this->query->__toString();
+
+        $expect = '
+            SELECT
+            MAX (field)
+            FROM
+                <<t1>>
+        ';
+        $this->assertSameSql($expect, $actual);
+    }
 }


### PR DESCRIPTION
I've been using Aura.SqlQuery at work for the past two weeks. We have to do some `Select Max (field) From <table>` queries. It'd be nice to use this library for those queries as well. 
