### PR TITLE
[BUG] Fix bad use of strripos

### DIFF
--- a/src/Quoter.php
+++ b/src/Quoter.php
@@ -223,7 +223,7 @@ class Quoter
     {
         $quoted = $this->replaceNamesIn($val);
         $pos = strripos($quoted, ' AS ');
-        if ($pos) {
+        if ($pos !== false) {
             $alias = $this->replaceName(substr($quoted, $pos + 4));
             $quoted = substr($quoted, 0, $pos) . " AS $alias";
         }


### PR DESCRIPTION
It is 100% valid for strripos to return 0
we want quotes in that case for the AS blah
NEVER EVER if a strripos, always explicitly check for false!!

This was breaking jsonb text returns with mixed case aliases

Select "pt"."name"->>'en_US' AS "myDescription" from mytable pt is what we want to end up with The replaceNamesAndAliasIn was getting ' AS myDescription' and not properly escaping it because the strripos was returning 0