### PR TITLE
Extract builder logic to separate classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - hhvm
   - 7
 script:
-  - phpunit --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - hhvm
   - 7
 script:
+  - composer install
   - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -29,15 +29,6 @@ abstract class AbstractDmlQuery extends AbstractQuery
 
     /**
      *
-     * The columns to be returned.
-     *
-     * @var array
-     *
-     */
-    protected $returning = array();
-
-    /**
-     *
      * Does the query have any columns in it?
      *
      * @return bool
@@ -118,26 +109,6 @@ abstract class AbstractDmlQuery extends AbstractQuery
         $key = $this->quoter->quoteName($col);
         $value = $this->quoter->quoteNamesIn($value);
         $this->col_values[$key] = $value;
-        return $this;
-    }
-
-    /**
-     *
-     * Adds returning columns to the query.
-     *
-     * Multiple calls to returning() will append to the list of columns, not
-     * overwrite the previous columns.
-     *
-     * @param array $cols The column(s) to add to the query.
-     *
-     * @return $this
-     *
-     */
-    protected function addReturning(array $cols)
-    {
-        foreach ($cols as $col) {
-            $this->returning[] = $this->quoter->quoteNamesIn($col);
-        }
         return $this;
     }
 }

--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -140,20 +140,4 @@ abstract class AbstractDmlQuery extends AbstractQuery
         }
         return $this;
     }
-
-    /**
-     *
-     * Builds the `RETURNING` clause of the statement.
-     *
-     * @return string
-     *
-     */
-    protected function buildReturning()
-    {
-        if (empty($this->returning)) {
-            return ''; // not applicable
-        }
-
-        return PHP_EOL . 'RETURNING' . $this->indentCsv($this->returning);
-    }
 }

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -84,9 +84,10 @@ abstract class AbstractQuery
      * placeholders (@see getSeqPlaceholder()).
      *
      */
-    public function __construct(Quoter $quoter, $seq_bind_prefix = '')
+    public function __construct(Quoter $quoter, $builder, $seq_bind_prefix = '')
     {
         $this->quoter = $quoter;
+        $this->builder = $builder;
         $this->seq_bind_prefix = $seq_bind_prefix;
     }
 
@@ -162,36 +163,6 @@ abstract class AbstractQuery
 
     /**
      *
-     * Returns an array as an indented comma-separated values string.
-     *
-     * @param array $list The values to convert.
-     *
-     * @return string
-     *
-     */
-    protected function indentCsv(array $list)
-    {
-        return PHP_EOL . '    '
-             . implode(',' . PHP_EOL . '    ', $list);
-    }
-
-    /**
-     *
-     * Returns an array as an indented string.
-     *
-     * @param array $list The values to convert.
-     *
-     * @return string
-     *
-     */
-    protected function indent(array $list)
-    {
-        return PHP_EOL . '    '
-             . implode(PHP_EOL . '    ', $list);
-    }
-
-    /**
-     *
      * Binds multiple values to placeholders; merges with existing values.
      *
      * @param array $bind_values Values to bind to placeholders.
@@ -249,22 +220,6 @@ abstract class AbstractQuery
     {
         $this->bind_values = array();
         return $this;
-    }
-
-    /**
-     *
-     * Builds the flags as a space-separated string.
-     *
-     * @return string
-     *
-     */
-    protected function buildFlags()
-    {
-        if (empty($this->flags)) {
-            return ''; // not applicable
-        }
-
-        return ' ' . implode(' ', array_keys($this->flags));
     }
 
     /**
@@ -427,22 +382,6 @@ abstract class AbstractQuery
 
     /**
      *
-     * Builds the `WHERE` clause of the statement.
-     *
-     * @return string
-     *
-     */
-    protected function buildWhere()
-    {
-        if (empty($this->where)) {
-            return ''; // not applicable
-        }
-
-        return PHP_EOL . 'WHERE' . $this->indent($this->where);
-    }
-
-    /**
-     *
      * Adds a column order to the query.
      *
      * @param array $spec The columns and direction to order by.
@@ -456,21 +395,5 @@ abstract class AbstractQuery
             $this->order_by[] = $this->quoter->quoteNamesIn($col);
         }
         return $this;
-    }
-
-    /**
-     *
-     * Builds the `ORDER BY ...` clause of the statement.
-     *
-     * @return string
-     *
-     */
-    protected function buildOrderBy()
-    {
-        if (empty($this->order_by)) {
-            return ''; // not applicable
-        }
-
-        return PHP_EOL . 'ORDER BY' . $this->indentCsv($this->order_by);
     }
 }

