### PR TITLE
Fix #177: allow # in quoted identifiers for DB2 / IBM i

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
   `cast(col as varchar)`) as a column alias, which produced misquoted
   SQL. Fixes #157.
 
+- [FIX] The quoter now recognizes `#` as an identifier character (legal
+  on DB2 / IBM i, in any position), so `table.col#` quotes as
+  `"table"."col#"` instead of the broken `"table"."col"#`. Fixes #177.
+
 - [CHG] An Update with no columns now throws
   Aura\SqlQuery\Exception\LogicException with
   a clear message, instead of a TypeError; an UPDATE with an empty SET

--- a/src/Common/Quoter.php
+++ b/src/Common/Quoter.php
@@ -284,19 +284,20 @@ class Quoter implements QuoterInterface
             return $text;
         }
 
-        $word = "[a-z_][a-z0-9_]*";
+        // issue #177: '#' is a legal identifier character on DB2 / IBM i,
+        // in any position; lookarounds instead of \b, because there is no
+        // word boundary next to a '#'
+        $word = "[a-z_#][a-z0-9_#]*";
 
-        $find = "/(\\b)($word)\\.($word)(\\b)/i";
+        $find = "/(?<![\\w#])($word)\\.($word)(?![\\w#])/i";
 
-        $repl = '$1'
-              . $this->quote_name_prefix
-              . '$2'
+        $repl = $this->quote_name_prefix
+              . '$1'
               . $this->quote_name_suffix
               . '.'
               . $this->quote_name_prefix
-              . '$3'
+              . '$2'
               . $this->quote_name_suffix
-              . '$4'
               ;
 
         $text = preg_replace($find, $repl, $text);

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -86,6 +86,25 @@ class QuoterTest extends TestCase
         $this->assertSame('"t"."foo" AS "foo$bar"', $actual);
     }
 
+    public function testQuoteNamesInWithHash()
+    {
+        // issue #177: DB2 / IBM i allow # in identifiers, in any position
+        $actual = $this->quoter->quoteNamesIn('a.g01gl# ASC');
+        $this->assertSame('"a"."g01gl#" ASC', $actual);
+
+        $actual = $this->quoter->quoteNamesIn('lib.#col');
+        $this->assertSame('"lib"."#col"', $actual);
+
+        $actual = $this->quoter->quoteNamesIn('lib#.tab = :v');
+        $this->assertSame('"lib#"."tab" = :v', $actual);
+
+        $actual = $this->quoter->quoteNamesIn('#lib.tab');
+        $this->assertSame('"#lib"."tab"', $actual);
+
+        $actual = $this->quoter->quoteNamesIn('t.foo#bar');
+        $this->assertSame('"t"."foo#bar"', $actual);
+    }
+
     public function testQuoteNamesInWithMultiWordAlias()
     {
         // legacy behavior: a multi-word alias is still quoted as a whole


### PR DESCRIPTION
Fixes #177.

DB2 / IBM i allow `#` in identifiers, in any position (e.g. `A.G01GL#`). The quoter's `replaceNamesIn()` regex only matched `[a-z_][a-z0-9_]*`, so the match stopped before the `#` and produced broken SQL:

```
ORDER BY "A"."G01GL"# ASC   -- before
ORDER BY "A"."G01GL#" ASC   -- after
```

The identifier character class now includes `#` in any position, for **both** the table and column parts, and the `\b` anchors are replaced with `(?<![\w#])` / `(?![\w#])` lookarounds — `\b` cannot work adjacent to `#`, because `#` is a non-word character.

The regex suggested in the issue comments only extended the column part: with it, `lib#.tab` stays completely unquoted, and `#lib.tab` mis-quotes as `#"lib"."tab"` (the leading `\b` starts a match right after the `#`). Both cases are covered here, with tests pinning all five `#` positions: trailing/leading column, trailing/leading table, and mid-name.

Behavior is unchanged for identifiers without `#`; the existing suite passes as-is. One theoretical edge: a MySQL inline comment glued directly to a column with no space (`t.col#comment`) is now absorbed into the quoted name — previously it produced `"t"."col"#comment`, which was equally broken, so nothing working is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quoting for fully qualified identifiers containing `#`.
  * Ensured identifiers such as `table.col#` are quoted correctly without breaking aliases or related name handling.

* **Tests**
  * Added coverage for identifiers containing `#` in multiple positions and database-specific quoting scenarios.

* **Documentation**
  * Added an entry describing the fix in the upcoming release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->