### PR TITLE
Go back to pseudo-sequential where() and having() placeholders?

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -75,6 +75,10 @@ abstract class AbstractQuery
      */
     protected $builder;
 
+    static protected $instance_count = 0;
+
+    protected $seq_bind_prefix = '';
+
     /**
      *
      * Constructor.
@@ -88,6 +92,12 @@ abstract class AbstractQuery
     {
         $this->quoter = $quoter;
         $this->builder = $builder;
+
+        if (static::$instance_count > 0) {
+            $this->seq_bind_prefix = '_' . static::$instance_count;
+        }
+
+        static::$instance_count ++;
     }
 
     /**
@@ -395,5 +405,11 @@ abstract class AbstractQuery
             $this->order_by[] = $this->quoter->quoteNamesIn($col);
         }
         return $this;
+    }
+
+    protected function getSeqPlaceholder()
+    {
+        $i = count($this->bind_values) + 1;
+        return $this->seq_bind_prefix . "_{$i}_";
     }
 }

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -292,7 +292,7 @@ abstract class AbstractQuery
         $cond = $this->fixConditions($cond);
         $clause =& $this->$clause;
         if ($clause) {
-            $clause[] = "{$andor} {$cond}";
+            $clause[] = "$andor $cond";
         } else {
             $clause[] = $cond;
         }

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -483,13 +483,13 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws Exception
      *
      */
-    public function join($join, $spec, $cond = null, array $bind = array())
+    public function join($join, $spec, ...$cond)
     {
         $join = strtoupper(ltrim("$join JOIN"));
         $this->addTableRef($join, $spec);
 
         $spec = $this->quoter->quoteName($spec);
-        $cond = $this->fixJoinCondition($cond, $bind);
+        $cond = $this->fixJoinConditions($cond);
         return $this->addJoin(rtrim("$join $spec $cond"));
     }
 
@@ -505,14 +505,13 @@ class Select extends AbstractQuery implements SelectInterface
      * @return string
      *
      */