--- a/src/Common/AbstractBuilder.php
+++ b/src/Common/AbstractBuilder.php
@@ -5,11 +5,6 @@ use Aura\SqlQuery\Exception;
 
 abstract class AbstractBuilder
 {
-    public function __construct($quoter)
-    {
-        $this->quoter = $quoter;
-    }
-
     /**
      *
      * Builds the flags as a space-separated string.

--- a/src/Common/AbstractBuilder.php
+++ b/src/Common/AbstractBuilder.php
@@ -1,0 +1,147 @@
+<?php
+namespace Aura\SqlQuery\Common;
+
+use Aura\SqlQuery\Exception;
+
+abstract class AbstractBuilder
+{
+    public function __construct($quoter)
+    {
+        $this->quoter = $quoter;
+    }
+
+    /**
+     *
+     * Builds the flags as a space-separated string.
+     *
+     * @return string
+     *
+     */
+    public function buildFlags($flags)
+    {
+        if (empty($flags)) {
+            return ''; // not applicable
+        }
+
+        return ' ' . implode(' ', array_keys($flags));
+    }
+
+    /**
+     *
+     * Builds the `WHERE` clause of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildWhere($where)
+    {
+        if (empty($where)) {
+            return ''; // not applicable
+        }
+
+        return PHP_EOL . 'WHERE' . $this->indent($where);
+    }
+
+    /**
+     *
+     * Builds the `ORDER BY ...` clause of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildOrderBy($order_by)
+    {
+        if (empty($order_by)) {
+            return ''; // not applicable
+        }
+
+        return PHP_EOL . 'ORDER BY' . $this->indentCsv($order_by);
+    }
+
+    /**
+     *
+     * Builds the `LIMIT` clause of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildLimit($limit)
+    {
+        if (empty($limit)) {
+            return '';
+        }
+        return PHP_EOL . "LIMIT {$limit}";
+    }
+
+    /**
+     *
+     * Builds the `LIMIT ... OFFSET` clause of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildLimitOffset($limit, $offset)
+    {
+        $clause = '';
+
+        if (!empty($limit)) {
+            $clause .= "LIMIT {$limit}";
+        }
+
+        if (!empty($offset)) {
+            $clause .= " OFFSET {$offset}";
+        }
+
+        if (!empty($clause)) {
+            $clause = PHP_EOL . trim($clause);
+        }
+
+        return $clause;
+    }
+
+    /**
+     *
+     * Builds the `RETURNING` clause of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildReturning($returning)
+    {
+        if (empty($returning)) {
+            return ''; // not applicable
+        }
+
+        return PHP_EOL . 'RETURNING' . $this->indentCsv($returning);
+    }
+
+    /**
+     *
+     * Returns an array as an indented comma-separated values string.
+     *
+     * @param array $list The values to convert.
+     *
+     * @return string
+     *
+     */
+    public function indentCsv(array $list)
+    {
+        return PHP_EOL . '    '
+             . implode(',' . PHP_EOL . '    ', $list);
+    }
+
+    /**
+     *
+     * Returns an array as an indented string.
+     *
+     * @param array $list The values to convert.
+     *
+     * @return string
+     *
+     */
+    public function indent(array $list)
+    {
+        return PHP_EOL . '    '
+             . implode(PHP_EOL . '    ', $list);
+    }
+}

--- a/src/Common/AbstractBuilder.php
+++ b/src/Common/AbstractBuilder.php
@@ -96,22 +96,6 @@ abstract class AbstractBuilder
 
     /**
      *
-     * Builds the `RETURNING` clause of the statement.
-     *
-     * @return string
-     *
-     */
-    public function buildReturning($returning)
-    {
-        if (empty($returning)) {
-            return ''; // not applicable
-        }
-
-        return PHP_EOL . 'RETURNING' . $this->indentCsv($returning);
-    }
-
-    /**
-     *
      * Returns an array as an indented comma-separated values string.
      *
      * @param array $list The values to convert.

--- a/src/Common/Delete.php
+++ b/src/Common/Delete.php
@@ -55,39 +55,9 @@ class Delete extends AbstractDmlQuery implements DeleteInterface
     protected function build()
     {
         return 'DELETE'
-            . $this->buildFlags()
-            . $this->buildFrom()
-            . $this->buildWhere()
-            . $this->buildOrderBy()
-            . $this->buildLimit()
-            . $this->buildReturning();
-    }
-
-    /**
-     *
-     * Builds the FROM clause.
-     *
-     * @return string
-     *
-     */
-    protected function buildFrom()
-    {
-        return " FROM {$this->from}";
-    }
-
-    /**
-     *
-     * Template method overridden for queries that allow LIMIT and OFFSET.
-     *
-     * Builds the `LIMIT ... OFFSET` clause of the statement.
-     *
-     * Note that this will allow OFFSET values with a LIMIT.
-     *
-     * @return string
-     *
-     */
-    protected function buildLimit()
-    {
-        return '';
+            . $this->builder->buildFlags($this->flags)
+            . $this->builder->buildFrom($this->from)
+            . $this->builder->buildWhere($this->where)
+            . $this->builder->buildOrderBy($this->order_by);
     }
 }

--- a/src/Common/DeleteBuilder.php
+++ b/src/Common/DeleteBuilder.php
@@ -1,0 +1,17 @@
+<?php
+namespace Aura\SqlQuery\Common;
+
+class DeleteBuilder extends AbstractBuilder
+{
+    /**
+     *
+     * Builds the FROM clause.
+     *
+     * @return string
+     *
+     */
+    public function buildFrom($from)
+    {
+        return " FROM {$from}";
+    }
+}

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -116,23 +116,18 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      */
     protected function build()
     {
-        return 'INSERT'
-            . $this->buildFlags()
-            . $this->buildInto()
-            . $this->buildValuesForInsert()
-            . $this->buildReturning();
-    }
+        $stm = 'INSERT'
+            . $this->builder->buildFlags($this->flags)
+            . $this->builder->buildInto($this->into);
 
