### PR TITLE
Add table-reference tracking to disallow duplicate references

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -262,7 +262,7 @@ class Select extends AbstractQuery implements SelectInterface
     {
         $name = $spec;
 
-        $pos = strripos(' AS ', $name);
+        $pos = strripos($name, ' AS ');
         if ($pos !== false) {
             $name = trim(substr($name, $pos + 4));
         }
@@ -327,7 +327,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function fromSubSelect($spec, $name)
     {
-        $this->addTableRef('FROM', $name);
+        $this->addTableRef('FROM (SELECT ...) AS', $name);
         $spec = ltrim(preg_replace('/^/m', '        ', (string) $spec));
         $this->from[] = array(
             "("
@@ -459,7 +459,7 @@ class Select extends AbstractQuery implements SelectInterface
         }
 
         $join = strtoupper(ltrim("$join JOIN"));
-        $this->addTableRef($join, $name);
+        $this->addTableRef("$join (SELECT ...) AS", $name);
 
         $spec = PHP_EOL . '    '
               . ltrim(preg_replace('/^/m', '    ', (string) $spec))

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -287,10 +287,7 @@ class Select extends AbstractQuery implements SelectInterface
     public function from($spec)
     {
         $this->addTableRef('FROM', $spec);
-        $spec = $this->quoter->quoteName($spec);
-        $this->from[] = array($spec);
-        $this->from_key ++;
-        return $this;
+        return $this->addFrom($this->quoter->quoteName($spec));
     }
 
     /**
@@ -306,6 +303,11 @@ class Select extends AbstractQuery implements SelectInterface
     public function fromRaw($spec)
     {
         $this->addTableRef('FROM', $spec);
+        return $this->addFrom($spec);
+    }
+
+    protected function addFrom($spec)
+    {
         $this->from[] = array($spec);
         $this->from_key ++;
         return $this;

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -94,6 +94,15 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
+     * Tracks table references to avoid duplicate identifiers.
+     *
+     * @var array
+     *
+     */
+    protected $table_refs = array();
+
+    /**
+     *
      * Returns this object as an SQL statement string.
      *
      * @return string An SQL statement string.
@@ -238,6 +247,36 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
+     * Tracks table references.
+     *
+     * @var string $type FROM, JOIN, etc.
+     *
+     * @var string $spec The table and alias name.
+     *
+     * @return null
+     *
+     * @throws Exception when the reference has already been used.
+     *
+     */
+    protected function addTableRef($type, $spec)
+    {
+        $name = $spec;
+
+        $pos = strripos(' AS ', $name);
+        if ($pos !== false) {
+            $name = trim(substr($name, $pos + 4));
+        }
+
+        if (isset($this->table_refs[$name])) {
+            $used = $this->table_refs[$name];
+            throw new Exception("Cannot reference '$type $spec' after '$used'");
+        }
+
+        $this->table_refs[$name] = "$type $spec";
+    }
+
+    /**
+     *
      * Adds a FROM element to the query; quotes the table name automatically.
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
@@ -247,7 +286,11 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function from($spec)
     {
-        return $this->fromRaw($this->quoter->quoteName($spec));
+        $this->addTableRef('FROM', $spec);
+        $spec = $this->quoter->quoteName($spec);
+        $this->from[] = array($spec);
+        $this->from_key ++;
+        return $this;
     }
 
     /**
@@ -262,10 +305,12 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function fromRaw($spec)
     {
+        $this->addTableRef('FROM', $spec);
         $this->from[] = array($spec);
         $this->from_key ++;
         return $this;
     }
+
     /**
      *
      * Adds an aliased sub-select to the query.
@@ -280,6 +325,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function fromSubSelect($spec, $name)
     {
+        $this->addTableRef('FROM', $name);
         $spec = ltrim(preg_replace('/^/m', '        ', (string) $spec));
         $this->from[] = array(
             "("
@@ -312,6 +358,8 @@ class Select extends AbstractQuery implements SelectInterface
         }
 
         $join = strtoupper(ltrim("$join JOIN"));
+        $this->addTableRef($join, $spec);
+
         $spec = $this->quoter->quoteName($spec);
         $cond = $this->fixJoinCondition($cond);
         $this->from[$this->from_key][] = rtrim("$join $spec $cond");
@@ -409,6 +457,8 @@ class Select extends AbstractQuery implements SelectInterface
         }
 
         $join = strtoupper(ltrim("$join JOIN"));
+        $this->addTableRef($join, $name);
+
         $spec = PHP_EOL . '    '
               . ltrim(preg_replace('/^/m', '    ', (string) $spec))
               . PHP_EOL;

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -133,7 +133,7 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
-    public function testDuplicateTableName()
+    public function testDuplicateFromTable()
     {
         $this->query->cols(array('*'));
         $this->query->from('t1');
@@ -146,7 +146,7 @@ class SelectTest extends AbstractQueryTest
     }
 
 
-    public function testDuplicateTableAlias()
+    public function testDuplicateFromAlias()
     {
         $this->query->cols(array('*'));
         $this->query->from('t1');
@@ -172,6 +172,20 @@ class SelectTest extends AbstractQueryTest
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
+    }
+
+    public function testDuplicateSubSelectTableRef()
+    {
+        $this->query->cols(array('*'));
+        $this->query->from('t1');
+
+        $this->setExpectedException(
+            'Aura\SqlQuery\Exception',
+            "Cannot reference 'FROM (SELECT ...) AS t1' after 'FROM t1'"
+        );
+
+        $sub = 'SELECT * FROM t2';
+        $this->query->fromSubSelect($sub, 't1');
     }
 
     public function testFromSubSelectObject()
@@ -218,6 +232,18 @@ class SelectTest extends AbstractQueryTest
         $select = $this->newQuery();
         $this->setExpectedException('Aura\SqlQuery\Exception');
         $select->join('left', 't2', 't1.id = t2.id');
+    }
+
+    public function testDuplicateJoinRef()
+    {
+        $this->query->cols(array('*'));
+        $this->query->from('t1');
+
+        $this->setExpectedException(
+            'Aura\SqlQuery\Exception',
+            "Cannot reference 'NATURAL JOIN t1' after 'FROM t1'"
+        );
+        $this->query->join('natural', 't1');
     }
 
     public function testLeftAndInnerJoin()
@@ -272,6 +298,20 @@ class SelectTest extends AbstractQueryTest
         $select = $this->newQuery();
         $this->setExpectedException('Aura\SqlQuery\Exception');
         $select->joinSubSelect('left', $sub1, 'a2', 't2.c1 = a3.c1');
+    }
+
+    public function testDuplicateJoinSubSelectRef()
+    {
+        $this->query->cols(array('*'));
+        $this->query->from('t1');
+
+        $this->setExpectedException(
+            'Aura\SqlQuery\Exception',
+            "Cannot reference 'NATURAL JOIN (SELECT ...) AS t1' after 'FROM t1'"
+        );
+
+        $sub2 = 'SELECT * FROM t3';
+        $this->query->joinSubSelect('natural', $sub2, 't1');
     }
 
     public function testJoinSubSelectObject()

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -133,6 +133,31 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testDuplicateTableName()
+    {
+        $this->query->cols(array('*'));
+        $this->query->from('t1');
+
+        $this->setExpectedException(
+            'Aura\SqlQuery\Exception',
+            "Cannot reference 'FROM t1' after 'FROM t1'"
+        );
+        $this->query->from('t1');
+    }
+
+
+    public function testDuplicateTableAlias()
+    {
+        $this->query->cols(array('*'));
+        $this->query->from('t1');
+
+        $this->setExpectedException(
+            'Aura\SqlQuery\Exception',
+            "Cannot reference 'FROM t2 AS t1' after 'FROM t1'"
+        );
+        $this->query->from('t2 AS t1');
+    }
+
     public function testFromSubSelect()
     {
         $sub = 'SELECT * FROM t2';

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -116,6 +116,23 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testFromRaw()
+    {
+        $this->query->cols(array('*'));
+        $this->query->fromRaw('t1')
+                    ->fromRaw('t2');
+
+        $actual = $this->query->__toString();
+        $expect = '
+            SELECT
+                *
+            FROM
+                t1,
+                t2
+        ';
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testFromSubSelect()
     {
         $sub = 'SELECT * FROM t2';


### PR DESCRIPTION
Applies to all from() and join() methods.
