### PR TITLE
Fix #151: concrete exceptions + ExceptionInterface marker; deprecate Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,18 @@
   on MySQL, which does not support DEFAULT VALUES), letting the database
   apply column defaults. Fixes #149.
 
-- [CHG] Aura\SqlQuery\Exception now extends \LogicException instead of
-  \Exception, since every exception thrown by this package is a developer
-  error; existing `catch` blocks keep working, and top-level handlers can
-  now treat these as unchecked. Added the Aura\SqlQuery\ExceptionInterface
-  marker interface, which all package exceptions implement. Fixes #151.
+- [BRK] The package now throws concrete exceptions from the new
+  Aura\SqlQuery\Exception namespace — LogicException,
+  BadMethodCallException, and InvalidArgumentException — each extending
+  its SPL counterpart and implementing the new
+  Aura\SqlQuery\ExceptionInterface marker (extends \Throwable), which is
+  the recommended catch-all. Aura\SqlQuery\Exception is now a deprecated
+  interface extending that marker, so existing `catch
+  (Aura\SqlQuery\Exception $e)` blocks keep working until its removal in
+  7.x; since every SPL parent used derives from \LogicException, `catch
+  (\LogicException $e)` also catches everything. Code that instantiated
+  or subclassed Aura\SqlQuery\Exception directly must switch to one of
+  the concrete classes. Fixes #151.
 
 - [CHG] An Update with no columns now throws Aura\SqlQuery\Exception with
   a clear message, instead of a TypeError; an UPDATE with an empty SET

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   on MySQL, which does not support DEFAULT VALUES), letting the database
   apply column defaults. Fixes #149.
 
+- [CHG] Aura\SqlQuery\Exception now extends \LogicException instead of
+  \Exception, since every exception thrown by this package is a developer
+  error; existing `catch` blocks keep working, and top-level handlers can
+  now treat these as unchecked. Added the Aura\SqlQuery\ExceptionInterface
+  marker interface, which all package exceptions implement. Fixes #151.
+
 - [CHG] An Update with no columns now throws Aura\SqlQuery\Exception with
   a clear message, instead of a TypeError; an UPDATE with an empty SET
   clause has no meaning. This matches the existing Select behavior of

--- a/src/Common/AbstractBuilder.php
+++ b/src/Common/AbstractBuilder.php
@@ -8,7 +8,6 @@
  */
 namespace Aura\SqlQuery\Common;
 