-    /**
-     *
-     * Builds the INTO clause.
-     *
-     * @return string
-     *
-     */
-    protected function buildInto()
-    {
-        return " INTO " . $this->quoter->quoteName($this->into);
+        if ($this->row) {
+            $this->finishRow();
+            $stm .= $this->builder->buildValuesForBulkInsert($this->col_order, $this->col_values_bulk);
+        } else {
+            $stm .= $this->builder->buildValuesForInsert($this->col_values);
+        }
+
+        return $stm;
     }
 
     /**
@@ -330,45 +325,5 @@ class Insert extends AbstractDmlQuery implements InsertInterface
         if (array_key_exists($name, $this->bind_values)) {
             $this->bind_values_bulk["{$name}_{$this->row}"] = $this->bind_values[$name];
         }
-    }
-
-    /**
-     *
-     * Builds the inserted columns and values of the statement.
-     *
-     * @return string
-     *
-     */
-    protected function buildValuesForInsert()
-    {
-        if ($this->row) {
-            return $this->buildValuesForBulkInsert();
-        }
-
-        return ' ('
-            . $this->indentCsv(array_keys($this->col_values))
-            . PHP_EOL . ') VALUES ('
-            . $this->indentCsv(array_values($this->col_values))
-            . PHP_EOL . ')';
-    }
-
-    /**
-     *
-     * Builds the bulk-inserted columns and values of the statement.
-     *
-     * @return string
-     *
-     */
-    protected function buildValuesForBulkInsert()
-    {
-        $this->finishRow();
-        $cols = "    (" . implode(', ', $this->col_order) . ")";
-        $vals = array();
-        foreach ($this->col_values_bulk as $row_values) {
-            $vals[] = "    (" . implode(', ', $row_values) . ")";
-        }
-        return PHP_EOL . $cols . PHP_EOL
-            . "VALUES" . PHP_EOL
-            . implode("," . PHP_EOL, $vals);
     }
 }

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -29,6 +29,8 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      */
     protected $into;
 
+    protected $into_raw;
+
     /**
      *
      * A map of fully-qualified `table.column` names to last-insert-id names.
@@ -102,8 +104,8 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      */
     public function into($into)
     {
-        // don't quote yet, we might need it for getLastInsertIdName()
-        $this->into = $into;
+        $this->into_raw = $into;
+        $this->into = $this->quoter->quoteName($into);
         return $this;
     }
 
