### PR TITLE
Fix #157: do not treat AS inside an expression as a column alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   on MySQL, which does not support DEFAULT VALUES), letting the database
   apply column defaults. Fixes #149.
 
+- [FIX] The quoter no longer treats an `AS` inside an expression (e.g.
+  `cast(col as varchar)`) as a column alias, which produced misquoted
+  SQL. Fixes #157.
+
 - [CHG] An Update with no columns now throws Aura\SqlQuery\Exception with
   a clear message, instead of a TypeError; an UPDATE with an empty SET
   clause has no meaning. This matches the existing Select behavior of

--- a/src/Common/Quoter.php
+++ b/src/Common/Quoter.php
@@ -205,16 +205,39 @@ class Quoter implements QuoterInterface
     protected function replaceNamesAndAliasIn($val)
     {
         $quoted = $this->replaceNamesIn($val);
-        $pos = strripos($quoted, ' AS ');
+        $pos = $this->findAliasSeparator($quoted);
         if ($pos !== false) {
-            $alias = trim(substr($quoted, $pos + 4));
-            // quote only when the remainder is a word-only alias; an 'AS'
-            // inside an expression, e.g. cast(col as varchar), is not an alias
-            if (preg_match('/^[a-z_][a-z0-9_ ]*$/i', $alias)) {
-                $quoted = substr($quoted, 0, $pos) . ' AS ' . $this->replaceName($alias);
-            }
+            $alias = $this->replaceName(substr($quoted, $pos + 4));
+            $quoted = substr($quoted, 0, $pos) . " AS $alias";
         }
         return $quoted;
+    }
+
+    /**
+     *
+     * Finds the position of the last ' AS ' that acts as an alias separator;
+     * an 'AS' inside parentheses, e.g. cast(col as varchar), is part of an
+     * expression, not an alias.
+     *
+     * @param string $text The string to search.
+     *
+     * @return int|false The position of the separator, or false if none.
+     *
+     */
+    protected function findAliasSeparator($text)
+    {
+        $pos = strripos($text, ' AS ');
+        while ($pos !== false) {
+            $before = substr($text, 0, $pos);
+            $after = substr($text, $pos + 4);
+            $inside_parens = substr_count($before, '(') > substr_count($before, ')');
+            $parens_after = strpbrk($after, '()') !== false;
+            if (! $inside_parens && ! $parens_after) {
+                return $pos;
+            }
+            $pos = strripos($before, ' AS ');
+        }
+        return false;
     }
 
     /**

--- a/src/Common/Quoter.php
+++ b/src/Common/Quoter.php
@@ -207,8 +207,12 @@ class Quoter implements QuoterInterface
         $quoted = $this->replaceNamesIn($val);
         $pos = strripos($quoted, ' AS ');
         if ($pos !== false) {
-            $alias = $this->replaceName(substr($quoted, $pos + 4));
-            $quoted = substr($quoted, 0, $pos) . " AS $alias";
+            $alias = trim(substr($quoted, $pos + 4));
+            // quote only when the remainder is a word-only alias; an 'AS'
+            // inside an expression, e.g. cast(col as varchar), is not an alias
+            if (preg_match('/^[a-z_][a-z0-9_ ]*$/i', $alias)) {
+                $quoted = substr($quoted, 0, $pos) . ' AS ' . $this->replaceName($alias);
+            }
         }
         return $quoted;
     }

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -54,4 +54,29 @@ class QuoterTest extends TestCase
         $expect = "*, *.*, \"f\".\"bar\", \"foo\".\"bar\", CONCAT('foo.bar', \"baz.dib\") AS \"zim\"";
         $this->assertSame($expect, $actual);
     }
+
+    public function testQuoteNamesInWithCast()
+    {
+        // issue #157: the 'as' inside cast() must not be treated as an alias
+        $sql = "cast(street_number as varchar) like :sn";
+        $actual = $this->quoter->quoteNamesIn($sql);
+        $this->assertSame($sql, $actual);
+    }
+
+    public function testQuoteNamesInWithCastAndAlias()
+    {
+        $sql = "cast(t.street_number as varchar) AS street";
+        $actual = $this->quoter->quoteNamesIn($sql);
+        $expect = "cast(\"t\".\"street_number\" as varchar) AS \"street\"";
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testQuoteNamesInWithMultiWordAlias()
+    {
+        // legacy behavior: a multi-word alias is still quoted as a whole
+        $sql = "legacy invalid as alias still works";
+        $actual = $this->quoter->quoteNamesIn($sql);
+        $expect = "legacy invalid AS \"alias still works\"";
+        $this->assertSame($expect, $actual);
+    }
 }

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -71,6 +71,21 @@ class QuoterTest extends TestCase
         $this->assertSame($expect, $actual);
     }
 
+    public function testQuoteNamesInWithNonWordAlias()
+    {
+        // aliases with non-word characters must still be quoted
+        $actual = $this->quoter->quoteNamesIn('t.foo AS foo-bar');
+        $this->assertSame('"t"."foo" AS "foo-bar"', $actual);
+
+        // an alias beginning with a digit
+        $actual = $this->quoter->quoteNamesIn('t.foo AS 2col');
+        $this->assertSame('"t"."foo" AS "2col"', $actual);
+
+        // a dollar-sign identifier
+        $actual = $this->quoter->quoteNamesIn('t.foo AS foo$bar');
+        $this->assertSame('"t"."foo" AS "foo$bar"', $actual);
+    }
+
     public function testQuoteNamesInWithMultiWordAlias()
     {
         // legacy behavior: a multi-word alias is still quoted as a whole

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -898,6 +898,24 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testIssue157WhereWithCast()
+    {
+        $this->query->cols(array('street_number'))
+            ->from('addresses')
+            ->where('cast(street_number as varchar) like :sn', ['sn' => '10%']);
+
+        $expect = '
+            SELECT
+                street_number
+            FROM
+                <<addresses>>
+            WHERE
+                cast(street_number as varchar) like :sn
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testWhereExistsSubSelect()
     {
         $sub = $this->newQuery()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL quoting so `AS` inside `CAST(... AS ...)` expressions is no longer treated as a column alias separator.
  * Preserved correct quoting for real aliases after cast expressions.
  * Improved generated query output when using cast expressions in `WHERE` clauses (including `LIKE` with bound parameters).
* **Tests**
  * Added coverage for cast handling and alias parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->