### PR TITLE
Add new getStatement method to the interface

### DIFF
--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -76,4 +76,13 @@ interface QueryInterface
      *
      */
     public function getBindValues();
+
+    /**
+     *
+     * Gets the query statement text.
+     *
+     * @return string
+     *
+     */
+    public function getStatement();
 }


### PR DESCRIPTION
PHPStorm wasn't autocompleting the new `getStatement` method (added in 2.3), and as it appears that the new method applies to all query types, the above change appears to get autocompletion of the method working for all queries.
