### PR TITLE
reset method now clears the table_refs internal variable

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -735,6 +735,7 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
         $this->offset     = 0;
         $this->page       = 0;
         $this->for_update = false;
+        $this->table_refs = array();
     }
 
     /**

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -891,4 +891,35 @@ class SelectTest extends AbstractQueryTest
         $actual = $select->getBindValues();
         $this->assertSame($expect, $actual);
     }
+
+    public function testUnionSelectCanHaveSameAliasesInDifferentSelects()
+    {
+        $select = $this->query
+            ->cols(array(
+                '...'
+            ))
+            ->from('a')
+            ->join('INNER', 'c', 'a_cid = c_id')
+            ->union()
+            ->cols(array(
+                '...'
+            ))
+            ->from('b')
+            ->join('INNER', 'c', 'b_cid = c_id');
+
+        $expected = 'SELECT
+                    ...
+                    FROM
+                    <<a>>
+                    INNER JOIN <<c>> ON a_cid = c_id
+                    UNION
+                    SELECT
+                    ...
+                    FROM
+                    <<b>>
+                    INNER JOIN <<c>> ON b_cid = c_id';
+
+        $actual = (string) $select->getStatement();
+        $this->assertSameSql($expected, $actual);
+    }
 }


### PR DESCRIPTION
Fix for #73, allows union with queries using the same aliases.