-    protected function fixJoinCondition($cond, array $bind)
+    protected function fixJoinConditions(array $cond)
     {
-        if (! $cond) {
+        if (empty($cond)) {
             return '';
         }
 
-        $cond = $this->quoter->quoteNamesIn($cond);
-        $cond = $this->rebuildCondAndBindValues($cond, $bind);
+        $cond = $this->fixConditions($cond);
 
         if (strtoupper(substr(ltrim($cond), 0, 3)) == 'ON ') {
             return $cond;
@@ -540,9 +539,9 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws Exception
      *
      */
-    public function innerJoin($spec, $cond = null, array $bind = array())
+    public function innerJoin($spec, ...$conditions)
     {
-        return $this->join('INNER', $spec, $cond, $bind);
+        return $this->join('INNER', $spec, ...$conditions);
     }
 
     /**
@@ -560,9 +559,9 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws Exception
      *
      */
-    public function leftJoin($spec, $cond = null, array $bind = array())
+    public function leftJoin($spec, ...$conditions)
     {
-        return $this->join('LEFT', $spec, $cond, $bind);
+        return $this->join('LEFT', $spec, ...$conditions);
     }
 
     /**
@@ -586,14 +585,14 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws Exception
      *
      */
-    public function joinSubSelect($join, $spec, $name, $cond = null, array $bind = array())
+    public function joinSubSelect($join, $spec, $name, ...$conditions)
     {
         $join = strtoupper(ltrim("$join JOIN"));
         $this->addTableRef("$join (SELECT ...) AS", $name);
 
         $spec = $this->subSelect($spec, '            ');
         $name = $this->quoter->quoteName($name);
-        $cond = $this->fixJoinCondition($cond, $bind);
+        $cond = $this->fixJoinConditions($conditions);
 
         $text = rtrim("$join ($spec        ) AS $name $cond");
         return $this->addJoin('        ' . $text);
@@ -637,16 +636,12 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Adds a HAVING condition to the query by AND.
      *
-     * @param string $cond The HAVING condition.
-     *
-     * @param array $bind arguments to bind to placeholders
-     *
      * @return $this
      *
      */
-    public function having($cond, array $bind = [])
+    public function having(...$conditions)
     {
-        $this->addClauseCondWithBind('having', 'AND', $cond, $bind);
+        $this->addClauseConditions('having', 'AND', $conditions);
         return $this;
     }
 
@@ -663,9 +658,9 @@ class Select extends AbstractQuery implements SelectInterface
      * @see having()
      *
      */
-    public function orHaving($cond, array $bind = [])
+    public function orHaving(...$conditions)
     {
-        $this->addClauseCondWithBind('having', 'OR', $cond, $bind);
+        $this->addClauseConditions('having', 'OR', $conditions);
         return $this;
     }
 

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -176,7 +176,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * @return $this
      *
      */
-    public function join($join, $spec, $cond = null);
+    public function join($join, $spec, ...$conditions);
 
     /**
      *
@@ -193,7 +193,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * @throws \Exception
      *
      */
-    public function innerJoin($spec, $cond = null, array $bind = array());
+    public function innerJoin($spec, ...$conditions);
 
     /**
      *
@@ -210,7 +210,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * @throws \Exception
      *
      */
-    public function leftJoin($spec, $cond = null, array $bind = array());
+    public function leftJoin($spec, ...$conditions);
 
     /**
      *
@@ -229,7 +229,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * @return $this
      *
      */
-    public function joinSubSelect($join, $spec, $name, $cond = null);
+    public function joinSubSelect($join, $spec, $name, ...$conditions);
 
     /**
      *
@@ -246,29 +246,21 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * Adds a HAVING condition to the query by AND.
      *
-     * @param string $cond The HAVING condition.
-     *
-     * @param array $bind Values to be bound to placeholders.
-     *
      * @return $this
      *
      */
-    public function having($cond, array $bind = []);
+    public function having(...$conditions);
 
     /**
      *
      * Adds a HAVING condition to the query by OR.
-     *
-     * @param string $cond The HAVING condition.
-     *
-     * @param array $bind Values to be bound to placeholders.
      *
      * @return $this
      *
      * @see having()
      *
      */
-    public function orHaving($cond, array $bind = []);
+    public function orHaving(...$conditions);
 
     /**
      *

--- a/src/Common/WhereInterface.php
+++ b/src/Common/WhereInterface.php
@@ -30,7 +30,7 @@ interface WhereInterface
      * @return $this
      *
      */
-    public function where($cond, array $bind = []);
+    public function where(...$conditions);
 
     /**
      *
@@ -47,5 +47,5 @@ interface WhereInterface
      * @see where()
      *
      */
-    public function orWhere($cond, array $bind = []);
+    public function orWhere(...$conditions);
 }

--- a/src/Common/WhereTrait.php
+++ b/src/Common/WhereTrait.php
@@ -28,9 +28,9 @@ trait WhereTrait
      * @return $this
      *
      */
-    public function where($cond, array $bind = [])
+    public function where(...$conditions)
     {
-        $this->addClauseCondWithBind('where', 'AND', $cond, $bind);
+        $this->addClauseConditions('where', 'AND', $conditions);
         return $this;
     }
 
@@ -49,9 +49,9 @@ trait WhereTrait
      * @see where()
      *
      */
-    public function orWhere($cond, array $bind = [])
+    public function orWhere(...$conditions)
     {
-        $this->addClauseCondWithBind('where', 'OR', $cond, $bind);
+        $this->addClauseConditions('where', 'OR', $conditions);
         return $this;
     }
 }

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -58,6 +58,8 @@ class QueryFactory
      */
     protected $quoter;
 
+    protected $instance_count = 0;
+
     /**
      *
      * Constructor.
@@ -160,10 +162,22 @@ class QueryFactory
             $builderClass = "Aura\SqlQuery\Common\\{$query}Builder";
         }
 
+
         return new $queryClass(
             $this->getQuoter(),
-            $this->newBuilder($query)
+            $this->newBuilder($query),
+            $this->getSeqBindPrefix()
         );
+    }
+
+    protected function getSeqBindPrefix()
+    {
+        $seq_bind_prefix = '';
+        if ($this->instance_count > 0) {
+            $seq_bind_prefix = '_' . $this->instance_count;
+        }
+        $this->instance_count ++;
+        return $seq_bind_prefix;
     }
 
     /**

--- a/tests/Common/DeleteTest.php
+++ b/tests/Common/DeleteTest.php
@@ -17,16 +17,16 @@ class DeleteTest extends AbstractQueryTest
     public function testCommon()
     {
         $this->query->from('t1')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir');
 
         $actual = $this->query->__toString();
         $expect = "
             DELETE FROM <<t1>>
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
         ";
 
@@ -34,8 +34,8 @@ class DeleteTest extends AbstractQueryTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -204,11 +204,11 @@ class SelectTest extends AbstractQueryTest
         $sub = $this->newQuery();
         $sub->cols(array('*'))
             ->from('t2')
-            ->where('foo = :foo', ['foo' => 'bar']);
+            ->where('foo = ', 'bar');
 
         $this->query->cols(array('*'))
             ->fromSubSelect($sub, 'a2')
-            ->where('a2.baz = :baz', ['baz' => 'dib']);
+            ->where('a2.baz = ', 'dib');
 
         $expect = '
             SELECT
@@ -220,10 +220,10 @@ class SelectTest extends AbstractQueryTest
                     FROM
                         <<t2>>
                     WHERE
-                        foo = :foo
+                        foo = :_1_1_
                 ) AS <<a2>>
             WHERE
-                <<a2>>.<<baz>> = :baz
+                <<a2>>.<<baz>> = :_1_
         ';
 
         $actual = $this->query->__toString();
@@ -293,8 +293,8 @@ class SelectTest extends AbstractQueryTest
         $this->query->join(
             'left',
             't2',
-            't1.id = t2.id AND t1.foo = :foo',
-            ['foo' => 'bar']
+            't1.id = t2.id AND t1.foo = ',
+            'bar'
         );
 
         $expect = '
@@ -302,12 +302,12 @@ class SelectTest extends AbstractQueryTest
                 *
             FROM
                 <<t1>>
-            LEFT JOIN <<t2>> ON <<t1>>.<<id>> = <<t2>>.<<id>> AND <<t1>>.<<foo>> = :foo
+            LEFT JOIN <<t2>> ON <<t1>>.<<id>> = <<t2>>.<<id>> AND <<t1>>.<<foo>> = :_1_
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
-        $expect = array('foo' => 'bar');
+        $expect = array('_1_' => 'bar');
         $actual = $this->query->getBindValues();
         $this->assertSame($expect, $actual);
     }
@@ -336,20 +336,20 @@ class SelectTest extends AbstractQueryTest
     {
         $this->query->cols(array('*'));
         $this->query->from('t1');
-        $this->query->leftJoin('t2', 't2.id = :t2_id', ['t2_id' => 'foo']);
-        $this->query->innerJoin('t3 AS a3', 'a3.id = :a3_id', ['a3_id' => 'bar']);
+        $this->query->leftJoin('t2', 't2.id = ', 'foo');
+        $this->query->innerJoin('t3 AS a3', 'a3.id = ', 'bar');
         $expect = '
             SELECT
                 *
             FROM
                 <<t1>>
-            LEFT JOIN <<t2>> ON <<t2>>.<<id>> = :t2_id
-            INNER JOIN <<t3>> AS <<a3>> ON <<a3>>.<<id>> = :a3_id
+            LEFT JOIN <<t2>> ON <<t2>>.<<id>> = :_1_
+            INNER JOIN <<t3>> AS <<a3>> ON <<a3>>.<<id>> = :_2_
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
-        $expect = array('t2_id' => 'foo', 'a3_id' => 'bar');
+        $expect = array('_1_' => 'foo', '_2_' => 'bar');
         $actual = $this->query->getBindValues();
         $this->assertSame($expect, $actual);
     }
@@ -419,12 +419,12 @@ class SelectTest extends AbstractQueryTest
     public function testJoinSubSelectObject()
     {
         $sub = $this->newQuery();
-        $sub->cols(array('*'))->from('t2')->where('foo = :foo', ['foo' => 'bar']);
+        $sub->cols(array('*'))->from('t2')->where('foo = ', 'bar');
 
         $this->query->cols(array('*'));
         $this->query->from('t1');
         $this->query->joinSubSelect('left', $sub, 'a3', 't2.c1 = a3.c1');
-        $this->query->where('baz = :baz', ['baz' => 'dib']);
+        $this->query->where('baz = ', 'baz');
 
         $expect = '
             SELECT
@@ -437,10 +437,10 @@ class SelectTest extends AbstractQueryTest
                         FROM
                             <<t2>>
                         WHERE
-                            foo = :foo
+                            foo = :_1_1_
                     ) AS <<a3>> ON <<t2>>.<<c1>> = <<a3>>.<<c1>>
             WHERE
-                baz = :baz
+                baz = :_1_
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
@@ -492,20 +492,20 @@ class SelectTest extends AbstractQueryTest
     {
         $this->query->cols(array('*'));
         $this->query->where('c1 = c2')
-                     ->where('c3 = :c3', ['c3' => 'foo']);
+                     ->where('c3 = ', 'foo');
         $expect = '
             SELECT
                 *
             WHERE
                 c1 = c2
-                AND c3 = :c3
+                AND c3 = :_1_
         ';
 
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $actual = $this->query->getBindValues();
-        $expect = ['c3' => 'foo'];
+        $expect = ['_1_' => 'foo'];
         $this->assertSame($expect, $actual);
     }
 
@@ -513,21 +513,21 @@ class SelectTest extends AbstractQueryTest
     {
         $this->query->cols(array('*'));
         $this->query->orWhere('c1 = c2')
-                     ->orWhere('c3 = :c3', ['c3' => 'foo']);
+                     ->orWhere('c3 = ', 'foo');
 
         $expect = '
             SELECT
                 *
             WHERE
                 c1 = c2
-                OR c3 = :c3
+                OR c3 = :_1_
         ';
 
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $actual = $this->query->getBindValues();
-        $expect = ['c3' => 'foo'];
+        $expect = ['_1_' => 'foo'];
         $this->assertSame($expect, $actual);
     }
 
@@ -551,20 +551,20 @@ class SelectTest extends AbstractQueryTest
     {
         $this->query->cols(array('*'));
         $this->query->having('c1 = c2')
-                     ->having('c3 = :c3', ['c3' => 'foo']);
+                     ->having('c3 = ', 'foo');
         $expect = '
             SELECT
                 *
             HAVING
                 c1 = c2
-                AND c3 = :c3
+                AND c3 = :_1_
         ';
 
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $actual = $this->query->getBindValues();
-        $expect = ['c3' => 'foo'];
+        $expect = ['_1_' => 'foo'];
         $this->assertSame($expect, $actual);
     }
 
@@ -572,20 +572,20 @@ class SelectTest extends AbstractQueryTest
     {
         $this->query->cols(array('*'));
         $this->query->orHaving('c1 = c2')
-                     ->orHaving('c3 = :c3', ['c3' => 'foo']);
+                     ->orHaving('c3 = ', 'foo');
         $expect = '
             SELECT
                 *
             HAVING
                 c1 = c2
-                OR c3 = :c3
+                OR c3 = :_1_
         ';
 
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $actual = $this->query->getBindValues();
-        $expect = ['c3' => 'foo'];
+        $expect = ['_1_' => 'foo'];
         $this->assertSame($expect, $actual);
     }
 
@@ -712,24 +712,24 @@ class SelectTest extends AbstractQueryTest
     public function testAutobind()
     {
         // do these out of order
-        $this->query->having('baz IN (:baz)', ['baz' => ['dib', 'zim', 'gir']]);
-        $this->query->where('foo = :foo', ['foo' => 'bar']);
+        $this->query->having('baz IN (', ['dib', 'zim', 'gir'], ')');
+        $this->query->where('foo = ', 'bar');
         $this->query->cols(array('*'));
 
         $expect = '
             SELECT
                 *
             WHERE
-                foo = :foo
+                foo = :_2_
             HAVING
-                baz IN (:baz)
+                baz IN (:_1_)
         ';
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
 
         $expect = array(
-            'baz' => array('dib', 'zim', 'gir'),
-            'foo' => 'bar',
+            '_1_' => array('dib', 'zim', 'gir'),
+            '_2_' => 'bar',
         );
         $actual = $this->query->getBindValues();
         $this->assertSame($expect, $actual);
@@ -830,7 +830,7 @@ class SelectTest extends AbstractQueryTest
         $select = $this->newQuery()
             ->cols(array('*'))
             ->from('table2 AS t2')
-            ->where("field IN (:field)", ['field' => $sub]);
+            ->where('field IN (', $sub, ')');
 
         $expect = '
             SELECT
@@ -886,7 +886,7 @@ class SelectTest extends AbstractQueryTest
         $sub = $this->newQuery()
             ->cols(array('*'))
             ->from('table1 AS t1')
-            ->where('t1.foo = :foo', ['foo' => 'bar']);
+            ->where('t1.foo = ', 'bar');
 
         $expect = '
             SELECT
@@ -894,7 +894,7 @@ class SelectTest extends AbstractQueryTest
             FROM
                 <<table1>> AS <<t1>>
             WHERE
-                <<t1>>.<<foo>> = :foo
+                <<t1>>.<<foo>> = :_1_1_
         ';
         $actual = $sub->getStatement();
         $this->assertSameSql($expect, $actual);
@@ -903,8 +903,8 @@ class SelectTest extends AbstractQueryTest
         $select = $this->newQuery()
             ->cols(array('*'))
             ->from('table2 AS t2')
-            ->where("field IN (:field)", ['field' => $sub])
-            ->where("t2.baz = :baz", ['baz' => 'dib']);
+            ->where('field IN (', $sub, ')')
+            ->where('t2.baz = ', 'dib');
 
         $expect = '
             SELECT
@@ -917,20 +917,16 @@ class SelectTest extends AbstractQueryTest
                     FROM
                         <<table1>> AS <<t1>>
                     WHERE
-                        <<t1>>.<<foo>> = :foo)
-            AND <<t2>>.<<baz>> = :baz
+                        <<t1>>.<<foo>> = :_1_1_)
+            AND <<t2>>.<<baz>> = :_2_1_
         ';
-
-        // B.b.: The _2_2_ means "2nd query, 2nd sequential bound value". It's
-        // the 2nd bound value because the 1st one is imported fromt the 1st
-        // query (the subselect).
 
         $actual = $select->getStatement();
         $this->assertSameSql($expect, $actual);
 
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_1_' => 'bar',
+            '_2_1_' => 'dib',
         );
         $actual = $select->getBindValues();
         $this->assertSame($expect, $actual);

--- a/tests/Common/UpdateTest.php
+++ b/tests/Common/UpdateTest.php
@@ -14,8 +14,8 @@ class UpdateTest extends AbstractQueryTest
                     ->col('c3')
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir');
 
         $actual = $this->query->__toString();
@@ -28,8 +28,8 @@ class UpdateTest extends AbstractQueryTest
                 <<c4>> = NULL,
                 <<c5>> = NOW()
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
         ";
 
@@ -37,8 +37,8 @@ class UpdateTest extends AbstractQueryTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/Mysql/DeleteTest.php
+++ b/tests/Mysql/DeleteTest.php
@@ -10,8 +10,8 @@ class DeleteTest extends Common\DeleteTest
     protected $expected_sql_with_flag = "
         DELETE %s FROM <<t1>>
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
     ";
 
@@ -36,8 +36,8 @@ class DeleteTest extends Common\DeleteTest
     {
         $this->query->lowPriority()
                     ->from('t1')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir');
 
         $actual = $this->query->__toString();
@@ -46,8 +46,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -56,8 +56,8 @@ class DeleteTest extends Common\DeleteTest
     {
         $this->query->quick()
                     ->from('t1')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir');
 
         $actual = $this->query->__toString();
@@ -66,8 +66,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -76,8 +76,8 @@ class DeleteTest extends Common\DeleteTest
     {
         $this->query->ignore()
                     ->from('t1')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir');
 
         $actual = $this->query->__toString();
@@ -86,8 +86,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/Mysql/UpdateTest.php
+++ b/tests/Mysql/UpdateTest.php
@@ -16,8 +16,8 @@ class UpdateTest extends Common\UpdateTest
                 <<c4>> = NULL,
                 <<c5>> = NOW()
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             LIMIT 5
     ";
@@ -49,8 +49,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->limit(5);
 
@@ -60,8 +60,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -73,8 +73,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->limit(5);
 
@@ -84,8 +84,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/Pgsql/DeleteTest.php
+++ b/tests/Pgsql/DeleteTest.php
@@ -10,8 +10,8 @@ class DeleteTest extends Common\DeleteTest
     public function testReturning()
     {
         $this->query->from('t1')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->returning(array('foo', 'baz', 'zim'));
 
@@ -19,8 +19,8 @@ class DeleteTest extends Common\DeleteTest
         $expect = "
             DELETE FROM <<t1>>
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             RETURNING
                 foo,
@@ -31,8 +31,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/Pgsql/UpdateTest.php
+++ b/tests/Pgsql/UpdateTest.php
@@ -13,8 +13,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->returning(array('c1', 'c2'))
                     ->returning(array('c3'));
@@ -29,8 +29,8 @@ class UpdateTest extends Common\UpdateTest
                 <<c4>> = NULL,
                 <<c5>> = NOW()
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             RETURNING
                 c1,
@@ -41,8 +41,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/Sqlite/DeleteTest.php
+++ b/tests/Sqlite/DeleteTest.php
@@ -10,8 +10,8 @@ class DeleteTest extends Common\DeleteTest
     public function testOrderLimit()
     {
         $this->query->from('t1')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->orderBy(array('zim DESC'))
                     ->limit(5)
@@ -21,8 +21,8 @@ class DeleteTest extends Common\DeleteTest
         $expect = "
             DELETE FROM <<t1>>
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             ORDER BY
                 zim DESC
@@ -32,8 +32,8 @@ class DeleteTest extends Common\DeleteTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }

--- a/tests/Sqlite/UpdateTest.php
+++ b/tests/Sqlite/UpdateTest.php
@@ -17,8 +17,8 @@ class UpdateTest extends Common\UpdateTest
                 <<c4>> = NULL,
                 <<c5>> = NOW()
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             LIMIT 5
     ";
@@ -29,8 +29,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->orderBy(array('zim DESC', 'baz ASC'))
                     ->limit(5)
@@ -46,8 +46,8 @@ class UpdateTest extends Common\UpdateTest
                 <<c4>> = NULL,
                 <<c5>> = NOW()
             WHERE
-                foo = :foo
-                AND baz = :baz
+                foo = :_1_
+                AND baz = :_2_
                 OR zim = gir
             ORDER BY
                 zim DESC,
@@ -58,8 +58,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -71,8 +71,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->limit(5);
 
@@ -82,8 +82,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -95,8 +95,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->limit(5);
 
@@ -106,8 +106,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -119,8 +119,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->limit(5);
 
@@ -130,8 +130,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -143,8 +143,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->limit(5);
 
@@ -154,8 +154,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -167,8 +167,8 @@ class UpdateTest extends Common\UpdateTest
                     ->cols(array('c1', 'c2', 'c3'))
                     ->set('c4', null)
                     ->set('c5', 'NOW()')
-                    ->where('foo = :foo', ['foo' => 'bar'])
-                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->where('foo = ', 'bar')
+                    ->where('baz = ', 'dib')
                     ->orWhere('zim = gir')
                     ->limit(5);
 
@@ -178,8 +178,8 @@ class UpdateTest extends Common\UpdateTest
 
         $actual = $this->query->getBindValues();
         $expect = array(
-            'foo' => 'bar',
-            'baz' => 'dib',
+            '_1_' => 'bar',
+            '_2_' => 'dib',
         );
         $this->assertSame($expect, $actual);
     }
@@ -206,7 +206,7 @@ class UpdateTest extends Common\UpdateTest
 
         $this->query->table('test')
                     ->cols(array('name'))
-                    ->where('id = :id', ['id' => 1])
+                    ->where('id = ', 1)
                     ->bindValues(array('name' => 'Annabelle'));
 
         $stm = $this->query->__toString();


### PR DESCRIPTION
Hi all, esp. @pavarnos --

Earlier, we removed ?-placeholder replacements from where(), having(), etc., and replaced it with binding of named parameters as part of the method call. So, in 2.x we had this:

```
$select->where('foo IN(?)', [1, 2, 3]);
// WHERE foo IN (:_1_)
```

And then changed it to this in 3.x:

```
$select->where('foo IN(:foo)', ['foo' => [1, 2, 3]]);
// WHERE foo IN (:foo)
```

After having used this for a while, I'm unsatisfied with it. It feels clunky and verbose.

This PR kind-of goes back to pseudo-sequential placeholders. However, instead of ?-placeholders, the conditions are alternately interpreted as literals and bind-values:

```
$select->where('foo IN(', [1, 2, 3], ')');
// WHERE foo IN(:_1_)
```

This feels a little bit better to me overall. It also makes it so that the SqlQuery code does not need to scan through for ?-marks, which means the various Postgres JSON query syntaxes are left untouched.

Any thoughts here?
