### PR TITLE
Add getStatement method to QueryInterface

### DIFF
--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -76,4 +76,13 @@ interface QueryInterface
      *
      */
     public function getBindValues();
+    
+    /**
+     *
+     * Returns this query object as an SQL statement string.
+     *
+     * @return string
+     *
+     */
+    public function getStatement();
 }


### PR DESCRIPTION
Since all methods now have getStatement since 2.3, add to QueryInterface to help with IDE autocompletion.
