### PR TITLE
Add PHP 8.4 and 8.5 to CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,6 +25,8 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
+          - '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2022, Aura for PHP
+Copyright (c) 2016-2025, Aura for PHP
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the `Aura\SqlQuery\` namespace to the package `src/` directory.
 
 ## Dependencies
 
-This package requires PHP 5.6 or later; it has been tested on PHP 5.6-8.1. We recommend using the latest available version of PHP as a matter of principle.
+This package requires PHP 5.6 or later; it has been tested on PHP 5.6-8.5. We recommend using the latest available version of PHP as a matter of principle.
 
 Aura library packages may sometimes depend on external interfaces, but never on
 external implementations. This allows compliance with community standards


### PR DESCRIPTION
## Summary
- Add PHP 8.4 and 8.5 to CI test matrix
- Update LICENSE copyright year to 2025
- Update README to reflect PHP 8.5 support

## Test plan
- CI will run tests on PHP 8.4 and 8.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year in license to 2025.
  * Extended continuous integration testing to include PHP versions 8.4 and 8.5.

* **Documentation**
  * Updated PHP compatibility range to PHP 5.6-8.5.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->