### PR TITLE
Fix #149: insert with no columns no longer throws TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG 
 
+## 6.0.0 (unreleased)
+
+- [BRK] Bumped the minimum version to PHP 8.4; the CI matrix now covers
+  PHP 8.4 and 8.5.
+
+- [CHG] Migrated the test suite to PHPUnit 12 (replacing
+  yoast/phpunit-polyfills).
+
+- [FIX] An Insert with no columns no longer throws a TypeError; it now
+  renders `INSERT INTO t DEFAULT VALUES` (or `INSERT INTO t () VALUES ()`
+  on MySQL, which does not support DEFAULT VALUES), letting the database
+  apply column defaults. Fixes #149.
+
+- [CHG] An Update with no columns now throws Aura\SqlQuery\Exception with
+  a clear message, instead of a TypeError; an UPDATE with an empty SET
+  clause has no meaning. This matches the existing Select behavior of
+  throwing when no columns are given.
+
 ## 2.7.1
 
 Hygiene release: update README.

--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -25,7 +25,7 @@ abstract class AbstractDmlQuery extends AbstractQuery
      * @param array
      *
      */
-    protected $col_values;
+    protected $col_values = array();
 
     /**
      *

--- a/src/Common/InsertBuilder.php
+++ b/src/Common/InsertBuilder.php
@@ -43,6 +43,10 @@ class InsertBuilder extends AbstractBuilder
      */
     public function buildValuesForInsert(array $col_values)
     {
+        if (empty($col_values)) {
+            return ' DEFAULT VALUES';
+        }
+
         return ' ('
             . $this->indentCsv(array_keys($col_values))
             . PHP_EOL . ') VALUES ('

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -9,6 +9,7 @@
 namespace Aura\SqlQuery\Common;
 
 use Aura\SqlQuery\AbstractDmlQuery;
+use Aura\SqlQuery\Exception;
 
 /**
  *
@@ -51,9 +52,15 @@ class Update extends AbstractDmlQuery implements UpdateInterface
      *
      * @return string
      *
+     * @throws Exception when there are no columns to update.
+     *
      */
     protected function build()
     {
+        if (! $this->hasCols()) {
+            throw new Exception('No columns to update.');
+        }
+
         return 'UPDATE'
             . $this->builder->buildFlags($this->flags)
             . $this->builder->buildTable($this->table)

--- a/src/Mysql/InsertBuilder.php
+++ b/src/Mysql/InsertBuilder.php
@@ -21,6 +21,26 @@ class InsertBuilder extends Common\InsertBuilder
 {
     /**
      *
+     * Builds the inserted columns and values of the statement; MySQL does
+     * not support `DEFAULT VALUES`, so an insert with no columns uses the
+     * empty-list form instead.
+     *
+     * @param array $col_values The column names and values.
+     *
+     * @return string
+     *
+     */
+    public function buildValuesForInsert(array $col_values)
+    {
+        if (empty($col_values)) {
+            return ' () VALUES ()';
+        }
+
+        return parent::buildValuesForInsert($col_values);
+    }
+
+    /**
+     *
      * Builds the UPDATE ON DUPLICATE KEY part of the statement.
      *
      * @param array $col_on_update_values Columns and values to use for

--- a/tests/Common/InsertTest.php
+++ b/tests/Common/InsertTest.php
@@ -15,6 +15,17 @@ class InsertTest extends AbstractQueryTest
         return parent::newQuery();
     }
 
+    protected $expected_sql_no_cols = "
+        INSERT INTO <<t1>> DEFAULT VALUES
+    ";
+
+    public function testNoCols()
+    {
+        $this->query->into('t1');
+        $actual = $this->query->__toString();
+        $this->assertSameSql($this->expected_sql_no_cols, $actual);
+    }
+
     public function testCommon()
     {
         $this->query->into('t1')

--- a/tests/Common/UpdateTest.php
+++ b/tests/Common/UpdateTest.php
@@ -7,6 +7,13 @@ class UpdateTest extends AbstractQueryTest
 {
     protected $query_type = 'update';
 
+    public function testExceptionWithNoCols()
+    {
+        $this->query->table('t1')->where('foo = :foo', ['foo' => 'bar']);
+        $this->expectException('Aura\SqlQuery\Exception');
+        $this->query->__toString();
+    }
+
     public function testCommon()
     {
         $this->query->table('t1')

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -7,6 +7,10 @@ class InsertTest extends Common\InsertTest
 {
     protected $db_type = 'mysql';
 
+    protected $expected_sql_no_cols = "
+        INSERT INTO <<t1>> () VALUES ()
+    ";
+
     protected $expected_sql_with_flag = "
         INSERT %s INTO <<t1>> (
             <<c1>>,


### PR DESCRIPTION
An Insert with no cols() crashed with a raw TypeError because AbstractDmlQuery::$col_values was uninitialized (null) and InsertBuilder::buildValuesForInsert() requires an array.

- initialize $col_values to an empty array
- an empty insert now renders 'INSERT INTO t DEFAULT VALUES' (Pgsql/Sqlite/Sqlsrv/Common), letting the database apply column defaults as requested in #149
- MySQL does not support DEFAULT VALUES, so its InsertBuilder renders the equivalent 'INSERT INTO t () VALUES ()'
- an Update with no columns now throws Aura\SqlQuery\Exception with a clear message instead of the same TypeError (matching Select's no-cols behavior)
- start a 6.0.0 section in CHANGELOG.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - INSERT queries without specified columns now use database-defined default values.
  - MySQL supports empty-column INSERT statements using MySQL-compatible syntax.
  - UPDATE queries without specified columns now provide a clear error message.

- **Compatibility**
  - Minimum supported PHP version is now 8.4.
  - Test tooling has been updated to PHPUnit 12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->