### PR TITLE
Fix #172: unify insert-ignore as ignore() across dialects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@
   `cast(col as varchar)`) as a column alias, which produced misquoted
   SQL. Fixes #157.
 
+- [ADD] Insert-ignore is now spelled `ignore()` on every dialect that
+  supports it: Pgsql\Insert gains `ignore()`, rendering the Postgres
+  equivalent `ON CONFLICT DO NOTHING` (before any RETURNING clause), and
+  Sqlite\Update gains `ignore()` matching Mysql\Update; the Sqlite
+  `orIgnore()` methods remain as deprecated aliases. Sqlsrv, which has
+  no equivalent, keeps throwing Exception\BadMethodCallException.
+  Fixes #172; related to #158.
+
 - [CHG] An Update with no columns now throws
   Aura\SqlQuery\Exception\LogicException with
   a clear message, instead of a TypeError; an UPDATE with an empty SET

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,13 @@
   SQL. Fixes #157.
 
 - [ADD] Insert-ignore is now spelled `ignore()` on every dialect that
-  supports it: Pgsql\Insert gains `ignore()`, rendering the Postgres
-  equivalent `ON CONFLICT DO NOTHING` (before any RETURNING clause), and
-  Sqlite\Update gains `ignore()` matching Mysql\Update; the Sqlite
-  `orIgnore()` methods remain as deprecated aliases. Sqlsrv, which has
-  no equivalent, keeps throwing Exception\BadMethodCallException.
-  Fixes #172; related to #158.
+  supports it: Mysql\Insert renders `INSERT IGNORE` and Sqlite\Insert
+  renders `INSERT OR IGNORE` (both as before); Pgsql\Insert gains
+  `ignore()`, rendering the Postgres equivalent `ON CONFLICT DO NOTHING`
+  (before any RETURNING clause); and Sqlite\Update gains `ignore()`
+  matching Mysql\Update. The Sqlite `orIgnore()` methods remain as
+  deprecated aliases. Sqlsrv, which has no equivalent, keeps throwing
+  Exception\BadMethodCallException. Fixes #172; related to #158.
 
 - [FIX] The quoter now recognizes `#` as an identifier character (legal
   on DB2 / IBM i, in any position), so `table.col#` quotes as

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -282,7 +282,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * @param bool $enable Set or unset flag (default true).
      * @throws BadMethodCallException
-     * @return \Aura\SqlQuery\Sqlite\Insert
+     * @return static
      *
      */
     public function ignore($enable = true)

--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -23,6 +23,31 @@ class Insert extends Common\Insert implements ReturningInterface
 
     /**
      *
+     * Whether to render the `ON CONFLICT DO NOTHING` clause.
+     *
+     * @var bool
+     *
+     */
+    protected $ignore = false;
+
+    /**
+     *
+     * Adds or removes the `ON CONFLICT DO NOTHING` clause, the Postgres
+     * equivalent of the IGNORE flag on other databases.
+     *
+     * @param bool $enable Set or unset the clause (default true).
+     *
+     * @return $this
+     *
+     */
+    public function ignore($enable = true)
+    {
+        $this->ignore = (bool) $enable;
+        return $this;
+    }
+
+    /**
+     *
      * Builds the statement.
      *
      * @return string
@@ -31,6 +56,7 @@ class Insert extends Common\Insert implements ReturningInterface
     protected function build()
     {
         return parent::build()
+            . $this->builder->buildIgnore($this->ignore)
             . $this->builder->buildReturning($this->returning);
     }
 

--- a/src/Pgsql/InsertBuilder.php
+++ b/src/Pgsql/InsertBuilder.php
@@ -20,4 +20,22 @@ use Aura\SqlQuery\Common;
 class InsertBuilder extends Common\InsertBuilder
 {
     use BuildReturningTrait;
+
+    /**
+     *
+     * Builds the `ON CONFLICT DO NOTHING` clause of the statement.
+     *
+     * @param bool $ignore Whether the clause is enabled.
+     *
+     * @return string
+     *
+     */
+    public function buildIgnore($ignore)
+    {
+        if (! $ignore) {
+            return ''; // not applicable
+        }
+
+        return PHP_EOL . 'ON CONFLICT DO NOTHING';
+    }
 }

--- a/src/Sqlite/Update.php
+++ b/src/Sqlite/Update.php
@@ -68,12 +68,28 @@ class Update extends Common\Update implements Common\OrderByInterface, Common\Li
      *
      * Adds or removes OR IGNORE flag.
      *
+     * @deprecated use ignore instead
      * @param bool $enable Set or unset flag (default true).
      *
      * @return $this
      *
      */
     public function orIgnore($enable = true)
