### PR TITLE
Add rudimentary array support for Postgres

### DIFF
--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -54,4 +54,21 @@ class Insert extends Common\Insert implements Common\ReturningInterface
     {
         return $this->addReturning($cols);
     }
+
+    /**
+     * Bind a value, supporting simple array values. No escaping done, whatsoever.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return self
+     */
+    public function bindValue($name, $value)
+    {
+        if (is_array($value)) {
+            $value = '{' . implode(",", $value) . '}';
+        }
+
+        return parent::bindValue($name, $value);
+    }
+
 }

--- a/src/Pgsql/Update.php
+++ b/src/Pgsql/Update.php
@@ -35,4 +35,21 @@ class Update extends Common\Update implements Common\ReturningInterface
     {
         return $this->addReturning($cols);
     }
+
+    /**
+     * Bind a value, supporting simple array values. No escaping done, whatsoever.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return self
+     */
+    public function bindValue($name, $value)
+    {
+        if (is_array($value)) {
+            $value = '{' . implode(",", $value) . '}';
+        }
+
+        return parent::bindValue($name, $value);
+    }
+
 }

--- a/tests/unit/src/Pgsql/InsertTest.php
+++ b/tests/unit/src/Pgsql/InsertTest.php
@@ -47,4 +47,23 @@ class InsertTest extends Common\InsertTest
         $expect = 'table_col_seq';
         $this->assertSame($expect, $actual);
     }
+
+    /**
+     * @dataProvider getArrayBindValues
+     */
+    public function testBindValueWithArrayValue(array $param, $expected)
+    {
+        $this->query->bindValue('array_col', $param);
+        $values = $this->query->getBindValues();
+        $this->assertSame($expected, $values['array_col']);
+    }
+
+    public function getArrayBindValues()
+    {
+        return array(
+          array(array(), "{}"),
+          array(array(1,2,3), "{1,2,3}"),
+          array(array('foo', 'bar'), "{foo,bar}"),
+        );
+    }
 }

--- a/tests/unit/src/Pgsql/UpdateTest.php
+++ b/tests/unit/src/Pgsql/UpdateTest.php
@@ -46,4 +46,24 @@ class UpdateTest extends Common\UpdateTest
         );
         $this->assertSame($expect, $actual);
     }
+
+    /**
+     * @dataProvider getArrayBindValues
+     */
+    public function testBindValueWithArrayValue(array $param, $expected)
+    {
+        $this->query->bindValue('array_col', $param);
+        $values = $this->query->getBindValues();
+        $this->assertSame($expected, $values['array_col']);
+    }
+
+    public function getArrayBindValues()
+    {
+        return array(
+          array(array(), "{}"),
+          array(array(1,2,3), "{1,2,3}"),
+          array(array('foo', 'bar'), "{foo,bar}"),
+        );
+    }
+
 }


### PR DESCRIPTION
This is some very basic support, ie. no escaping and no support for decoding returned arrays, as it is quite hard to do automatically.

I don't like how the bindValue implementation is duplicated, but there is no nice place to put it in and I did not want to create a new helper or base class for this purpose.