-use Aura\SqlQuery\Exception;
 
 /**
  *

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -9,7 +9,8 @@
 namespace Aura\SqlQuery\Common;
 
 use Aura\SqlQuery\AbstractDmlQuery;
-use Aura\SqlQuery\Exception;
+use Aura\SqlQuery\Exception\BadMethodCallException;
+use Aura\SqlQuery\Exception\InvalidArgumentException;
 
 /**
  *
@@ -280,14 +281,14 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * Adds IGNORE flag depending on DB syntax.
      *
      * @param bool $enable Set or unset flag (default true).
-     * @throws Exception
+     * @throws BadMethodCallException
      * @return \Aura\SqlQuery\Sqlite\Insert
      *
      */
     public function ignore($enable = true)
     {
         // override in child classes
-        throw new Exception(get_class($this) . " doesn't support IGNORE flag");
+        throw new BadMethodCallException(get_class($this) . " doesn't support IGNORE flag");
     }
 
     /**
@@ -320,13 +321,13 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * @return null
      *
-     * @throws Exception on named column missing from row.
+     * @throws InvalidArgumentException on named column missing from row.
      *
      */
     protected function finishCol($col)
     {
         if (! array_key_exists($col, $this->col_values)) {
-            throw new Exception("Column $col missing from row {$this->row}.");
+            throw new InvalidArgumentException("Column $col missing from row {$this->row}.");
         }
 
         // get the current col_value

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -9,7 +9,7 @@
 namespace Aura\SqlQuery\Common;
 
 use Aura\SqlQuery\AbstractQuery;
-use Aura\SqlQuery\Exception;
+use Aura\SqlQuery\Exception\LogicException;
 
 /**
  *
@@ -356,7 +356,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @return null
      *
-     * @throws Exception when the reference has already been used.
+     * @throws LogicException when the reference has already been used.
      *
      */
     protected function addTableRef($type, $spec)
@@ -370,7 +370,7 @@ class Select extends AbstractQuery implements SelectInterface
 
         if (isset($this->table_refs[$name])) {
             $used = $this->table_refs[$name];
-            throw new Exception("Cannot reference '$type $spec' after '$used'");
+            throw new LogicException("Cannot reference '$type $spec' after '$used'");
         }
 
         $this->table_refs[$name] = "$type $spec";
@@ -480,7 +480,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @return $this
      *
-     * @throws Exception
+     * @throws LogicException
      *
      */
     public function join($join, $spec, $cond = null, array $bind = array())
@@ -537,7 +537,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @return $this
      *
-     * @throws Exception
+     * @throws LogicException
      *
      */
     public function innerJoin($spec, $cond = null, array $bind = array())
@@ -557,7 +557,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @return $this
      *
-     * @throws Exception
+     * @throws LogicException
      *
      */
     public function leftJoin($spec, $cond = null, array $bind = array())
@@ -583,7 +583,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @return $this
      *
-     * @throws Exception
+     * @throws LogicException
      *
      */
     public function joinSubSelect($join, $spec, $name, $cond = null, array $bind = array())

--- a/src/Common/SelectBuilder.php
+++ b/src/Common/SelectBuilder.php
@@ -8,7 +8,7 @@
  */
 namespace Aura\SqlQuery\Common;
 
-use Aura\SqlQuery\Exception;
+use Aura\SqlQuery\Exception\LogicException;
 
 /**
  *
@@ -27,13 +27,13 @@ class SelectBuilder extends AbstractBuilder
      *
      * @return string
      *
-     * @throws Exception when there are no columns in the SELECT.
+     * @throws LogicException when there are no columns in the SELECT.
      *
      */
     public function buildCols(array $cols)
     {
         if (empty($cols)) {
-            throw new Exception('No columns in the SELECT.');
+            throw new LogicException('No columns in the SELECT.');
         }
         return $this->indentCsv($cols);
     }

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -190,7 +190,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @return $this
      *
-     * @throws \Exception
+     * @throws \Aura\SqlQuery\Exception\LogicException
      *
      */
     public function innerJoin($spec, $cond = null, array $bind = array());
@@ -207,7 +207,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @return $this
      *
-     * @throws \Exception
+     * @throws \Aura\SqlQuery\Exception\LogicException
      *
      */
     public function leftJoin($spec, $cond = null, array $bind = array());

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -9,7 +9,7 @@
 namespace Aura\SqlQuery\Common;
 
 use Aura\SqlQuery\AbstractDmlQuery;
-use Aura\SqlQuery\Exception;
+use Aura\SqlQuery\Exception\LogicException;
 
 /**
  *
@@ -52,13 +52,13 @@ class Update extends AbstractDmlQuery implements UpdateInterface
      *
      * @return string
      *
-     * @throws Exception when there are no columns to update.
+     * @throws LogicException when there are no columns to update.
      *
      */
     protected function build()
     {
         if (! $this->hasCols()) {
-            throw new Exception('No columns to update.');
+            throw new LogicException('No columns to update.');
         }
 
         return 'UPDATE'

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -10,12 +10,14 @@ namespace Aura\SqlQuery;
 
 /**
  *
- * Generic package-level exception for developer errors, e.g. misuse of
- * a query builder.
+ * Retained so that pre-6.x `catch (Aura\SqlQuery\Exception $e)` blocks
+ * keep catching all package exceptions; to be removed in 7.x.
  *
  * @package Aura.SqlQuery
  *
+ * @deprecated catch Aura\SqlQuery\ExceptionInterface instead.
+ *
  */
-class Exception extends \LogicException implements ExceptionInterface
+interface Exception extends ExceptionInterface
 {
 }

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Exception;
+
+use Aura\SqlQuery\Exception as SqlQueryException;
+
+/**
+ *
+ * A query method was called that the underlying database does not support.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+class BadMethodCallException extends \BadMethodCallException implements SqlQueryException
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Exception;
+
+use Aura\SqlQuery\Exception as SqlQueryException;
+
+/**
+ *
+ * A value passed to a query builder does not match what the builder expects.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements SqlQueryException
+{
+}

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Exception;
+
+use Aura\SqlQuery\Exception as SqlQueryException;
+
+/**
+ *
+ * Developer error, e.g. misuse of a query builder.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+class LogicException extends \LogicException implements SqlQueryException
+{
+}

--- a/src/ExceptionInterface.php
+++ b/src/ExceptionInterface.php
@@ -10,12 +10,12 @@ namespace Aura\SqlQuery;
 
 /**
  *
- * Generic package-level exception for developer errors, e.g. misuse of
- * a query builder.
+ * Marker interface for all package-level exceptions; catch this to catch
+ * any exception thrown by this package, regardless of its SPL base class.
  *
  * @package Aura.SqlQuery
  *
  */
-class Exception extends \LogicException implements ExceptionInterface
+interface ExceptionInterface extends \Throwable
 {
 }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -22,6 +22,17 @@ class ExceptionTest extends TestCase
     }
 
     /**
+     * the marker must extend \Throwable so implementing it is only
+     * possible on classes that extend \Exception or \Error, and so a
+     * caught ExceptionInterface is guaranteed to have getMessage() etc.
+     */
+    public function testMarkerInterfaceIsThrowable()
+    {
+        $this->assertTrue(is_a(ExceptionInterface::class, \Throwable::class, true));
+        $this->assertTrue(is_a(Exception::class, ExceptionInterface::class, true));
+    }
+
+    /**
      * catch (Aura\SqlQuery\ExceptionInterface $e) catches every exception
      * thrown by this package, regardless of its SPL base class; the
      * deprecated Aura\SqlQuery\Exception must keep working until 7.x

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace Aura\SqlQuery;
+
+use PHPUnit\Framework\TestCase;
+
+class ExceptionTest extends TestCase
+{
+    public function testIsLogicException()
+    {
+        // issue #151: package exceptions are developer errors, so they
+        // should be catchable (or ignorable) as \LogicException
+        $e = new Exception('message');
+        $this->assertInstanceOf(\LogicException::class, $e);
+    }
+
+    public function testImplementsExceptionInterface()
+    {
+        $e = new Exception('message');
+        $this->assertInstanceOf(ExceptionInterface::class, $e);
+    }
+
+    public function testLegacyCatchesStillWork()
+    {
+        // BC: catch (\Exception) and catch (Aura\SqlQuery\Exception)
+        // must both keep working
+        $e = new Exception('message');
+        $this->assertInstanceOf(\Exception::class, $e);
+        $this->assertInstanceOf(Exception::class, $e);
+    }
+}

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -5,26 +5,37 @@ use PHPUnit\Framework\TestCase;
 
 class ExceptionTest extends TestCase
 {
-    public function testIsLogicException()
+    /**
+     * issue #151: package exceptions are developer errors, so they
+     * should be catchable (or ignorable) as \LogicException
+     */
+    public function testAllAreLogicExceptions()
     {
-        // issue #151: package exceptions are developer errors, so they
-        // should be catchable (or ignorable) as \LogicException
-        $e = new Exception('message');
-        $this->assertInstanceOf(\LogicException::class, $e);
+        $exceptions = array(
+            new Exception\LogicException('message'),
+            new Exception\BadMethodCallException('message'),
+            new Exception\InvalidArgumentException('message'),
+        );
+        foreach ($exceptions as $e) {
+            $this->assertInstanceOf(\LogicException::class, $e);
+        }
     }
 
-    public function testImplementsExceptionInterface()
+    /**
+     * catch (Aura\SqlQuery\ExceptionInterface $e) catches every exception
+     * thrown by this package, regardless of its SPL base class; the
+     * deprecated Aura\SqlQuery\Exception must keep working until 7.x
+     */
+    public function testAllImplementMarkerInterface()
     {
-        $e = new Exception('message');
-        $this->assertInstanceOf(ExceptionInterface::class, $e);
-    }
-
-    public function testLegacyCatchesStillWork()
-    {
-        // BC: catch (\Exception) and catch (Aura\SqlQuery\Exception)
-        // must both keep working
-        $e = new Exception('message');
-        $this->assertInstanceOf(\Exception::class, $e);
-        $this->assertInstanceOf(Exception::class, $e);
+        $exceptions = array(
+            new Exception\LogicException('message'),
+            new Exception\BadMethodCallException('message'),
+            new Exception\InvalidArgumentException('message'),
+        );
+        foreach ($exceptions as $e) {
+            $this->assertInstanceOf(ExceptionInterface::class, $e);
+            $this->assertInstanceOf(Exception::class, $e);
+        }
     }
 }


