### PR TITLE
Fixed tests for windows

### DIFF
--- a/tests/unit/src/AbstractQueryTest.php
+++ b/tests/unit/src/AbstractQueryTest.php
@@ -40,6 +40,10 @@ abstract class AbstractQueryTest extends \PHPUnit_Framework_TestCase
         $actual = preg_replace('/^[ \t]*/m', '', $actual);
         $actual = preg_replace('/[ \t]*$/m', '', $actual);
 
+        // remove all line endings to be sure tests will pass on windows and mac
+        $expect = preg_replace('/\r\n|\n|\r/', ' ', $expect);
+        $actual = preg_replace('/\r\n|\n|\r/', ' ', $actual);
+
         // are they the same now?
         $this->assertSame($expect, $actual);
     }


### PR DESCRIPTION
In tests you're trying to compare strings built with PHP_EOL with strings written in test files with fixed `\n` line endings. That leads to tests failures on windows where PHP_EOL equals to `\r\n` (and mac I suppose, where PHP_EOL equals to `\r`).

So it's better to remove all the line endings in query strings.
