### PR TITLE
Updated Github Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,7 +42,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -55,6 +55,6 @@ jobs:
         run: php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,9 +24,10 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -5,7 +5,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class QuoterTest extends TestCase
 {
-    protected ?\Aura\SqlQuery\Common\Quoter $quoter = null;
+    protected $quoter = null;
 
     public function set_up()
     {

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -5,6 +5,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class QuoterTest extends TestCase
 {
+    protected ?\Aura\SqlQuery\Common\Quoter $quoter = null;
+
     public function set_up()
     {
         $this->quoter = new Quoter();


### PR DESCRIPTION
* Github actions now tests against PHP 8.3
* Updated some Github action dependencies to their latest version
* Added **protected $quoter = null;** to **Aura\SqlQuery\Common\QuoterTest** to fix warning below in PHP 8.1+

```
PHP Deprecated:  Creation of dynamic property Aura\SqlQuery\Common\QuoterTest::$quoter is deprecated in /home/runner/work/Aura.SqlQuery/Aura.SqlQuery/tests/Common/QuoterTest.php on line 10
```