### PR TITLE
Add *whereBoundValue functions to Where trait and interface

### DIFF
--- a/src/Common/WhereInterface.php
+++ b/src/Common/WhereInterface.php
@@ -66,7 +66,7 @@ interface WhereInterface
      * @throws Exception
      *
      */
-    public function whereBoundValue(string $cond, string $placeholder, $value);
+    public function whereBoundValue($cond, $placeholder, $value);
 
     /**
      *
@@ -85,5 +85,5 @@ interface WhereInterface
      * @see whereBoundValue()
      *
      */
-    public function orWhereBoundValue(string $cond, string $placeholder, $value);
+    public function orWhereBoundValue($cond, $placeholder, $value);
 }

--- a/src/Common/WhereInterface.php
+++ b/src/Common/WhereInterface.php
@@ -8,6 +8,8 @@
  */
 namespace Aura\SqlQuery\Common;
 
+use Aura\SqlQuery\Exception;
+
 /**
  *
  * An interface for WHERE clauses.
@@ -48,4 +50,40 @@ interface WhereInterface
      *
      */
     public function orWhere($cond, array $bind = []);
+
+    /**
+     *
+     * Adds a WHERE condition with a prepared statement placeholder and value to the query by AND.
+     *
+     * @param string $cond the first part of the WHERE condition without the placeholder. e.g. "name = " or "name IN"
+     *
+     * @param string $placeholder the placeholder as a string. e.g. ":NAME" or "(:NAMES)"
+     *
+     * @param (string|int|float|array) $value the value to be bound to the placeholder. e.g. "John" or ["John", "Eric", "Michael", "Terry"]
+     *
+     * @return $this
+     *
+     * @throws Exception
+     *
+     */
+    public function whereBoundValue(string $cond, string $placeholder, $value);
+
+    /**
+     *
+     * Adds a WHERE condition with a prepared statement placeholder and value to the query by OR.
+     *
+     * @param string $cond the first part of the WHERE condition without the placeholder. e.g. "name = " or "name IN"
+     *
+     * @param string $placeholder the placeholder as a string. e.g. ":NAME" or "(:NAMES)"
+     *
+     * @param (string|int|float|array) $value the value to be bound to the placeholder. e.g. "John" or ["John", "Eric", "Michael", "Terry"]
+     *
+     * @return $this
+     *
+     * @throws Exception
+     *
+     * @see whereBoundValue()
+     *
+     */
+    public function orWhereBoundValue(string $cond, string $placeholder, $value);
 }

--- a/src/Common/WhereTrait.php
+++ b/src/Common/WhereTrait.php
@@ -72,7 +72,7 @@ trait WhereTrait
      * @throws Exception
      *
      */
