### PR TITLE
Specify composer version to run up to PHP 7.1 with CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: xdebug
-          tools: none
+          tools: composer:2.2
           ini-values: assert.exception=1, zend.assertions=1
 
       - name: Get composer cache directory


### PR DESCRIPTION
"Composer 2.3 will increase the required PHP version to >=7.2.5 and thus stop supporting PHP 5.3.2 - 7.2.4. "

https://blog.packagist.com/composer-2-2/