### PR TITLE
move copy/pasted limit()/offset() code to traits

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -459,20 +459,4 @@ abstract class AbstractQuery
 
         return PHP_EOL . 'ORDER BY' . $this->indentCsv($this->order_by);
     }
-
-    /**
-     *
-     * Template method overridden for queries that allow LIMIT and OFFSET.
-     *
-     * Builds the `LIMIT ... OFFSET` clause of the statement.
-     *
-     * Note that this will allow OFFSET values with a LIMIT.
-     *
-     * @return string
-     *
-     */
-    protected function buildLimit()
-    {
-        return '';
-    }
 }

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -8,8 +8,6 @@
  */
 namespace Aura\SqlQuery;
 
-use Aura\SqlQuery\Common\LimitInterface;
-use Aura\SqlQuery\Common\LimitOffsetInterface;
 use Aura\SqlQuery\Common\SubselectInterface;
 
 /**
@@ -47,24 +45,6 @@ abstract class AbstractQuery
      *
      */
     protected $order_by = array();
-
-    /**
-     *
-     * The number of rows to select
-     *
-     * @var int
-     *
-     */
-    protected $limit = 0;
-
-    /**
-     *
-     * Return rows after this offset.
-     *
-     * @var int
-     *
-     */
-    protected $offset = 0;
 
     /**
      *
@@ -482,6 +462,8 @@ abstract class AbstractQuery
 
     /**
      *
+     * Template method overridden for queries that allow LIMIT and OFFSET.
+     *
      * Builds the `LIMIT ... OFFSET` clause of the statement.
      *
      * Note that this will allow OFFSET values with a LIMIT.
@@ -491,22 +473,6 @@ abstract class AbstractQuery
      */
     protected function buildLimit()
     {
-        $clause = '';
-        $limit = $this instanceof LimitInterface && $this->limit;
-        $offset = $this instanceof LimitOffsetInterface && $this->offset;
-
-        if ($limit) {
-            $clause .= "LIMIT {$this->limit}";
-        }
-
-        if ($offset) {
-            $clause .= " OFFSET {$this->offset}";
-        }
-
-        if ($clause) {
-            $clause = PHP_EOL . trim($clause);
-        }
-
-        return $clause;
+        return '';
     }
 }

--- a/src/Common/Delete.php
+++ b/src/Common/Delete.php
@@ -74,4 +74,20 @@ class Delete extends AbstractDmlQuery implements DeleteInterface
     {
         return " FROM {$this->from}";
     }
+
+    /**
+     *
+     * Template method overridden for queries that allow LIMIT and OFFSET.
+     *
+     * Builds the `LIMIT ... OFFSET` clause of the statement.
+     *
+     * Note that this will allow OFFSET values with a LIMIT.
+     *
+     * @return string
+     *
+     */
+    protected function buildLimit()
+    {
+        return '';
+    }
 }

--- a/src/Common/LimitInterface.php
+++ b/src/Common/LimitInterface.php
@@ -27,4 +27,13 @@ interface LimitInterface
      *
      */
     public function limit($limit);
+
+    /**
+     *
+     * Returns the LIMIT value.
+     *
+     * @return int
+     *
+     */
+    public function getLimit();
 }

--- a/src/Common/LimitOffsetInterface.php
+++ b/src/Common/LimitOffsetInterface.php
@@ -27,4 +27,13 @@ interface LimitOffsetInterface extends LimitInterface
      *
      */
     public function offset($offset);
+
+    /**
+     *
+     * Returns the OFFSET value.
+     *
+     * @return int
+     *
+     */
+    public function getOffset();
 }

--- a/src/Common/LimitOffsetTrait.php
+++ b/src/Common/LimitOffsetTrait.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+/**
+ *
+ * An interface for LIMIT...OFFSET clauses.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait LimitOffsetTrait
+{
+    use LimitTrait;
+
+    private $offset = 0;
+
+    /**
+     *
+     * Sets a limit offset on the query.
+     *
+     * @param int $offset Start returning after this many rows.
+     *
+     * @return $this
+     *
+     */
+    public function offset($offset)
+    {
+        $this->offset = (int) $offset;
+        return $this;
+    }
+
+    /**
+     *
+     * Returns the OFFSET value.
+     *
+     * @return int
+     *
+     */
+    public function getOffset()
+    {
+        return $this->offset;
+    }
+
+    /**
+     *
+     * Builds the `LIMIT ... OFFSET` clause of the statement.
+     *
+     * @return string
+     *
+     */
+    protected function buildLimit()
+    {
+        $clause = '';
+
+        $limit = $this->getLimit();
+        if (!empty($limit)) {
+            $clause .= "LIMIT {$limit}";
+        }
+
+        if (!empty($this->offset)) {
+            $clause .= " OFFSET {$this->offset}";
+        }
+
+        if (!empty($clause)) {
+            $clause = PHP_EOL . trim($clause);
+        }
+
+        return $clause;
+    }
+}

