### PR TITLE
Correct preg_split call

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -391,7 +391,7 @@ abstract class AbstractQuery
         // bind values against ?-mark placeholders, but because PDO is finicky
         // about the numbering of sequential placeholders, convert each ?-mark
         // to a named placeholder
-        $parts = preg_split('/(\?)/', $cond, null, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('/(\?)/', $cond, -1, PREG_SPLIT_DELIM_CAPTURE);
         foreach ($parts as $key => $val) {
             if ($val != '?') {
                 continue;


### PR DESCRIPTION
Since version 2.* is still the latest released version, in PHP 8.1 preg_split is creating deprections notices due to null being used.

Also in the php docs is shows the value for no limit should be -1.