-    public function whereBoundValue(string $cond, string $placeholder, $value)
+    public function whereBoundValue($cond, $placeholder, $value)
     {
         $name = $this->extractNameOrThrow($placeholder);
         $this->addClauseCondWithBind('where', 'AND', $cond.$placeholder, [ $name => $value ] );
@@ -96,7 +96,7 @@ trait WhereTrait
      * @see whereBoundValue()
      *
      */
-    public function orWhereBoundValue(string $cond, string $placeholder, $value)
+    public function orWhereBoundValue($cond, $placeholder, $value)
     {
         $name = $this->extractNameOrThrow($placeholder);
         $this->addClauseCondWithBind('where', 'OR', $cond.$placeholder, [ $name => $value ] );
@@ -113,7 +113,7 @@ trait WhereTrait
      * @throws Exception
      *
      */
-    protected static function extractNameOrThrow(string $placeholder) {
+    protected static function extractNameOrThrow($placeholder) {
         $name = preg_replace( '/^\(?:([^\)]+)\)?$/', '\1', $placeholder);
         // XXX add type checks
         if (strlen($name)===strlen($placeholder)) {

--- a/src/Common/WhereTrait.php
+++ b/src/Common/WhereTrait.php
@@ -8,6 +8,8 @@
  */
 namespace Aura\SqlQuery\Common;
 
+use Aura\SqlQuery\Exception;
+
 /**
  *
  * Common code for WHERE clauses.
@@ -53,5 +55,70 @@ trait WhereTrait
     {
         $this->addClauseCondWithBind('where', 'OR', $cond, $bind);
         return $this;
+    }
+
+    /**
+     *
+     * Adds a WHERE condition with a prepared statement placeholder and value to the query by AND.
+     *
+     * @param string $cond the first part of the WHERE condition without the placeholder. e.g. "name = " or "name IN"
+     *
+     * @param string $placeholder the placeholder as a string. e.g. ":NAME" or "(:NAMES)"
+     *
+     * @param (string|int|float|array) $value the value to be bound to the placeholder. e.g. "John" or ["John", "Eric", "Michael", "Terry"]
+     *
+     * @return $this
+     *
+     * @throws Exception
+     *
+     */
+    public function whereBoundValue(string $cond, string $placeholder, $value)
+    {
+        $name = $this->extractNameOrThrow($placeholder);
+        $this->addClauseCondWithBind('where', 'AND', $cond.$placeholder, [ $name => $value ] );
+        return $this;
+    }
+
+    /**
+     *
+     * Adds a WHERE condition with a prepared statement placeholder and value to the query by OR.
+     *
+     * @param string $cond the first part of the WHERE condition without the placeholder. e.g. "name = " or "name IN"
+     *
+     * @param string $placeholder the placeholder as a string. e.g. ":NAME" or "(:NAMES)"
+     *
+     * @param (string|int|float|array) $value the value to be bound to the placeholder. e.g. "John" or ["John", "Eric", "Michael", "Terry"]
+     *
+     * @return $this
+     *
+     * @throws Exception
+     *
+     * @see whereBoundValue()
+     *
+     */
+    public function orWhereBoundValue(string $cond, string $placeholder, $value)
+    {
+        $name = $this->extractNameOrThrow($placeholder);
+        $this->addClauseCondWithBind('where', 'OR', $cond.$placeholder, [ $name => $value ] );
+        return $this;
+    }
+
+    /**
+     * Extract the name of PDO placeholders (e.g. "P")  of the form ":P" for simple values and "(:P)" for array values.
+     *
+     * @param string $placeholder the placeholder specification
+     *
+     * @return the placeholder name as string
+     *
+     * @throws Exception
+     *
+     */
+    protected static function extractNameOrThrow(string $placeholder) {
+        $name = preg_replace( '/^\(?:([^\)]+)\)?$/', '\1', $placeholder);
+        // XXX add type checks
+        if (strlen($name)===strlen($placeholder)) {
+            throw new Exception("Bad placeholder \"$name\"");
+        }
+        return $name;
     }
 }

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -531,6 +531,30 @@ class SelectTest extends AbstractQueryTest
         $this->assertSame($expect, $actual);
     }
 
+
+    public function testWhereBoundValue()
+    {
+        $this->query->cols(array('*'));
+        $this->query->where('c1 = c2')
+                     ->whereBoundValue('c2 IN ', '(:c2)', ['foo'])
+                     ->whereBoundValue('c3 = ', ':c3', 'foo');
+        $expect = '
+            SELECT
+                *
+            WHERE
+                c1 = c2
+                AND c2 IN (:c2)
+                AND c3 = :c3
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+
+        $actual = $this->query->getBindValues();
+        $expect = ['c2' => ['foo'], 'c3' => 'foo'];
+        $this->assertSame($expect, $actual);
+    }
+
     public function testGroupBy()
     {
         $this->query->cols(array('*'));


### PR DESCRIPTION
This is a working minimal implementation for https://github.com/auraphp/Aura.SqlQuery/issues/164 to get coding feedback.

Implementation is directly in the WhereTrait with a separate function name ("whereBoundValue") in order to keep the where function interfaces clean. 

As alternative to the direct implementation I considered having a separate trait; so the framework user could easily decide if the functionality is wanted by composing traits. But this seems infeasible considering how the factory/implementation lookup works.

What is mainly missing is *having support. 

