### PR TITLE
Add PHPStan level 1 to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,6 +51,27 @@ jobs:
         with:
           fail_ci_if_error: false
 
+  phpstan:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        run: composer analyse -- --no-progress
+
   scrutinizer-coverage:
     name: Scrutinizer Code Coverage
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
-        "phpunit/phpunit": "^12.0"
+        "phpunit/phpunit": "^12.0",
+        "phpstan/phpstan": "^2"
     },
     "autoload": {
         "psr-4": {
@@ -51,6 +52,7 @@
     },
     "scripts": {
         "test": "phpunit",
-        "test-coverage": "php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover=coverage.xml"
+        "test-coverage": "php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover=coverage.xml",
+        "analyse": "phpstan analyse"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+# Start at the highest level that passes clean; raise the level as the
+# 6.x native-types work lands (level 2+ currently fails on $this->builder
+# being typed as AbstractBuilder while queries call dialect-builder methods).
+parameters:
+    level: 1
+    paths:
+        - src


### PR DESCRIPTION
Adds PHPStan ^2 (2.2.5) as a dev dependency, with a `phpstan.neon.dist` pinned at **level 1** over `src/` — the highest level that currently passes with zero errors — and a separate "Static Analysis" job in the CI workflow running `composer analyse`.

Level 2 currently reports 39 errors, dominated by `$this->builder` being docblock-typed as `Common\AbstractBuilder` while the query classes call dialect-builder methods (`buildCols()`, `buildReturning()`, etc.), plus a handful of malformed docblocks. Those are exactly what the planned native-types PRs will address, so the intent (noted in the config) is to ratchet the level up as that work lands rather than fix them here.

No CHANGELOG entry: dev infrastructure only, no user-facing change. `composer validate` and the full test suite pass.
