### PR TITLE
Add reset functionality on the Select class

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,4 +4,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -258,6 +258,12 @@ abstract class AbstractQuery
         return $this->bind_values;
     }
 
+    public function resetBindValues()
+    {
+        $this->bind_values = array();
+        return $this;
+    }
+
     /**
      *
      * Builds the flags as a space-separated string.
@@ -298,12 +304,13 @@ abstract class AbstractQuery
      *
      * Reset all query flags.
      *
-     * @return null
+     * @return $this
      *
      */
-    protected function resetFlags()
+    public function resetFlags()
     {
         $this->flags = array();
+        return $this;
     }
 
     /**

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -755,12 +755,12 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
      */
     public function resetCols()
     {
-        $this->cols = [];
+        $this->cols = array();
     }
 
     public function resetOrderBy()
     {
-        $this->order_by = [];
+        $this->order_by = array();
     }
 
     public function resetLimit()

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -751,6 +751,34 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
     }
 
     /**
+     * if user needs to reset
+     */
+    public function resetCols()
+    {
+        $this->cols = [];
+    }
+
+    public function resetOrderBy()
+    {
+        $this->order_by = [];
+    }
+
+    public function resetLimit()
+    {
+        $this->limit = 0;
+    }
+
+    public function resetOffset()
+    {
+        $this->offset = 0;
+    }
+
+    public function resetPage()
+    {
+        $this->page = 0;
+    }
+
+    /**
      *
      * Builds this query object into a string.
      *

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -736,38 +736,29 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
     protected function reset()
     {
         $this->resetFlags();
-        $this->cols       = array();
-        $this->from       = array();
-        $this->from_key   = -1;
-        $this->where      = array();
-        $this->group_by   = array();
-        $this->having     = array();
-        $this->order_by   = array();
-        $this->limit      = 0;
-        $this->offset     = 0;
-        $this->page       = 0;
-        $this->for_update = false;
-        $this->table_refs = array();
+        $this->resetCols();
+        $this->resetTables();
+        $this->resetWhere();
+        $this->resetGroupBy();
+        $this->resetHaving();
+        $this->resetOrderBy();
+        $this->limit(0);
+        $this->offset(0);
+        $this->page(0);
+        $this->forUpdate(false);
     }
 
-    /**
-     * if user needs to reset
-     */
     public function resetCols()
     {
         $this->cols = array();
         return $this;
     }
 
-    public function resetFrom()
+    public function resetTables()
     {
         $this->from = array();
-        return $this;
-    }
-
-    public function resetFromKey()
-    {
         $this->from_key = -1;
+        $this->table_refs = array();
         return $this;
     }
 
@@ -795,33 +786,9 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
         return $this;
     }
 
-    public function resetLimit()
+    public function resetUnions()
     {
-        $this->limit = 0;
-        return $this;
-    }
-
-    public function resetOffset()
-    {
-        $this->offset = 0;
-        return $this;
-    }
-
-    public function resetPage()
-    {
-        $this->page = 0;
-        return $this;
-    }
-
-    public function resetForUpdate()
-    {
-        $this->for_update = false;
-        return $this;
-    }
-
-    public function resetTableRefs()
-    {
-        $this->table_refs = array();
+        $this->union = array();
         return $this;
     }
 

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -756,26 +756,73 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
     public function resetCols()
     {
         $this->cols = array();
+        return $this;
+    }
+
+    public function resetFrom()
+    {
+        $this->from = array();
+        return $this;
+    }
+
+    public function resetFromKey()
+    {
+        $this->from_key = -1;
+        return $this;
+    }
+
+    public function resetWhere()
+    {
+        $this->where = array();
+        return $this;
+    }
+
+    public function resetGroupBy()
+    {
+        $this->group_by = array();
+        return $this;
+    }
+
+    public function resetHaving()
+    {
+        $this->having = array();
+        return $this;
     }
 
     public function resetOrderBy()
     {
         $this->order_by = array();
+        return $this;
     }
 
     public function resetLimit()
     {
         $this->limit = 0;
+        return $this;
     }
 
     public function resetOffset()
     {
         $this->offset = 0;
+        return $this;
     }
 
     public function resetPage()
     {
         $this->page = 0;
+        return $this;
+    }
+
+    public function resetForUpdate()
+    {
+        $this->for_update = false;
+        return $this;
+    }
+
+    public function resetTableRefs()
+    {
+        $this->table_refs = array();
+        return $this;
     }
 
     /**


### PR DESCRIPTION
@yespire @golgote @gauthier @harikt --

This PR is based on #84 from @yespire. It combines the resetFrom(), resetFromKey(), and resetTableRefs() into a single resetTables() method, and adds resetBindValues() and resetUnions(). It removes resetLimit(), resetOffset(), resetPage(), because those values are accessible through existing limit(), offset(), and page() methods. Finally, the resetFlags() method is made public instead of protected, and now returns $this.

In summary, the newly-public reset methods are:
- resetBindValues()
- resetFlags()
- resetCols()
- resetTables()
- resetWhere()
- resetGroupBy()
- resetHaving
- resetOrderBy()
- resetUnions()

Thoughts?
