### PR TITLE
Fix ParamNameMismatch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: xdebug
-          tools: none
+          tools: composer:2.2
           ini-values: assert.exception=1, zend.assertions=1
 
       - name: Get composer cache directory


### PR DESCRIPTION
PHP 8 introduces [named parameters](https://wiki.php.net/rfc/named_params) which allow developers to call methods with explicitly-named parameters;

source: https://psalm.dev/docs/running_psalm/issues/ParamNameMismatch/