--- a/src/Common/LimitTrait.php
+++ b/src/Common/LimitTrait.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+/**
+ *
+ * A trait for LIMIT clauses.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait LimitTrait
+{
+    private $limit = 0;
+
+    /**
+     *
+     * Sets a limit count on the query.
+     *
+     * @param int $limit The number of rows to select.
+     *
+     * @return $this
+     *
+     */
+    public function limit($limit)
+    {
+        $this->limit = (int) $limit;
+        return $this;
+    }
+
+    /**
+     *
+     * Returns the LIMIT value.
+     *
+     * @return int
+     *
+     */
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
+    /**
+     *
+     * Builds the `LIMIT` clause of the statement.
+     *
+     * @return string
+     *
+     */
+    protected function buildLimit()
+    {
+        if (empty($this->limit)) {
+            return '';
+        }
+        return PHP_EOL . "LIMIT {$this->limit}";
+    }
+}

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -21,6 +21,7 @@ use Aura\SqlQuery\Exception;
 class Select extends AbstractQuery implements SelectInterface, SubselectInterface
 {
     use WhereTrait;
+    use LimitOffsetTrait { limit as setLimit; offset as setOffset; }
 
     /**
      *
@@ -671,11 +672,11 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
      */
     protected function setPagingLimitOffset()
     {
-        $this->limit  = 0;
-        $this->offset = 0;
+        $this->setLimit(0);
+        $this->setOffset(0);
         if ($this->page) {
-            $this->limit  = $this->paging;
-            $this->offset = $this->paging * ($this->page - 1);
+            $this->setLimit($this->paging);
+            $this->setOffset($this->paging * ($this->page - 1));
         }
     }
 
@@ -719,30 +720,6 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
         $this->union[] = $this->build() . PHP_EOL . 'UNION ALL';
         $this->reset();
         return $this;
-    }
-
-    /**
-     *
-     * Returns the LIMIT value.
-     *
-     * @return int
-     *
-     */
-    public function getLimit()
-    {
-        return $this->limit;
-    }
-
-    /**
-     *
-     * Returns the OFFSET value.
-     *
-     * @return int
-     *
-     */
-    public function getOffset()
-    {
-        return $this->offset;
     }
 
     /**
@@ -992,10 +969,10 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
      */
     public function limit($limit)
     {
-        $this->limit = (int) $limit;
+        $this->setLimit($limit);
         if ($this->page) {
             $this->page = 0;
-            $this->offset = 0;
+            $this->setOffset(0);
         }
         return $this;
     }
@@ -1011,10 +988,10 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
      */
     public function offset($offset)
     {
-        $this->offset = (int) $offset;
+        $this->setOffset($offset);
         if ($this->page) {
             $this->page = 0;
-            $this->limit = 0;
+            $this->setLimit(0);
         }
         return $this;
     }

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -142,4 +142,20 @@ class Update extends AbstractDmlQuery implements UpdateInterface
         }
         return PHP_EOL . 'SET' . $this->indentCsv($values);
     }
+
+    /**
+     *
+     * Template method overridden for queries that allow LIMIT and OFFSET.
+     *
+     * Builds the `LIMIT ... OFFSET` clause of the statement.
+     *
+     * Note that this will allow OFFSET values with a LIMIT.
+     *
+     * @return string
+     *
+     */
+    protected function buildLimit()
+    {
+        return '';
+    }
 }

