### PR TITLE
Bind Values From Sub-Selects

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -85,14 +85,25 @@ abstract class AbstractQuery
 
     /**
      *
+     * Prefix to use on placeholders for "sequential" bound values; used for
+     * deconfliction when merging bound values from sub-selects, etc.
+     *
+     * @var mixed
+     *
+     */
+    protected $seq_bind_prefix = '';
+
+    /**
+     *
      * Constructor.
      *
      * @param Quoter $quoter A helper for quoting identifier names.
      *
      */
-    public function __construct(Quoter $quoter)
+    public function __construct(Quoter $quoter, $seq_bind_prefix = '')
     {
         $this->quoter = $quoter;
+        $this->seq_bind_prefix = $seq_bind_prefix;
     }
 
     /**
@@ -322,14 +333,12 @@ abstract class AbstractQuery
         // remaining args are bind values; bind against ?-mark placeholders,
         // but becuase PDO is finicky about the numbering of sequential
         // placeholders, convert the ?-mark to a named placeholder
-        $k = count($this->bind_values);
         $parts = preg_split('/(\?)/', $cond, null, PREG_SPLIT_DELIM_CAPTURE);
         foreach ($parts as $key => $val) {
             if ($val != '?') {
                 continue;
             }
-            $k ++;
-            $placeholder = "_{$k}_";
+            $placeholder = $this->getSeqPlaceholder();
             $parts[$key] = ':' . $placeholder;
             $this->bind_values[$placeholder] = array_shift($args);
         }
@@ -342,6 +351,12 @@ abstract class AbstractQuery
         } else {
             $clause[] = $cond;
         }
+    }
+
+    protected function getSeqPlaceholder()
+    {
+        $i = count($this->bind_values) + 1;
+        return $this->seq_bind_prefix . "_{$i}_";
     }
 
     /**

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -106,6 +106,11 @@ abstract class AbstractQuery
         $this->seq_bind_prefix = $seq_bind_prefix;
     }
 
+    public function getSeqBindPrefix()
+    {
+        return $this->seq_bind_prefix;
+    }
+
     /**
      *
      * Returns this query object as an SQL statement string.

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -280,14 +280,34 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function fromSubSelect($spec, $name)
     {
-        $spec = ltrim(preg_replace('/^/m', '        ', (string) $spec));
-        $this->from[] = array(
-            "("
-            . PHP_EOL . '        ' . $spec . PHP_EOL
-            . "    ) AS " . $this->quoter->quoteName($name)
-        );
+        $spec = $this->subSelect($spec, '        ');
+        $name = $this->quoter->quoteName($name);
+        $this->from[] = array("({$spec}    ) AS $name");
         $this->from_key ++;
         return $this;
+    }
+
+    /**
+     *
+     * Formats a sub-SELECT statement, binding values from a Select object as
+     * needed.
+     *
+     * @param string|SelectInterface $spec A sub-SELECT specification.
+     *
+     * @param string $indent Indent each line with this string.
+     *
+     * @return string The sub-SELECT string.
+     *
+     */
+    protected function subSelect($spec, $indent)
+    {
+        if ($spec instanceof SelectInterface) {
+            $this->bindValues($spec->getBindValues());
+        }
+
+        return PHP_EOL . $indent
+            . ltrim(preg_replace('/^/m', $indent, (string) $spec))
+            . PHP_EOL;
     }
 
     /**
@@ -314,7 +334,9 @@ class Select extends AbstractQuery implements SelectInterface
         $join = strtoupper(ltrim("$join JOIN"));
         $spec = $this->quoter->quoteName($spec);
         $cond = $this->fixJoinCondition($cond);
-        $this->from[$this->from_key][] = rtrim("$join $spec $cond");
+        $text = rtrim("$join $spec $cond");
+
+        $this->from[$this->from_key][] = '        ' . $text;
         return $this;
     }
 
@@ -409,13 +431,12 @@ class Select extends AbstractQuery implements SelectInterface
         }
 
         $join = strtoupper(ltrim("$join JOIN"));
-        $spec = PHP_EOL . '    '
-              . ltrim(preg_replace('/^/m', '    ', (string) $spec))
-              . PHP_EOL;
+        $spec = $this->subSelect($spec, '            ');
         $name = $this->quoter->quoteName($name);
-
         $cond = $this->fixJoinCondition($cond);
-        $this->from[$this->from_key][] = rtrim("$join ($spec) AS $name $cond");
+
+        $text = rtrim("$join ($spec        ) AS $name $cond");
+        $this->from[$this->from_key][] = '        ' . $text ;
         return $this;
     }
 

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -217,8 +217,12 @@ class QueryFactory
 
     protected function newSeqBindPrefix()
     {
+        $seq_bind_prefix = '';
         if ($this->instance_count) {
-            return '_' . $this->instance_count ++;
+            $seq_bind_prefix = '_' . $this->instance_count;
         }
+
+        $this->instance_count ++;
+        return $seq_bind_prefix;
     }
 }

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -79,6 +79,17 @@ class QueryFactory
      */
     protected $last_insert_id_names = array();
 