+    {
+        $this->ignore($enable);
+        return $this;
+    }
+
+    /**
+     *
+     * Adds or removes OR IGNORE flag.
+     *
+     * @param bool $enable Set or unset flag (default true).
+     *
+     * @return $this
+     *
+     */
+    public function ignore($enable = true)
     {
         $this->setFlag('OR IGNORE', $enable);
         return $this;

--- a/tests/Pgsql/InsertTest.php
+++ b/tests/Pgsql/InsertTest.php
@@ -50,10 +50,44 @@ class InsertTest extends Common\InsertTest
 
     public function testIgnore()
     {
-        $this->expectException(
-            'Aura\SqlQuery\Exception',
-            "Aura\SqlQuery\Pgsql\Insert doesn't support IGNORE flag"
-        );
-        $this->query->ignore();
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->ignore()
+                    ->returning(array('c1'));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>
+            ) VALUES (
+                :c1,
+                :c2
+            )
+            ON CONFLICT DO NOTHING
+            RETURNING
+                c1
+        ";
+
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testIgnoreDisable()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1'))
+                    ->ignore()
+                    ->ignore(false);
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>
+            ) VALUES (
+                :c1
+            )
+        ";
+
+        $this->assertSameSql($expect, $actual);
     }
 }

--- a/tests/Sqlite/UpdateTest.php
+++ b/tests/Sqlite/UpdateTest.php
@@ -112,6 +112,30 @@ class UpdateTest extends Common\UpdateTest
         $this->assertSame($expect, $actual);
     }
 
+    public function testIgnore()
+    {
+        $this->query->ignore()
+                    ->table('t1')
+                    ->cols(array('c1', 'c2', 'c3'))
+                    ->set('c4', null)
+                    ->set('c5', 'NOW()')
+                    ->where('foo = :foo', ['foo' => 'bar'])
+                    ->where('baz = :baz', ['baz' => 'dib'])
+                    ->orWhere('zim = gir')
+                    ->limit(5);
+
+        $actual = $this->query->__toString();
+        $expect = sprintf($this->expected_sql_with_flag, 'OR IGNORE');
+        $this->assertSameSql($expect, $actual);
+
+        $actual = $this->query->getBindValues();
+        $expect = array(
+            'foo' => 'bar',
+            'baz' => 'dib',
+        );
+        $this->assertSame($expect, $actual);
+    }
+
     public function testOrIgnore()
     {
         $this->query->orIgnore()

--- a/tests/Sqlsrv/InsertTest.php
+++ b/tests/Sqlsrv/InsertTest.php
@@ -6,4 +6,13 @@ use Aura\SqlQuery\Common;
 class InsertTest extends Common\InsertTest
 {
     protected $db_type = 'sqlsrv';
+
+    public function testIgnore()
+    {
+        // T-SQL has no INSERT IGNORE equivalent, so the base behavior
+        // of throwing on ignore() must be retained
+        $this->expectException(\Aura\SqlQuery\Exception\BadMethodCallException::class);
+        $this->expectExceptionMessage("doesn't support IGNORE");
+        $this->query->ignore();
+    }
 }


### PR DESCRIPTION
Fixes #172; related to #158.

Insert-ignore is now spelled `ignore()` on every dialect that supports it:

| Dialect | `ignore()` renders | Notes |
|---|---|---|
| MySQL | `INSERT IGNORE` | unchanged |
| SQLite | `INSERT OR IGNORE` | unchanged; `orIgnore()` now a deprecated alias |
| Pgsql | `ON CONFLICT DO NOTHING` | **new** — rendered after the values, before any `RETURNING` clause |
| Sqlsrv | throws `Exception\BadMethodCallException` | unchanged; T-SQL has no equivalent (now pinned by a test) |

`Sqlite\Update` also gains `ignore()` to match `Mysql\Update::ignore()`, with `orIgnore()` deprecated as an alias there too.

Semantic caveat, called out for reviewers: MySQL's `IGNORE` suppresses a range of errors (duplicate keys, bad enum values, etc.), while Postgres's `ON CONFLICT DO NOTHING` only skips conflict (duplicate-key) rows. They are equivalent for the common "insert if not exists" use case, which is what #172 asks for.

Tests: Pgsql `ignore()` asserted enabled, disabled, and combined with `RETURNING`; Sqlite `Update::ignore()` asserted alongside the legacy `orIgnore()`; Sqlsrv asserted to keep throwing. 461 tests, 828 assertions passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PostgreSQL INSERT queries now support `ignore()` to generate `ON CONFLICT DO NOTHING`.
  - SQLite UPDATE queries now support the standardized `ignore()` method.

- **Deprecations**
  - SQLite’s existing `orIgnore()` method remains available but is deprecated in favor of `ignore()`.

- **Compatibility**
  - SQL Server continues to report that ignore behavior is unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->