### PR TITLE
[WIP] Fix xdebug mode for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
   - 7.2
   - 7.3
   - 7.4
+env:
+  global:
+    - XDEBUG_MODE=coverage
 script:
   - composer install
   - ./vendor/bin/phpunit --coverage-clover=coverage.clover


### PR DESCRIPTION
Error message: `Code coverage needs to be enabled in php.ini by setting 'xdebug.mode' to 'coverage'`
Solution found here: https://travis-ci.community/t/xdebug-3-is-installed-by-default-breaking-builds/10748