### PR TITLE
Fixes #47

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -328,10 +328,17 @@ abstract class AbstractQuery
             if ($val != '?') {
                 continue;
             }
+
+            $bind_value = array_shift($args);
+            if ($bind_value instanceof self) {
+                $parts[$key] = $bind_value->__toString();
+                continue;
+            }
+
             $k ++;
             $placeholder = "_{$k}_";
             $parts[$key] = ':' . $placeholder;
-            $this->bind_values[$placeholder] = array_shift($args);
+            $this->bind_values[$placeholder] = $bind_value;
         }
         $cond = implode('', $parts);
 

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -590,19 +590,18 @@ class SelectTest extends AbstractQueryTest
         $select = $this->newQuery()
             ->cols(array('*'))
             ->from('table2 AS t2')
-            ->where("field IN (" . PHP_EOL . $sub . PHP_EOL . ")");
+            ->where("field IN (?)", $sub);
+
         $expect = '
             SELECT
                 *
             FROM
                 <<table2>> AS <<t2>>
             WHERE
-                field IN (
-            SELECT
+                field IN (SELECT
                 *
             FROM
-                <<table1>> AS <<t1>>
-            )
+                <<table1>> AS <<t1>>)
         ';
         $actual = $select->__toString();
         $this->assertSameSql($expect, $actual);

--- a/tests/unit/src/Common/SelectTest.php
+++ b/tests/unit/src/Common/SelectTest.php
@@ -570,4 +570,41 @@ class SelectTest extends AbstractQueryTest
         ';
         $this->assertSameSql($expect, $actual);
     }
+
+    public function testIssue47()
+    {
+        // sub select
+        $sub = $this->newQuery()
+            ->cols(array('*'))
+            ->from('table1 AS t1');
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<table1>> AS <<t1>>
+        ';
+        $actual = $sub->__toString();
+        $this->assertSameSql($expect, $actual);
+
+        // main select
+        $select = $this->newQuery()
+            ->cols(array('*'))
+            ->from('table2 AS t2')
+            ->where("field IN (" . PHP_EOL . $sub . PHP_EOL . ")");
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<table2>> AS <<t2>>
+            WHERE
+                field IN (
+            SELECT
+                *
+            FROM
+                <<table1>> AS <<t1>>
+            )
+        ';
+        $actual = $select->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
 }


### PR DESCRIPTION
This allows you to pass a Select object (any AbstractQuery, really) as a bound value to a `where()` or `having()` condition, and the Select object will convert it to a string and place it inline in the condition, _not_ as a bound value. (Previously, you had to use a SELECT string as the condition for a subselect, and SqlQuery would attempt to quote the entire subselect. This gets around the issue of quoting the entire condition.)
