### PR TITLE
Drop HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 php:
   - 5.6
-  - hhvm
   - 7
 script:
   - composer install


### PR DESCRIPTION
> HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
https://travis-ci.org/auraphp/Aura.SqlQuery/jobs/249719786