### PR TITLE
Make travis use trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: php
+dist: trusty
 php:
   - 5.6
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - hhvm
   - 7
+  - 7.1
 script:
   - composer install
   - ./vendor/bin/phpunit --coverage-clover=coverage.clover


### PR DESCRIPTION
#147 suggests dropping hhvm support. I'm not sure why we'd do that, 
although I see [that was done in Aura/Auth](https://github.com/auraphp/Aura.Auth/commit/811f799aca9df07bf73c1c3a21221dfc4ff4b2c9) seemingly without explanation. 