@@ -142,7 +144,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      */
     public function getLastInsertIdName($col)
     {
-        $key = $this->into . '.' . $col;
+        $key = $this->into_raw . '.' . $col;
         if (isset($this->last_insert_id_names[$key])) {
             return $this->last_insert_id_names[$key];
         }

--- a/src/Common/InsertBuilder.php
+++ b/src/Common/InsertBuilder.php
@@ -13,7 +13,7 @@ class InsertBuilder extends AbstractBuilder
      */
     public function buildInto($into)
     {
-        return " INTO " . $this->quoter->quoteName($into);
+        return " INTO {$into}";
     }
 
 

--- a/src/Common/InsertBuilder.php
+++ b/src/Common/InsertBuilder.php
@@ -1,0 +1,54 @@
+<?php
+namespace Aura\SqlQuery\Common;
+
+class InsertBuilder extends AbstractBuilder
+{
+
+    /**
+     *
+     * Builds the INTO clause.
+     *
+     * @return string
+     *
+     */
+    public function buildInto($into)
+    {
+        return " INTO " . $this->quoter->quoteName($into);
+    }
+
+
+    /**
+     *
+     * Builds the inserted columns and values of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildValuesForInsert($col_values)
+    {
+        return ' ('
+            . $this->indentCsv(array_keys($col_values))
+            . PHP_EOL . ') VALUES ('
+            . $this->indentCsv(array_values($col_values))
+            . PHP_EOL . ')';
+    }
+
+    /**
+     *
+     * Builds the bulk-inserted columns and values of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildValuesForBulkInsert($col_order, $col_values_bulk)
+    {
+        $cols = "    (" . implode(', ', $col_order) . ")";
+        $vals = array();
+        foreach ($col_values_bulk as $row_values) {
+            $vals[] = "    (" . implode(', ', $row_values) . ")";
+        }
+        return PHP_EOL . $cols . PHP_EOL
+            . "VALUES" . PHP_EOL
+            . implode("," . PHP_EOL, $vals);
+    }
+}

--- a/src/Common/LimitOffsetTrait.php
+++ b/src/Common/LimitOffsetTrait.php
@@ -19,7 +19,7 @@ trait LimitOffsetTrait
 {
     use LimitTrait;
 
-    private $offset = 0;
+    protected $offset = 0;
 
     /**
      *
@@ -46,32 +46,5 @@ trait LimitOffsetTrait
     public function getOffset()
     {
         return $this->offset;
-    }
-
-    /**
-     *
-     * Builds the `LIMIT ... OFFSET` clause of the statement.
-     *
-     * @return string
-     *
-     */
-    protected function buildLimit()
-    {
-        $clause = '';
-
-        $limit = $this->getLimit();
-        if (!empty($limit)) {
-            $clause .= "LIMIT {$limit}";
-        }
-
-        if (!empty($this->offset)) {
-            $clause .= " OFFSET {$this->offset}";
-        }
-
-        if (!empty($clause)) {
-            $clause = PHP_EOL . trim($clause);
-        }
-
-        return $clause;
     }
 }

--- a/src/Common/LimitTrait.php
+++ b/src/Common/LimitTrait.php
@@ -17,7 +17,7 @@ namespace Aura\SqlQuery\Common;
  */
 trait LimitTrait
 {
-    private $limit = 0;
+    protected $limit = 0;
 
     /**
      *
@@ -44,20 +44,5 @@ trait LimitTrait
     public function getLimit()
     {
         return $this->limit;
-    }
-
-    /**
-     *
-     * Builds the `LIMIT` clause of the statement.
-     *
-     * @return string
-     *
-     */
-    protected function buildLimit()
-    {
-        if (empty($this->limit)) {
-            return '';
-        }
-        return PHP_EOL . "LIMIT {$this->limit}";
     }
 }

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -874,9 +874,18 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
      */
     protected function build()
     {
+        $cols = array();
+        foreach ($this->cols as $key => $val) {
+            if (is_int($key)) {
+                $cols[] = $this->quoter->quoteNamesIn($val);
+            } else {
+                $cols[] = $this->quoter->quoteNamesIn("$val AS $key");
+            }
+        }
+
         return 'SELECT'
             . $this->builder->buildFlags($this->flags)
-            . $this->builder->buildCols($this->cols, $this->quoter)
+            . $this->builder->buildCols($cols)
             . $this->builder->buildFrom($this->from, $this->join)
             . $this->builder->buildWhere($this->where)
             . $this->builder->buildGroupBy($this->group_by)

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -875,113 +875,15 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
     protected function build()
     {
         return 'SELECT'
-            . $this->buildFlags()
-            . $this->buildCols()
-            . $this->buildFrom() // includes JOIN
-            . $this->buildWhere()
-            . $this->buildGroupBy()
-            . $this->buildHaving()
-            . $this->buildOrderBy()
-            . $this->buildLimit()
-            . $this->buildForUpdate();
-    }
-
-    /**
-     *
-     * Builds the columns clause.
-     *
-     * @return string
-     *
-     * @throws Exception when there are no columns in the SELECT.
-     *
-     */
-    protected function buildCols()
-    {
-        if (empty($this->cols)) {
-            throw new Exception('No columns in the SELECT.');
-        }
-
-        $cols = array();
-        foreach ($this->cols as $key => $val) {
-            if (is_int($key)) {
-                $cols[] = $this->quoter->quoteNamesIn($val);
-            } else {
-                $cols[] = $this->quoter->quoteNamesIn("$val AS $key");
-            }
-        }
-
-        return $this->indentCsv($cols);
-    }
-
-    /**
-     *
-     * Builds the FROM clause.
-     *
-     * @return string
-     *
-     */
-    protected function buildFrom()
-    {
-        if (empty($this->from)) {
-            return ''; // not applicable
-        }
-
-        $refs = array();
-        foreach ($this->from as $from_key => $from) {
-            if (isset($this->join[$from_key])) {
-                $from = array_merge($from, $this->join[$from_key]);
-            }
-            $refs[] = implode(PHP_EOL, $from);
-        }
-        return PHP_EOL . 'FROM' . $this->indentCsv($refs);
-    }
-
-    /**
-     *
-     * Builds the GROUP BY clause.
-     *
-     * @return string
-     *
-     */
-    protected function buildGroupBy()
-    {
-        if (empty($this->group_by)) {
-            return ''; // not applicable
-        }
-
-        return PHP_EOL . 'GROUP BY' . $this->indentCsv($this->group_by);
-    }
-
-    /**
-     *
-     * Builds the HAVING clause.
-     *
-     * @return string
-     *
-     */
-    protected function buildHaving()
-    {
-        if (empty($this->having)) {
-            return ''; // not applicable
-        }
-
-        return PHP_EOL . 'HAVING' . $this->indent($this->having);
-    }
-
-    /**
-     *
-     * Builds the FOR UPDATE clause.
-     *
-     * @return string
-     *
-     */
-    protected function buildForUpdate()
-    {
-        if (! $this->for_update) {
-            return ''; // not applicable
-        }
-
-        return PHP_EOL . 'FOR UPDATE';
+            . $this->builder->buildFlags($this->flags)
+            . $this->builder->buildCols($this->cols)
+            . $this->builder->buildFrom($this->from, $this->join)
+            . $this->builder->buildWhere($this->where)
+            . $this->builder->buildGroupBy($this->group_by)
+            . $this->builder->buildHaving($this->having)
+            . $this->builder->buildOrderBy($this->order_by)
+            . $this->builder->buildLimitOffset($this->limit, $this->offset)
+            . $this->builder->buildForUpdate($this->for_update);
     }
 
     /**

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -876,7 +876,7 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
     {
         return 'SELECT'
             . $this->builder->buildFlags($this->flags)
-            . $this->builder->buildCols($this->cols)
+            . $this->builder->buildCols($this->cols, $this->quoter)
             . $this->builder->buildFrom($this->from, $this->join)
             . $this->builder->buildWhere($this->where)
             . $this->builder->buildGroupBy($this->group_by)

--- a/src/Common/SelectBuilder.php
+++ b/src/Common/SelectBuilder.php
@@ -14,22 +14,12 @@ class SelectBuilder extends AbstractBuilder
      * @throws Exception when there are no columns in the SELECT.
      *
      */
-    public function buildCols($cols, $quoter)
+    public function buildCols($cols)
     {
         if (empty($cols)) {
             throw new Exception('No columns in the SELECT.');
         }
-
-        $list = array();
-        foreach ($cols as $key => $val) {
-            if (is_int($key)) {
-                $list[] = $quoter->quoteNamesIn($val);
-            } else {
-                $list[] = $quoter->quoteNamesIn("$val AS $key");
-            }
-        }
-
-        return $this->indentCsv($list);
+        return $this->indentCsv($cols);
     }
 
     /**

--- a/src/Common/SelectBuilder.php
+++ b/src/Common/SelectBuilder.php
@@ -1,0 +1,105 @@
+<?php
+namespace Aura\SqlQuery\Common;
+
+use Aura\SqlQuery\Exception;
+
+class SelectBuilder extends AbstractBuilder
+{
+    /**
+     *
+     * Builds the columns clause.
+     *
+     * @return string
+     *
+     * @throws Exception when there are no columns in the SELECT.
+     *
+     */
+    public function buildCols($cols)
+    {
+        if (empty($cols)) {
+            throw new Exception('No columns in the SELECT.');
+        }
+
+        $list = array();
+        foreach ($cols as $key => $val) {
+            if (is_int($key)) {
+                $list[] = $this->quoter->quoteNamesIn($val);
+            } else {
+                $list[] = $this->quoter->quoteNamesIn("$val AS $key");
+            }
+        }
+
+        return $this->indentCsv($list);
+    }
+
+    /**
+     *
+     * Builds the FROM clause.
+     *
+     * @return string
+     *
+     */
+    public function buildFrom($from, $join)
+    {
+        if (empty($from)) {
+            return ''; // not applicable
+        }
+
+        $refs = array();
+        foreach ($from as $from_key => $from) {
+            if (isset($join[$from_key])) {
+                $from = array_merge($from, $join[$from_key]);
+            }
+            $refs[] = implode(PHP_EOL, $from);
+        }
+        return PHP_EOL . 'FROM' . $this->indentCsv($refs);
+    }
+
+    /**
+     *
+     * Builds the GROUP BY clause.
+     *
+     * @return string
+     *
+     */
+    public function buildGroupBy($group_by)
+    {
+        if (empty($group_by)) {
+            return ''; // not applicable
+        }
+
+        return PHP_EOL . 'GROUP BY' . $this->indentCsv($group_by);
+    }
+
+    /**
+     *
+     * Builds the HAVING clause.
+     *
+     * @return string
+     *
+     */
+    public function buildHaving($having)
+    {
+        if (empty($having)) {
+            return ''; // not applicable
+        }
+
+        return PHP_EOL . 'HAVING' . $this->indent($having);
+    }
+
+    /**
+     *
+     * Builds the FOR UPDATE clause.
+     *
+     * @return string
+     *
+     */
+    public function buildForUpdate($for_update)
+    {
+        if (! $for_update) {
+            return ''; // not applicable
+        }
+
+        return PHP_EOL . 'FOR UPDATE';
+    }
+}

--- a/src/Common/SelectBuilder.php
+++ b/src/Common/SelectBuilder.php
@@ -14,7 +14,7 @@ class SelectBuilder extends AbstractBuilder
      * @throws Exception when there are no columns in the SELECT.
      *
      */
-    public function buildCols($cols)
+    public function buildCols($cols, $quoter)
     {
         if (empty($cols)) {
             throw new Exception('No columns in the SELECT.');
@@ -23,9 +23,9 @@ class SelectBuilder extends AbstractBuilder
         $list = array();
         foreach ($cols as $key => $val) {
             if (is_int($key)) {
-                $list[] = $this->quoter->quoteNamesIn($val);
+                $list[] = $quoter->quoteNamesIn($val);
             } else {
-                $list[] = $this->quoter->quoteNamesIn("$val AS $key");
+                $list[] = $quoter->quoteNamesIn("$val AS $key");
             }
         }
 

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -55,25 +55,11 @@ class Update extends AbstractDmlQuery implements UpdateInterface
     protected function build()
     {
         return 'UPDATE'
-            . $this->buildFlags()
-            . $this->buildTable()
-            . $this->buildValuesForUpdate()
-            . $this->buildWhere()
-            . $this->buildOrderBy()
-            . $this->buildLimit()
-            . $this->buildReturning();
-    }
-
-    /**
-     *
-     * Builds the table clause.
-     *
-     * @return null
-     *
-     */
-    protected function buildTable()
-    {
-        return " {$this->table}";
+            . $this->builder->buildFlags($this->flags)
+            . $this->builder->buildTable($this->table)
+            . $this->builder->buildValuesForUpdate($this->col_values)
+            . $this->builder->buildWhere($this->where)
+            . $this->builder->buildOrderBy($this->order_by);
     }
 
     /**
@@ -125,37 +111,5 @@ class Update extends AbstractDmlQuery implements UpdateInterface
     public function set($col, $value)
     {
         return $this->setCol($col, $value);
-    }
-
-    /**
-     *
-     * Builds the updated columns and values of the statement.
-     *
-     * @return string
-     *
-     */
-    protected function buildValuesForUpdate()
-    {
-        $values = array();
-        foreach ($this->col_values as $col => $value) {
-            $values[] = "{$col} = {$value}";
-        }
-        return PHP_EOL . 'SET' . $this->indentCsv($values);
-    }
-
-    /**
-     *
-     * Template method overridden for queries that allow LIMIT and OFFSET.
-     *
-     * Builds the `LIMIT ... OFFSET` clause of the statement.
-     *
-     * Note that this will allow OFFSET values with a LIMIT.
-     *
-     * @return string
-     *
-     */
-    protected function buildLimit()
-    {
-        return '';
     }
 }

--- a/src/Common/UpdateBuilder.php
+++ b/src/Common/UpdateBuilder.php
@@ -1,0 +1,33 @@
+<?php
+namespace Aura\SqlQuery\Common;
+
+class UpdateBuilder extends AbstractBuilder
+{
+    /**
+     *
+     * Builds the table clause.
+     *
+     * @return null
+     *
+     */
+    public function buildTable($table)
+    {
+        return " {$table}";
+    }
+
+    /**
+     *
+     * Builds the updated columns and values of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildValuesForUpdate($col_values)
+    {
+        $values = array();
+        foreach ($col_values as $col => $value) {
+            $values[] = "{$col} = {$value}";
+        }
+        return PHP_EOL . 'SET' . $this->indentCsv($values);
+    }
+}

--- a/src/Mysql/Delete.php
+++ b/src/Mysql/Delete.php
@@ -21,6 +21,12 @@ class Delete extends Common\Delete implements Common\OrderByInterface, Common\Li
 {
     use Common\LimitTrait;
 
+    protected function build()
+    {
+        return parent::build()
+            . $this->builder->buildLimit($this->getLimit());
+    }
+
     /**
      *
      * Adds or removes LOW_PRIORITY flag.

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -200,15 +200,11 @@ class Insert extends Common\Insert
      */
     protected function build()
     {
-        $stm = ($this->use_replace ? 'REPLACE' : 'INSERT')
-            . $this->builder->buildFlags($this->flags)
-            . $this->builder->buildInto($this->into);
+        $stm = parent::build();
 
-        if ($this->row) {
-            $this->finishRow();
-            $stm .= $this->builder->buildValuesForBulkInsert($this->col_order, $this->col_values_bulk);
-        } else {
-            $stm .= $this->builder->buildValuesForInsert($this->col_values);
+        if ($this->use_replace) {
+            // change INSERT to REPLACE
+            $stm = 'REPLACE' . substr($stm, 6);
         }
 
         return $stm

--- a/src/Mysql/InsertBuilder.php
+++ b/src/Mysql/InsertBuilder.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\SqlQuery\Mysql;
+
+use Aura\SqlQuery\Common;
+
+class InsertBuilder extends Common\InsertBuilder
+{
+    /**
+     *
+     * Builds the UPDATE ON DUPLICATE KEY part of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildValuesForUpdateOnDuplicateKey($col_on_update_values)
+    {
+        if (empty($col_on_update_values)) {
+            return ''; // not applicable
+        }
+
+        $values = array();
+        foreach ($col_on_update_values as $key => $row) {
+            $values[] = $this->indent(array($key . ' = ' . $row));
+        }
+
+        return ' ON DUPLICATE KEY UPDATE'
+            . implode (',', $values);
+    }
+}

--- a/src/Mysql/Update.php
+++ b/src/Mysql/Update.php
@@ -21,6 +21,12 @@ class Update extends Common\Update implements Common\OrderByInterface, Common\Li
 {
     use Common\LimitTrait;
 
+    protected function build()
+    {
+        return parent::build()
+            . $this->builder->buildLimit($this->getLimit());
+    }
+
     /**
      *
      * Adds or removes LOW_PRIORITY flag.

--- a/src/Pgsql/BuildReturningTrait.php
+++ b/src/Pgsql/BuildReturningTrait.php
@@ -1,0 +1,21 @@
+<?php
+namespace Aura\SqlQuery\Pgsql;
+
+trait BuildReturningTrait
+{
+    /**
+     *
+     * Builds the `RETURNING` clause of the statement.
+     *
+     * @return string
+     *
+     */
+    public function buildReturning($returning)
+    {
+        if (empty($returning)) {
+            return ''; // not applicable
+        }
+
+        return PHP_EOL . 'RETURNING' . $this->indentCsv($returning);
+    }
+}

--- a/src/Pgsql/Delete.php
+++ b/src/Pgsql/Delete.php
@@ -19,6 +19,12 @@ use Aura\SqlQuery\Common;
  */
 class Delete extends Common\Delete implements Common\ReturningInterface
 {
+    protected function build()
+    {
+        return parent::build()
+            . $this->builder->buildReturning($this->returning);
+    }
+
     /**
      *
      * Adds returning columns to the query.

--- a/src/Pgsql/Delete.php
+++ b/src/Pgsql/Delete.php
@@ -17,28 +17,13 @@ use Aura\SqlQuery\Common;
  * @package Aura.SqlQuery
  *
  */
-class Delete extends Common\Delete implements Common\ReturningInterface
+class Delete extends Common\Delete implements ReturningInterface
 {
+    use ReturningTrait;
+
     protected function build()
     {
         return parent::build()
             . $this->builder->buildReturning($this->returning);
-    }
-
-    /**
-     *
-     * Adds returning columns to the query.
-     *
-     * Multiple calls to returning() will append to the list of columns, not
-     * overwrite the previous columns.
-     *
-     * @param array $cols The column(s) to add to the query.
-     *
-     * @return $this
-     *
-     */
-    public function returning(array $cols)
-    {
-        return $this->addReturning($cols);
     }
 }

--- a/src/Pgsql/DeleteBuilder.php
+++ b/src/Pgsql/DeleteBuilder.php
@@ -1,0 +1,9 @@
+<?php
+namespace Aura\SqlQuery\Pgsql;
+
+use Aura\SqlQuery\Common;
+
+class DeleteBuilder extends Common\DeleteBuilder
+{
+    use BuildReturningTrait;
+}

--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -19,6 +19,12 @@ use Aura\SqlQuery\Common;
  */
 class Insert extends Common\Insert implements Common\ReturningInterface
 {
+    protected function build()
+    {
+        return parent::build()
+            . $this->builder->buildReturning($this->returning);
+    }
+
     /**
      *
      * Returns the proper name for passing to `PDO::lastInsertId()`.

--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -17,8 +17,10 @@ use Aura\SqlQuery\Common;
  * @package Aura.SqlQuery
  *
  */
-class Insert extends Common\Insert implements Common\ReturningInterface
+class Insert extends Common\Insert implements ReturningInterface
 {
+    use ReturningTrait;
+
     protected function build()
     {
         return parent::build()
@@ -42,22 +44,5 @@ class Insert extends Common\Insert implements Common\ReturningInterface
             $name = "{$this->into_raw}_{$col}_seq";
         }
         return $name;
-    }
-
-    /**
-     *
-     * Adds returning columns to the query.
-     *
-     * Multiple calls to returning() will append to the list of columns, not
-     * overwrite the previous columns.
-     *
-     * @param array $cols The column(s) to add to the query.
-     *
-     * @return $this
-     *
-     */
-    public function returning(array $cols)
-    {
-        return $this->addReturning($cols);
     }
 }

--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -39,7 +39,7 @@ class Insert extends Common\Insert implements Common\ReturningInterface
     {
         $name = parent::getLastInsertIdName($col);
         if (! $name) {
-            $name = "{$this->into}_{$col}_seq";
+            $name = "{$this->into_raw}_{$col}_seq";
         }
         return $name;
     }

--- a/src/Pgsql/InsertBuilder.php
+++ b/src/Pgsql/InsertBuilder.php
@@ -1,0 +1,9 @@
+<?php
+namespace Aura\SqlQuery\Pgsql;
+
+use Aura\SqlQuery\Common;
+
+class InsertBuilder extends Common\InsertBuilder
+{
+    use BuildReturningTrait;
+}

--- a/src/Pgsql/ReturningInterface.php
+++ b/src/Pgsql/ReturningInterface.php
@@ -6,7 +6,7 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  *
  */
-namespace Aura\SqlQuery\Common;
+namespace Aura\SqlQuery\Pgsql;
 
 /**
  *

--- a/src/Pgsql/ReturningTrait.php
+++ b/src/Pgsql/ReturningTrait.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\SqlQuery\Pgsql;
+
+/**
+ *
+ * Common code for RETURNING clauses.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait ReturningTrait
+{
+    /**
+     *
+     * The columns to be returned.
+     *
+     * @var array
+     *
+     */
+    protected $returning = [];
+
+    /**
+     *
+     * Adds returning columns to the query.
+     *
+     * Multiple calls to returning() will append to the list of columns, not
+     * overwrite the previous columns.
+     *
+     * @param array $cols The column(s) to add to the query.
+     *
+     * @return $this
+     *
+     */
+    public function returning(array $cols)
+    {
+        foreach ($cols as $col) {
+            $this->returning[] = $this->quoter->quoteNamesIn($col);
+        }
+        return $this;
+    }
+}

--- a/src/Pgsql/Update.php
+++ b/src/Pgsql/Update.php
@@ -17,28 +17,13 @@ use Aura\SqlQuery\Common;
  * @package Aura.SqlQuery
  *
  */
-class Update extends Common\Update implements Common\ReturningInterface
+class Update extends Common\Update implements ReturningInterface
 {
+    use ReturningTrait;
+
     protected function build()
     {
         return parent::build()
             . $this->builder->buildReturning($this->returning);
-    }
-
-    /**
-     *
-     * Adds returning columns to the query.
-     *
-     * Multiple calls to returning() will append to the list of columns, not
-     * overwrite the previous columns.
-     *
-     * @param array $cols The column(s) to add to the query.
-     *
-     * @return $this
-     *
-     */
-    public function returning(array $cols)
-    {
-        return $this->addReturning($cols);
     }
 }

--- a/src/Pgsql/Update.php
+++ b/src/Pgsql/Update.php
@@ -19,6 +19,12 @@ use Aura\SqlQuery\Common;
  */
 class Update extends Common\Update implements Common\ReturningInterface
 {
+    protected function build()
+    {
+        return parent::build()
+            . $this->builder->buildReturning($this->returning);
+    }
+
     /**
      *
      * Adds returning columns to the query.

--- a/src/Pgsql/UpdateBuilder.php
+++ b/src/Pgsql/UpdateBuilder.php
@@ -1,0 +1,9 @@
+<?php
+namespace Aura\SqlQuery\Pgsql;
+
+use Aura\SqlQuery\Common;
+
+class UpdateBuilder extends Common\UpdateBuilder
+{
+    use BuildReturningTrait;
+}

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -205,7 +205,7 @@ class QueryFactory
 
         return new $queryClass(
             $this->getQuoter(),
-            new $builderClass($this->getQuoter()),
+            new $builderClass(),
             $this->newSeqBindPrefix()
         );
     }

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -193,16 +193,19 @@ class QueryFactory
      */
     protected function newInstance($query)
     {
+        $queryClass = "Aura\SqlQuery\\{$this->db}\\{$query}";
         if ($this->common) {
-            $class = "Aura\SqlQuery\Common";
-        } else {
-            $class = "Aura\SqlQuery\\{$this->db}";
+            $queryClass = "Aura\SqlQuery\Common\\{$query}";
         }
 
-        $class .= "\\{$query}";
+        $builderClass = "Aura\SqlQuery\\{$this->db}\\{$query}Builder";
+        if ($this->common || ! class_exists($builderClass)) {
+            $builderClass = "Aura\SqlQuery\Common\\{$query}Builder";
+        }
 
-        return new $class(
+        return new $queryClass(
             $this->getQuoter(),
+            new $builderClass($this->getQuoter()),
             $this->newSeqBindPrefix()
         );
     }

--- a/src/Sqlite/Delete.php
+++ b/src/Sqlite/Delete.php
@@ -21,6 +21,12 @@ class Delete extends Common\Delete implements Common\OrderByInterface, Common\Li
 {
     use Common\LimitOffsetTrait;
 
+    protected function build()
+    {
+        return parent::build()
+            . $this->builder->buildLimitOffset($this->getLimit(), $this->offset);
+    }
+
     /**
      *
      * Adds a column order to the query.

--- a/src/Sqlite/Update.php
+++ b/src/Sqlite/Update.php
@@ -21,6 +21,12 @@ class Update extends Common\Update implements Common\OrderByInterface, Common\Li
 {
     use Common\LimitOffsetTrait;
 
+    protected function build()
+    {
+        return parent::build()
+            . $this->builder->buildLimitOffset($this->getLimit(), $this->offset);
+    }
+
     /**
      *
      * Adds or removes OR ABORT flag.

--- a/src/Sqlsrv/Select.php
+++ b/src/Sqlsrv/Select.php
@@ -26,7 +26,7 @@ class Select extends Common\Select
      * @return string
      *
      */
-    public function build()
+    protected function build()
     {
         return $this->builder->applyLimit(parent::build(), $this->getLimit(), $this->offset);
     }

--- a/src/Sqlsrv/Select.php
+++ b/src/Sqlsrv/Select.php
@@ -26,54 +26,8 @@ class Select extends Common\Select
      * @return string
      *
      */
-    protected function build()
+    public function build()
     {
-        return $this->applyLimit(parent::build());
-    }
-
-    /**
-     *
-     * Override so that LIMIT equivalent will be applied by applyLimit().
-     *
-     * @see build()
-     *
-     * @see applyLimit()
-     *
-     */
-    protected function buildLimit()
-    {
-        return '';
-    }
-
-    /**
-     *
-     * Modify the statement applying limit/offset equivalent portions to it.
-     *
-     * @param string $stm SQL statement
-     * @return string SQL statement with limit/offset applied
-     *
-     */
-    protected function applyLimit($stm)
-    {
-        $limit = $this->getLimit();
-        $offset = $this->getOffset();
-        if (! $limit && ! $offset) {
-            return $stm; // no limit or offset
-        }
-
-        // limit but no offset?
-        if ($limit && ! $offset) {
-            // use TOP in place
-            return preg_replace(
-                '/^(SELECT( DISTINCT)?)/',
-                "$1 TOP {$limit}",
-                $stm
-            );
-        }
-
-        // both limit and offset. must have an ORDER clause to work; OFFSET is
-        // a sub-clause of the ORDER clause. cannot use FETCH without OFFSET.
-        return $stm . PHP_EOL . "OFFSET {$offset} ROWS "
-                    . "FETCH NEXT {$limit} ROWS ONLY";
+        return $this->builder->applyLimit(parent::build(), $this->getLimit(), $this->offset);
     }
 }

--- a/src/Sqlsrv/SelectBuilder.php
+++ b/src/Sqlsrv/SelectBuilder.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\SqlQuery\Sqlsrv;
+
+use Aura\SqlQuery\Common;
+
+/**
+ *
+ * An object for Sqlsrv SELECT queries.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+class SelectBuilder extends Common\SelectBuilder
+{
+    /**
+     *
+     * Override so that LIMIT equivalent will be applied by applyLimit().
+     *
+     * @see build()
+     *
+     * @see applyLimit()
+     *
+     */
+    public function buildLimitOffset($limit, $offset)
+    {
+        return '';
+    }
+
+    /**
+     *
+     * Modify the statement applying limit/offset equivalent portions to it.
+     *
+     * @param string $stm SQL statement
+     * @return string SQL statement with limit/offset applied
+     *
+     */
+    public function applyLimit($stm, $limit, $offset)
+    {
+        if (! $limit && ! $offset) {
+            return $stm; // no limit or offset
+        }
+
+        // limit but no offset?
+        if ($limit && ! $offset) {
+            // use TOP in place
+            return preg_replace(
+                '/^(SELECT( DISTINCT)?)/',
+                "$1 TOP {$limit}",
+                $stm
+            );
+        }
+
+        // both limit and offset. must have an ORDER clause to work; OFFSET is
+        // a sub-clause of the ORDER clause. cannot use FETCH without OFFSET.
+        return $stm . PHP_EOL . "OFFSET {$offset} ROWS "
+                    . "FETCH NEXT {$limit} ROWS ONLY";
+    }
+}


### PR DESCRIPTION
To separate the concerns of "collecting" query parts, and "building" them into a statement, this PR moves the `build*()` methods to their own classes.  This entails creating a builder for each kind of statement (select/insert/update/delete) and in some cases a driver-specific builder for the statement (mysql insert and pgsql everything).

@pavarnos @harikt etc: any comments or concerns?