--- a/src/Mysql/Delete.php
+++ b/src/Mysql/Delete.php
@@ -19,6 +19,8 @@ use Aura\SqlQuery\Common;
  */
 class Delete extends Common\Delete implements Common\OrderByInterface, Common\LimitInterface
 {
+    use Common\LimitTrait;
+
     /**
      *
      * Adds or removes LOW_PRIORITY flag.
@@ -62,33 +64,6 @@ class Delete extends Common\Delete implements Common\OrderByInterface, Common\Li
     {
         $this->setFlag('QUICK', $enable);
         return $this;
-    }
-
-    /**
-     *
-     * Sets a limit count on the query.
-     *
-     * @param int $limit The number of rows to select.
-     *
-     * @return $this
-     *
-     */
-    public function limit($limit)
-    {
-        $this->limit = (int) $limit;
-        return $this;
-    }
-
-    /**
-     *
-     * Returns the LIMIT value.
-     *
-     * @return int
-     *
-     */
-    public function getLimit()
-    {
-        return $this->limit;
     }
 
     /**

--- a/src/Mysql/Update.php
+++ b/src/Mysql/Update.php
@@ -19,6 +19,8 @@ use Aura\SqlQuery\Common;
  */
 class Update extends Common\Update implements Common\OrderByInterface, Common\LimitInterface
 {
+    use Common\LimitTrait;
+
     /**
      *
      * Adds or removes LOW_PRIORITY flag.
@@ -47,33 +49,6 @@ class Update extends Common\Update implements Common\OrderByInterface, Common\Li
     {
         $this->setFlag('IGNORE', $enable);
         return $this;
-    }
-
-    /**
-     *
-     * Sets a limit count on the query.
-     *
-     * @param int $limit The number of rows to select.
-     *
-     * @return $this
-     *
-     */
-    public function limit($limit)
-    {
-        $this->limit = (int) $limit;
-        return $this;
-    }
-
-    /**
-     *
-     * Returns the LIMIT value.
-     *
-     * @return int
-     *
-     */
-    public function getLimit()
-    {
-        return $this->limit;
     }
 
     /**

--- a/src/Sqlite/Delete.php
+++ b/src/Sqlite/Delete.php
@@ -19,59 +19,7 @@ use Aura\SqlQuery\Common;
  */
 class Delete extends Common\Delete implements Common\OrderByInterface, Common\LimitOffsetInterface
 {
-    /**
-     *
-     * Sets a limit count on the query.
-     *
-     * @param int $limit The number of rows to select.
-     *
-     * @return $this
-     *
-     */
-    public function limit($limit)
-    {
-        $this->limit = (int) $limit;
-        return $this;
-    }
-
-    /**
-     *
-     * Returns the LIMIT value.
-     *
-     * @return int
-     *
-     */
-    public function getLimit()
-    {
-        return $this->limit;
-    }
-
-    /**
-     *
-     * Sets a limit offset on the query.
-     *
-     * @param int $offset Start returning after this many rows.
-     *
-     * @return $this
-     *
-     */
-    public function offset($offset)
-    {
-        $this->offset = (int) $offset;
-        return $this;
-    }
-
-    /**
-     *
-     * Returns the OFFSET value.
-     *
-     * @return int
-     *
-     */
-    public function getOffset()
-    {
-        return $this->offset;
-    }
+    use Common\LimitOffsetTrait;
 
     /**
      *

--- a/src/Sqlite/Update.php
+++ b/src/Sqlite/Update.php
@@ -19,6 +19,8 @@ use Aura\SqlQuery\Common;
  */
 class Update extends Common\Update implements Common\OrderByInterface, Common\LimitOffsetInterface
 {
+    use Common\LimitOffsetTrait;
+
     /**
      *
      * Adds or removes OR ABORT flag.
@@ -92,60 +94,6 @@ class Update extends Common\Update implements Common\OrderByInterface, Common\Li
     {
         $this->setFlag('OR ROLLBACK', $enable);
         return $this;
-    }
-
-    /**
-     *
-     * Sets a limit count on the query.
-     *
-     * @param int $limit The number of rows to select.
-     *
-     * @return $this
-     *
-     */
-    public function limit($limit)
-    {
-        $this->limit = (int) $limit;
-        return $this;
-    }
-
-    /**
-     *
-     * Returns the LIMIT value.
-     *
-     * @return int
-     *
-     */
-    public function getLimit()
-    {
-        return $this->limit;
-    }
-
-    /**
-     *
-     * Sets a limit offset on the query.
-     *
-     * @param int $offset Start returning after this many rows.
-     *
-     * @return $this
-     *
-     */
-    public function offset($offset)
-    {
-        $this->offset = (int) $offset;
-        return $this;
-    }
-
-    /**
-     *
-     * Returns the OFFSET value.
-     *
-     * @return int
-     *
-     */
-    public function getOffset()
-    {
-        return $this->offset;
     }
 
     /**

--- a/src/Sqlsrv/Select.php
+++ b/src/Sqlsrv/Select.php
@@ -55,23 +55,25 @@ class Select extends Common\Select
      */
     protected function applyLimit($stm)
     {
-        if (! $this->limit && ! $this->offset) {
+        $limit = $this->getLimit();
+        $offset = $this->getOffset();
+        if (! $limit && ! $offset) {
             return $stm; // no limit or offset
         }
 
         // limit but no offset?
-        if ($this->limit && ! $this->offset) {
+        if ($limit && ! $offset) {
             // use TOP in place
             return preg_replace(
                 '/^(SELECT( DISTINCT)?)/',
-                "$1 TOP {$this->limit}",
+                "$1 TOP {$limit}",
                 $stm
             );
         }
 
         // both limit and offset. must have an ORDER clause to work; OFFSET is
         // a sub-clause of the ORDER clause. cannot use FETCH without OFFSET.
-        return $stm . PHP_EOL . "OFFSET {$this->offset} ROWS "
-                    . "FETCH NEXT {$this->limit} ROWS ONLY";
+        return $stm . PHP_EOL . "OFFSET {$offset} ROWS "
+                    . "FETCH NEXT {$limit} ROWS ONLY";
     }
 }


### PR DESCRIPTION
similar to #116: the code for limit() and offset() was duplicated in several classes. Extracted the common code to traits, added getLimit() and getOffset() to the relevant interfaces.