### PR TITLE
add Insert::orReplace

### DIFF
--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -21,6 +21,15 @@ class Insert extends Common\Insert
 {
     /**
      *
+     * if true, use a REPLACE sql command instead of INSERT
+     *
+     * @var bool
+     *
+     */
+    private $use_replace = false;
+
+    /**
+     *
      * Column values for ON DUPLICATE KEY UPDATE section of query; the key is
      * the column name and the value is the column value.
      *
@@ -28,6 +37,22 @@ class Insert extends Common\Insert
      *
      */
     protected $col_on_update_values;
+
+    /**
+     *
+     * Use a REPLACE statement.
+     * Matches similar orReplace() function for Sqlite
+     *
+     * @param bool $enable Set or unset flag (default true).
+     *
+     * @return $this
+     *
+     */
+    public function orReplace($enable = true)
+    {
+        $this->use_replace = $enable;
+        return $this;
+    }
 
     /**
      *
@@ -175,7 +200,7 @@ class Insert extends Common\Insert
      */
     protected function build()
     {
-        return 'INSERT'
+        return ($this->use_replace ? 'REPLACE' : 'INSERT')
             . $this->buildFlags()
             . $this->buildInto()
             . $this->buildValuesForInsert()

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -58,6 +58,21 @@ class InsertTest extends Common\InsertTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testOrReplace()
+    {
+        $this->query->orReplace()
+                    ->into('t1')
+                    ->cols(array('c1', 'c2', 'c3'))
+                    ->set('c4', 'NOW()')
+                    ->set('c5', null);
+
+        $actual = $this->query->__toString();
+        $expect = sprintf($this->expected_sql_with_flag, '');
+        $expect = preg_replace('|INSERT |ms', 'REPLACE', $expect);
+
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testLowPriority()
     {
         $this->query->lowPriority()

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -44,6 +44,22 @@ class InsertTest extends Common\InsertTest
             <<c5>> = :c5__on_duplicate_key
     ";
 
+    protected $expected_replace_sql = "
+        REPLACE INTO <<t1>> (
+            <<c1>>,
+            <<c2>>,
+            <<c3>>,
+            <<c4>>,
+            <<c5>>
+        ) VALUES (
+            :c1,
+            :c2,
+            :c3,
+            NOW(),
+            NULL
+        )
+    ";
+
     public function testHighPriority()
     {
         $this->query->highPriority()
@@ -67,10 +83,7 @@ class InsertTest extends Common\InsertTest
                     ->set('c5', null);
 
         $actual = $this->query->__toString();
-        $expect = sprintf($this->expected_sql_with_flag, '');
-        $expect = preg_replace('|INSERT |ms', 'REPLACE', $expect);
-
-        $this->assertSameSql($expect, $actual);
+        $this->assertSameSql($this->expected_replace_sql, $actual);
     }
 
     public function testLowPriority()


### PR DESCRIPTION
originally added a useReplace() as suggested by #100, but then found sqlite has an orReplace() function and it will be very handy to have the same signature for both dbms when writing unit tests: can switch out mysql for sqlite and not have to add code to check which you are using.