### PR TITLE
Allow binding of values as part of join() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ $select
 ?>
 ```
 
+> N.b.: The `*where()`, `*having()`, and *join*()` methods all take an optional final parameter, a sequential array of values to bind to sequential question-mark placeholders in the condition clause.
+
 Once you have built the query, pass it to the database connection of your
 choice as a string, and send the bound values along with it.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $select
 ?>
 ```
 
-> N.b.: The `*where()`, `*having()`, and *join*()` methods all take an optional final parameter, a sequential array of values to bind to sequential question-mark placeholders in the condition clause.
+> N.b.: The `*where()`, `*having()`, and `*join*()` methods all take an optional final parameter, a sequential array of values to bind to sequential question-mark placeholders in the condition clause.
 
 Once you have built the query, pass it to the database connection of your
 choice as a string, and send the bound values along with it.

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -342,7 +342,7 @@ abstract class AbstractQuery
                 continue;
             }
 
-            $bind_value = array_shift($args);
+            $bind_value = array_shift($bind_values);
             if ($bind_value instanceof self) {
                 $parts[$key] = $bind_value->__toString();
                 continue;

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -305,7 +305,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws Exception
      *
      */
-    public function join($join, $spec, $cond = null)
+    public function join($join, $spec, $cond = null, array $bind = array())
     {
         if (! $this->from) {
             throw new Exception('Cannot join() without from() first.');
@@ -313,7 +313,7 @@ class Select extends AbstractQuery implements SelectInterface
 
         $join = strtoupper(ltrim("$join JOIN"));
         $spec = $this->quoter->quoteName($spec);
-        $cond = $this->fixJoinCondition($cond);
+        $cond = $this->fixJoinCondition($cond, $bind);
         $this->from[$this->from_key][] = rtrim("$join $spec $cond");
         return $this;
     }
@@ -328,13 +328,14 @@ class Select extends AbstractQuery implements SelectInterface
      * @return string
      *
      */
-    protected function fixJoinCondition($cond)
+    protected function fixJoinCondition($cond, array $bind)
     {
         if (! $cond) {
             return;
         }
 
         $cond = $this->quoter->quoteNamesIn($cond);
+        $cond = $this->rebuildCondAndBindValues($cond, $bind);
 
         if (strtoupper(substr(ltrim($cond), 0, 3)) == 'ON ') {
             return $cond;
@@ -360,9 +361,9 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws Exception
      *
      */
-    public function innerJoin($spec, $cond = null)
+    public function innerJoin($spec, $cond = null, array $bind = array())
     {
-        return $this->join('INNER', $spec, $cond);
+        return $this->join('INNER', $spec, $cond, $bind);
     }
 
     /**
@@ -378,9 +379,9 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws Exception
      *
      */
-    public function leftJoin($spec, $cond = null)
+    public function leftJoin($spec, $cond = null, array $bind = array())
     {
-        return $this->join('LEFT', $spec, $cond);
+        return $this->join('LEFT', $spec, $cond, $bind);
     }
 
     /**
@@ -402,7 +403,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws Exception
      *
      */
-    public function joinSubSelect($join, $spec, $name, $cond = null)
+    public function joinSubSelect($join, $spec, $name, $cond = null, array $bind = array())
     {
         if (! $this->from) {
             throw new Exception('Cannot join() without from() first.');
@@ -414,7 +415,7 @@ class Select extends AbstractQuery implements SelectInterface
               . PHP_EOL;
         $name = $this->quoter->quoteName($name);
 
-        $cond = $this->fixJoinCondition($cond);
+        $cond = $this->fixJoinCondition($cond, $bind);
         $this->from[$this->from_key][] = rtrim("$join ($spec) AS $name $cond");
         return $this;
     }


### PR DESCRIPTION
This adds a trailing optional `$bind` parameter, similar to `where()` and `having()`, to bind values to sequential placeholders in the JOIN condition.
