### PR TITLE
Add clear() method to common queries to allow clearing SQL part

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -21,6 +21,7 @@ use Aura\SqlQuery\Common\SubselectInterface;
  */
 abstract class AbstractQuery
 {
+
     /**
      *
      * Data to be bound to the query.

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -371,4 +371,34 @@ class Insert extends AbstractDmlQuery implements InsertInterface
             . "VALUES" . PHP_EOL
             . implode("," . PHP_EOL, $vals);
     }
+
+    /**
+     * Clear some part of the query
+     *
+     * @param $part
+     * @return $this
+     */
+    public function clear($part)
+    {
+
+        // arrays
+        if(in_array($part, array('where')))
+        {
+            $this->$part = array();
+        }
+
+        // 0
+        if(in_array($part, array('limit', 'offset')))
+        {
+            $this->$part = 0;
+        }
+
+        // null
+        if(in_array($part, array('into', 'col_values')))
+        {
+            unset($this->$part);
+        }
+
+        return $this;
+    }
 }

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -955,4 +955,28 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
     {
         return $this->addOrderBy($spec);
     }
+
+    /**
+     * Clear some part of the query
+     *
+     * @param $part
+     * @return $this
+     */
+    public function clear($part)
+    {
+
+        // arrays
+        if(in_array($part, array('where', 'cols', 'from', 'group_by', 'having', 'union')))
+        {
+            $this->$part = array();
+        }
+
+        // 0
+        if(in_array($part, array('limit', 'offset')))
+        {
+            $this->$part = 0;
+        }
+
+        return $this;
+    }
 }

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -177,4 +177,34 @@ class Update extends AbstractDmlQuery implements UpdateInterface
         }
         return PHP_EOL . 'SET' . $this->indentCsv($values);
     }
+
+    /**
+     * Clear some part of the query
+     * 
+     * @param $part
+     * @return $this
+     */
+    public function clear($part)
+    {
+
+        // arrays
+        if(in_array($part, array('where')))
+        {
+            $this->$part = array();
+        }
+
+        // 0
+        if(in_array($part, array('limit', 'offset')))
+        {
+            $this->$part = 0;
+        }
+
+        // null
+        if(in_array($part, array('table', 'col_values')))
+        {
+            unset($this->$part);
+        }
+
+        return $this;
+    }
 }

--- a/tests/AbstractQueryTest.php
+++ b/tests/AbstractQueryTest.php
@@ -74,4 +74,5 @@ abstract class AbstractQueryTest extends \PHPUnit_Framework_TestCase
         $actual = $this->query->getBindValues();
         $this->assertSame($expect, $actual);
     }
+    
 }

--- a/tests/Common/InsertTest.php
+++ b/tests/Common/InsertTest.php
@@ -333,4 +333,44 @@ class InsertTest extends AbstractQueryTest
         $actual = $this->query->getBindValues();
         $this->assertSame($expect, $actual);
     }
+
+    /**
+     * @dataProvider clearSqlPartsProvider
+     */
+    public function testClearSqlParts($part, $method, $value, $partValue, $clearedValue)
+    {
+
+        if($value instanceof \ArrayObject)
+        {
+            call_user_func_array([$this->query, $method], $value->getArrayCopy());
+        }
+        else
+        {
+            $this->query->$method($value);
+        }
+        if($partValue === true)
+        {
+            // only check it has a value (may differ depending on Select implementation)
+            $this->assertAttributeNotEmpty($part, $this->query);
+        }
+        else {
+            $this->assertAttributeEquals($partValue, $part, $this->query);
+        }
+        $this->query->clear($part);
+        $this->assertAttributeEquals($clearedValue, $part, $this->query);
+
+    }
+
+    /**
+     * Data provider for method testClearSqlParts
+     *
+     * @return array
+     */
+    public function clearSqlPartsProvider()
+    {
+        return array(
+            array('into', 'into', 'table_name', 'table_name', null),
+            array('col_values', 'set', new \ArrayObject(array('column', 'value')), true, null),
+        );
+    }
 }

--- a/tests/Common/InsertTest.php
+++ b/tests/Common/InsertTest.php
@@ -342,7 +342,7 @@ class InsertTest extends AbstractQueryTest
 
         if($value instanceof \ArrayObject)
         {
-            call_user_func_array([$this->query, $method], $value->getArrayCopy());
+            call_user_func_array(array($this->query, $method), $value->getArrayCopy());
         }
         else
         {

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -927,4 +927,42 @@ class SelectTest extends AbstractQueryTest
         $actual = (string) $select->getStatement();
         $this->assertSameSql($expected, $actual);
     }