### PR DESCRIPTION
Fixes #151.

All exceptions thrown by this package are developer errors (builder misuse), so the package now throws concrete exceptions from the new `Aura\SqlQuery\Exception` namespace, each extending its SPL counterpart:

| Throw site | Exception |
|---|---|
| `Insert::ignore()` on an unsupported driver | `Exception\BadMethodCallException` |
| Bulk-insert row missing a column | `Exception\InvalidArgumentException` |
| UPDATE with no columns | `Exception\LogicException` |
| SELECT with no columns | `Exception\LogicException` |
| Duplicate table reference | `Exception\LogicException` |

The package-wide catch-all is the new `Aura\SqlQuery\ExceptionInterface` marker interface (`extends \Throwable`). This is the standard pattern in modern packages (Symfony components, Guzzle, FastRoute): the catch-all is an interface, so each exception class is free to pick the SPL parent that fits it (e.g. a future `RuntimeException` sibling) while remaining catchable package-wide.

`Aura\SqlQuery\Exception` is retained as a **deprecated interface** extending the marker, and the concrete classes implement it, so existing `catch (Aura\SqlQuery\Exception $e)` blocks keep working unchanged through 6.x; it will be removed in 7.x. Since all current SPL parents derive from `\LogicException`, `catch (\LogicException $e)` also catches everything.

BC notes for 6.0:
- Catching `Aura\SqlQuery\Exception` or `\Exception`: unaffected.
- Instantiating or subclassing `Aura\SqlQuery\Exception` directly: breaks (it is now an interface); switch to one of the concrete classes.

Tests assert the hierarchy and both catch paths; existing `expectException('Aura\SqlQuery\Exception')` tests are left as-is as regression coverage for the deprecated catch target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Aura\SqlQuery\ExceptionInterface` as the recommended catch-all for package-thrown errors.
  * Introduced concrete package exceptions: `LogicException`, `BadMethodCallException`, and `InvalidArgumentException`.
* **Bug Fixes**
  * Query-builder misuse now throws more specific exception types instead of generic exceptions.
  * Improved consistency of “logic error” exceptions across select/insert/update builders.
* **Documentation**
  * Updated the changelog to clarify the exception hierarchy shift and compatibility expectations.
* **Tests**
  * Added/expanded PHPUnit coverage for the new exception relationships and marker-interface compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->