### PR TITLE
Require PHP 8.4, migrate to PHPUnit 12, trim CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,16 +15,6 @@ jobs:
         operating-system:
           - ubuntu-latest
         php-version:
-          - '5.6'
-          - '7.0'
-          - '7.1'
-          - '7.2'
-          - '7.3'
-          - '7.4'
-          - '8.0'
-          - '8.1'
-          - '8.2'
-          - '8.3'
           - '8.4'
           - '8.5'
     steps:
@@ -36,7 +26,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: xdebug
-          tools: composer:2.2
+          tools: composer:v2
           ini-values: assert.exception=1, zend.assertions=1
 
       - name: Get composer cache directory
@@ -57,6 +47,6 @@ jobs:
         run: php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false

--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
         }
     ],
     "require": {
-        "php": ">=5.6"
+        "php": "^8.4"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
-        "yoast/phpunit-polyfills": "^1.0"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {
@@ -48,5 +48,9 @@
     },
     "suggest": {
         "aura/sql": "Provides an extension to the native PDO along with a profiler and connection locator."
+    },
+    "scripts": {
+        "test": "phpunit",
+        "test-coverage": "php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover=coverage.xml"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,17 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="./phpunit.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd">
     <testsuites>
         <testsuite name="Aura.SqlQuery test suite">
             <directory>./tests</directory>
+            <!-- abstract base class, not a runnable test -->
+            <exclude>./tests/AbstractQueryTest.php</exclude>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/AbstractQueryTest.php
+++ b/tests/AbstractQueryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\SqlQuery;
 
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use PHPUnit\Framework\TestCase;
 
 abstract class AbstractQueryTest extends TestCase
 {
@@ -13,9 +13,9 @@ abstract class AbstractQueryTest extends TestCase
 
     protected $query;
 
-    protected function set_up()
+    protected function setUp(): void
     {
-        parent::set_up();
+        parent::setUp();
         $this->query_factory = new QueryFactory($this->db_type);
         $this->query = $this->newQuery();
     }
@@ -56,10 +56,6 @@ abstract class AbstractQueryTest extends TestCase
         return $string;
     }
 
-    protected function tear_down()
-    {
-        parent::tear_down();
-    }
 
     public function testBindValues()
     {

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -1,13 +1,13 @@
 <?php
 namespace Aura\SqlQuery\Common;
 
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class QuoterTest extends TestCase
 {
     protected $quoter = null;
 
-    public function set_up()
+    protected function setUp(): void
     {
         $this->quoter = new Quoter();
     }

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -110,6 +110,22 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testColsWithFunctionExpression()
+    {
+        $this->query->cols(array(
+            'id',
+            "CONCAT(first_name, ' ', last_name) AS full_name",
+        ));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            SELECT
+                id,
+                CONCAT(first_name, ' ', last_name) AS <<full_name>>
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testFrom()
     {
         $this->query->cols(array('*'));

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -898,6 +898,35 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testWhereExistsSubSelect()
+    {
+        $sub = $this->newQuery()
+            ->cols(array('*'))
+            ->from('orders')
+            ->where('orders.user_id = users.id');
+
+        $select = $this->newQuery()
+            ->cols(array('*'))
+            ->from('users')
+            ->where('EXISTS (:sub)', ['sub' => $sub]);
+
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<users>>
+            WHERE
+                EXISTS (SELECT
+                *
+            FROM
+                <<orders>>
+            WHERE
+                <<orders>>.<<user_id>> = <<users>>.<<id>>)
+        ';
+        $actual = $select->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testIssue49()
     {
         $this->assertSame(0, $this->query->getPage());

--- a/tests/QueryFactoryTest.php
+++ b/tests/QueryFactoryTest.php
@@ -1,13 +1,12 @@
 <?php
 namespace Aura\SqlQuery;
 
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
 class QueryFactoryTest extends TestCase
 {
-    /**
-     * @dataProvider provider
-     */
+    #[DataProvider('provider')]
     public function test($db_type, $common, $query_type, $expect)
     {
         $query_factory = new QueryFactory($db_type, $common);
@@ -16,7 +15,7 @@ class QueryFactoryTest extends TestCase
         $this->assertInstanceOf($expect, $actual);
     }
 
-    public function provider()
+    public static function provider()
     {
         return array(
             // db-specific


### PR DESCRIPTION
- composer.json: php ^8.4; replace yoast/phpunit-polyfills with phpunit/phpunit ^12; add composer test scripts
- phpunit.xml.dist: migrate to the PHPUnit 12 schema (<source> block); exclude the abstract AbstractQueryTest base class from collection so the runner does not warn about it
- tests: extend PHPUnit\Framework\TestCase directly; set_up/tear_down polyfill hooks become native setUp(); @dataProvider becomes the DataProvider attribute with a static provider
- CI: matrix down to 8.4/8.5, codecov-action v5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the minimum supported PHP version to 8.4.

* **Testing**
  * Upgraded the test suite to PHPUnit 12.
  * Improved test coverage configuration and added commands for running tests and generating coverage reports.
  * Updated test definitions to use current PHPUnit conventions.

* **Chores**
  * Updated continuous integration to test supported PHP versions and use current Composer and coverage tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->