+    protected $quoter;
+
+    /**
+     *
+     * A count of Query instances, used for determining $seq_bind_prefix.
+     *
+     * @var int
+     *
+     */
+    protected $instance_count = 0;
+
     /**
      *
      * Constructor.
@@ -186,9 +197,28 @@ class QueryFactory
 
         $class .= "\\{$query}";
 
-        return new $class(new Quoter(
-            $this->quote_name_prefix,
-            $this->quote_name_suffix
-        ));
+        return new $class(
+            $this->getQuoter(),
+            $this->newSeqBindPrefix()
+        );
+    }
+
+    protected function getQuoter()
+    {
+        if (! $this->quoter) {
+            $this->quoter = new Quoter(
+                $this->quote_name_prefix,
+                $this->quote_name_suffix
+            );
+        }
+
+        return $this->quoter;
+    }
+
+    protected function newSeqBindPrefix()
+    {
+        if ($this->instance_count) {
+            return '_' . $this->instance_count ++;
+        }
     }
 }

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -125,7 +125,7 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 (
-                SELECT * FROM t2
+                    SELECT * FROM t2
                 ) AS <<a2>>
         ';
         $actual = $this->query->__toString();
@@ -143,10 +143,10 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 (
-                SELECT
-                    *
-                FROM
-                    <<t2>>
+                    SELECT
+                        *
+                    FROM
+                        <<t2>>
                 ) AS <<a2>>
         ';
         $actual = $this->query->__toString();
@@ -165,9 +165,9 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 <<t1>>
-            LEFT JOIN <<t2>> ON <<t1>>.<<id>> = <<t2>>.<<id>>
-            INNER JOIN <<t3>> AS <<a3>> ON <<t2>>.<<id>> = <<a3>>.<<id>>
-            NATURAL JOIN <<t4>>
+                    LEFT JOIN <<t2>> ON <<t1>>.<<id>> = <<t2>>.<<id>>
+                    INNER JOIN <<t3>> AS <<a3>> ON <<t2>>.<<id>> = <<a3>>.<<id>>
+                    NATURAL JOIN <<t4>>
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
@@ -190,9 +190,9 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 <<t1>>
-            LEFT JOIN <<t2>> ON <<t1>>.<<id>> = <<t2>>.<<id>>
-            INNER JOIN <<t3>> AS <<a3>> ON <<t2>>.<<id>> = <<a3>>.<<id>>
-            NATURAL JOIN <<t4>>
+                    LEFT JOIN <<t2>> ON <<t1>>.<<id>> = <<t2>>.<<id>>
+                    INNER JOIN <<t3>> AS <<a3>> ON <<t2>>.<<id>> = <<a3>>.<<id>>
+                    NATURAL JOIN <<t4>>
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
@@ -216,12 +216,12 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 <<t1>>
-            LEFT JOIN (
-                SELECT * FROM t2
-            ) AS <<a2>> ON <<t2>>.<<c1>> = <<a3>>.<<c1>>
-            NATURAL JOIN (
-                SELECT * FROM t3
-            ) AS <<a3>>
+                    LEFT JOIN (
+                        SELECT * FROM t2
+                    ) AS <<a2>> ON <<t2>>.<<c1>> = <<a3>>.<<c1>>
+                    NATURAL JOIN (
+                        SELECT * FROM t3
+                    ) AS <<a3>>
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
@@ -245,12 +245,12 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 <<t1>>
-            LEFT JOIN (
-                SELECT
-                    *
-                FROM
-                    <<t2>>
-            ) AS <<a3>> ON <<t2>>.<<c1>> = <<a3>>.<<c1>>
+                    LEFT JOIN (
+                        SELECT
+                            *
+                        FROM
+                            <<t2>>
+                    ) AS <<a3>> ON <<t2>>.<<c1>> = <<a3>>.<<c1>>
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
@@ -270,10 +270,10 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 <<t1>>
-            INNER JOIN <<t2>> ON <<t2>>.<<id>> = <<t1>>.<<id>>
-            LEFT JOIN <<t3>> ON <<t3>>.<<id>> = <<t2>>.<<id>>,
-                <<t4>>
-            INNER JOIN <<t5>> ON <<t5>>.<<id>> = <<t4>>.<<id>>
+                    INNER JOIN <<t2>> ON <<t2>>.<<id>> = <<t1>>.<<id>>
+                    LEFT JOIN <<t3>> ON <<t3>>.<<id>> = <<t2>>.<<id>>,
+                        <<t4>>
+                    INNER JOIN <<t5>> ON <<t5>>.<<id>> = <<t4>>.<<id>>
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
@@ -291,8 +291,8 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 <<t1>>
-            INNER JOIN <<t2>> ON <<t2>>.<<id>> = <<t1>>.<<id>>
-            LEFT JOIN <<t3>> USING (id)
+                    INNER JOIN <<t2>> ON <<t2>>.<<id>> = <<t1>>.<<id>>
+                    LEFT JOIN <<t3>> USING (id)
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -135,9 +135,14 @@ class SelectTest extends AbstractQueryTest
     public function testFromSubSelectObject()
     {
         $sub = $this->newQuery();
-        $sub->cols(array('*'))->from('t2');
+        $sub->cols(array('*'))
+            ->from('t2')
+            ->where('foo = ?', 'bar');
 
-        $this->query->cols(array('*'))->fromSubSelect($sub, 'a2');
+        $this->query->cols(array('*'))
+            ->fromSubSelect($sub, 'a2')
+            ->where('a2.baz = ?', 'dib');
+
         $expect = '
             SELECT
                 *
@@ -147,8 +152,13 @@ class SelectTest extends AbstractQueryTest
                         *
                     FROM
                         <<t2>>
+                    WHERE
+                        foo = :_1_1_
                 ) AS <<a2>>
+            WHERE
+                <<a2>>.<<baz>> = :_2_
         ';
+
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
     }
@@ -235,11 +245,13 @@ class SelectTest extends AbstractQueryTest
     public function testJoinSubSelectObject()
     {
         $sub = $this->newQuery();
-        $sub->cols(array('*'))->from('t2');
+        $sub->cols(array('*'))->from('t2')->where('foo = ?', 'bar');
 
         $this->query->cols(array('*'));
         $this->query->from('t1');
         $this->query->joinSubSelect('left', $sub, 'a3', 't2.c1 = a3.c1');
+        $this->query->where('baz = ?', 'dib');
+
         $expect = '
             SELECT
                 *
@@ -250,7 +262,11 @@ class SelectTest extends AbstractQueryTest
                             *
                         FROM
                             <<t2>>
+                        WHERE
+                            foo = :_1_1_
                     ) AS <<a3>> ON <<t2>>.<<c1>> = <<a3>>.<<c1>>
+            WHERE
+                baz = :_2_
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);

--- a/tests/unit/src/QueryFactoryTest.php
+++ b/tests/unit/src/QueryFactoryTest.php
@@ -62,4 +62,15 @@ class QueryFactoryTest extends \PHPUnit_Framework_TestCase
             array('Sqlsrv', QueryFactory::COMMON, 'Delete', 'Aura\SqlQuery\Common\Delete'),
         );
     }
+
+    public function testSeqBindPrefix()
+    {
+        $query_factory = new QueryFactory('sqlite');
+
+        $first = $query_factory->newSelect();
+        $this->assertSame('', $first->getSeqBindPrefix());
+
+        $again = $query_factory->newSelect();
+        $this->assertSame('_1', $again->getSeqBindPrefix());
+    }
 }


### PR DESCRIPTION
Currently, if we call `fromSubSelect()` or `joinSubSelect()`, and pass a `Select` objects, the values bound to that object do not get merged into the main select. This PR corrects that, merging the sub-select bound values into the main select. This PR also modifies the indenting of the statement strings, indenting JOINs beneath their respective FROMs.

NOTE: Sequential placeholders in the subselect **will not** overwrite sequential placeholders in the main select; at least, not as long as you create `Select` objects through the `QueryFactory`. This is because the PR adds a feature where queries now get sequential placeholder prefixes, specifically to deconflict placeholders in this situation. (Doing the same for named placeholders is much more difficult, since they are outside the control of the `Select` object in the first place.

WARNING: Named placeholders in the subselect will **overwrite** placeholders in the main select, so name your subselect placeholders carefully.
