### PR TITLE
Fix types in phpdoc

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -61,7 +61,7 @@ abstract class AbstractQuery
      *
      * A helper for quoting identifier names.
      *
-     * @var Quoter
+     * @var Common\Quoter
      *
      */
     protected $quoter;
@@ -70,7 +70,7 @@ abstract class AbstractQuery
      *
      * A builder for the query.
      *
-     * @var AbstractBuilder
+     * @var Common\AbstractBuilder
      *
      */
     protected $builder;
@@ -79,9 +79,9 @@ abstract class AbstractQuery
      *
      * Constructor.
      *
-     * @param Quoter $quoter A helper for quoting identifier names.
+     * @param Common\Quoter $quoter A helper for quoting identifier names.
      *
-     * @param AbstractBuilder $builder A builder for the query.
+     * @param Common\AbstractBuilder $builder A builder for the query.
      *
      */
     public function __construct(QuoterInterface $quoter, $builder)

--- a/src/Common/Delete.php
+++ b/src/Common/Delete.php
@@ -34,14 +34,14 @@ class Delete extends AbstractDmlQuery implements DeleteInterface
      *
      * Sets the table to delete from.
      *
-     * @param string $table The table to delete from.
+     * @param string $from The table to delete from.
      *
      * @return $this
      *
      */
-    public function from($table)
+    public function from($from)
     {
-        $this->from = $this->quoter->quoteName($table);
+        $this->from = $this->quoter->quoteName($from);
         return $this;
     }
 

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -172,7 +172,7 @@ class QueryFactory
      *
      * @param string $query The query type.
      *
-     * @return AbstractBuilder
+     * @return Common\AbstractBuilder
      *
      */
     protected function newBuilder($query)
@@ -188,7 +188,7 @@ class QueryFactory
      *
      * Returns the Quoter object for queries; creates one if needed.
      *
-     * @return Quoter
+     * @return Common\Quoter
      *
      */
     protected function getQuoter()
@@ -203,7 +203,7 @@ class QueryFactory
      *
      * Returns a new Quoter for the database driver.
      *
-     * @return QuoterInerface
+     * @return Common\QuoterInterface
      *
      */
     protected function newQuoter()


### PR DESCRIPTION
The wrong type of phpdoc will cause false positive errors in static analysis such as phpstan and psalm in applications that depending this library. This PR fixes that problem. 