+
+    /**
+     * @dataProvider clearSqlPartsProvider
+     */
+    public function testClearSqlParts($part, $method, $value, $partValue, $clearedValue)
+    {
+
+        $this->query->$method($value);
+        if($partValue === true)
+        {
+            // only check it has a value (may differ depending on Select implementation)
+            $this->assertAttributeNotEmpty($part, $this->query);
+        }
+        else {
+            $this->assertAttributeEquals($partValue, $part, $this->query);
+        }
+        $this->query->clear($part);
+        $this->assertAttributeEquals($clearedValue, $part, $this->query);
+
+    }
+
+    /**
+     * Data provider for method testClearSqlParts
+     *
+     * @return array
+     */
+    public function clearSqlPartsProvider()
+    {
+        return array(
+          array('where', 'where', 'x = y', array('x = y'), array()),
+          array('limit', 'limit', '25', 25, 0),
+          array('offset', 'offset', '25', 25, 0),
+          array('cols', 'cols', array('x', 'y'), array('x', 'y'), array()),
+          array('from', 'from', 'x', true, array()),
+          array('group_by', 'groupBy', array('x'), array('x'), array()),
+          array('having', 'having', 'x = y', array('x = y'), array()),
+        );
+    }
 }

--- a/tests/Common/UpdateTest.php
+++ b/tests/Common/UpdateTest.php
@@ -42,4 +42,45 @@ class UpdateTest extends AbstractQueryTest
         );
         $this->assertSame($expect, $actual);
     }
+
+    /**
+     * @dataProvider clearSqlPartsProvider
+     */
+    public function testClearSqlParts($part, $method, $value, $partValue, $clearedValue)
+    {
+
+        if($value instanceof \ArrayObject)
+        {
+            call_user_func_array([$this->query, $method], $value->getArrayCopy());
+        }
+        else
+        {
+            $this->query->$method($value);
+        }
+        if($partValue === true)
+        {
+            // only check it has a value (may differ depending on Select implementation)
+            $this->assertAttributeNotEmpty($part, $this->query);
+        }
+        else {
+            $this->assertAttributeEquals($partValue, $part, $this->query);
+        }
+        $this->query->clear($part);
+        $this->assertAttributeEquals($clearedValue, $part, $this->query);
+
+    }
+
+    /**
+     * Data provider for method testClearSqlParts
+     *
+     * @return array
+     */
+    public function clearSqlPartsProvider()
+    {
+        return array(
+            array('where', 'where', 'x = y', array('x = y'), array()),
+            array('table', 'table', 'table_name', true, null),
+            array('col_values', 'set', new \ArrayObject(array('column', 'value')), true, null),
+        );
+    }
 }

--- a/tests/Common/UpdateTest.php
+++ b/tests/Common/UpdateTest.php
@@ -51,7 +51,7 @@ class UpdateTest extends AbstractQueryTest
 
         if($value instanceof \ArrayObject)
         {
-            call_user_func_array([$this->query, $method], $value->getArrayCopy());
+            call_user_func_array(array($this->query, $method), $value->getArrayCopy());
         }
         else
         {

--- a/tests/Mysql/UpdateTest.php
+++ b/tests/Mysql/UpdateTest.php
@@ -97,4 +97,19 @@ class UpdateTest extends Common\UpdateTest
 
         $this->assertSame(5, $this->query->getLimit());
     }
+
+    /**
+     * Data provider for method testClearSqlParts
+     *
+     * @return array
+     */
+    public function clearSqlPartsProvider()
+    {
+        return array(
+            array('where', 'where', 'x = y', array('x = y'), array()),
+            array('table', 'table', 'table_name', true, null),
+            array('limit', 'limit', 1, 1, 0),
+            array('col_values', 'set', new \ArrayObject(array('column', 'value')), true, null),
+        );
+    }
 }

--- a/tests/Sqlite/UpdateTest.php
+++ b/tests/Sqlite/UpdateTest.php
@@ -231,4 +231,19 @@ class UpdateTest extends Common\UpdateTest
         $this->assertSame(10, $this->query->getLimit());
         $this->assertSame(5, $this->query->getOffset());
     }
+
+    /**
+     * Data provider for method testClearSqlParts
+     *
+     * @return array
+     */
+    public function clearSqlPartsProvider()
+    {
+        return array(
+            array('where', 'where', 'x = y', array('x = y'), array()),
+            array('table', 'table', 'table_name', true, null),
+            array('limit', 'limit', 1, 1, 0),
+            array('col_values', 'set', new \ArrayObject(array('column', 'value')), true, null),
+        );
+    }
 }


### PR DESCRIPTION
This patch make queries more reusable, so that some treatments can be made reusable.

I made it very quickly, sorry for that, I did not have time to stick exactly to the contribution guidelines and I apologize for that.

Beside this, this PR does not introduce any BC break, only new method ->clear() made available to Select, Delete, Insert and Update common queries. 
