### PR TITLE
Run generated SQL against real MySQL and Postgres in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,6 +51,71 @@ jobs:
         with:
           fail_ci_if_error: false
 
+  integration:
+    name: Integration (MySQL ${{ matrix.mysql }} / Postgres ${{ matrix.postgres }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mysql: '8.4'
+            postgres: '17'
+          - mysql: '8.0'
+            postgres: '15'
+
+    services:
+      mysql:
+        image: mysql:${{ matrix.mysql }}
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: aura_sqlquery_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+      postgres:
+        image: postgres:${{ matrix.postgres }}
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: aura_sqlquery_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd=pg_isready
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo_mysql, pdo_pgsql, pdo_sqlite
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run integration test suite
+        env:
+          DB_MYSQL_DSN: 'mysql:host=127.0.0.1;port=3306;dbname=aura_sqlquery_test'
+          DB_MYSQL_USER: root
+          DB_MYSQL_PASS: root
+          DB_PGSQL_DSN: 'pgsql:host=127.0.0.1;port=5432;dbname=aura_sqlquery_test'
+          DB_PGSQL_USER: postgres
+          DB_PGSQL_PASS: postgres
+        run: ./vendor/bin/phpunit --testsuite integration
+
   phpstan:
     name: Static Analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,6 +55,9 @@ jobs:
     name: Integration (MySQL ${{ matrix.mysql }} / Postgres ${{ matrix.postgres }})
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +97,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 - [CHG] Migrated the test suite to PHPUnit 12 (replacing
   yoast/phpunit-polyfills).
 
+- [CHG] Added an `integration` test suite that executes the generated SQL
+  against real MySQL and PostgreSQL servers (in addition to SQLite), so
+  dialect output is proven to run and not merely to match a string. CI
+  runs it against MySQL 8.4/8.0 and Postgres 17/15 service containers.
+  Locally the MySQL and Postgres cases skip unless `DB_MYSQL_DSN` /
+  `DB_PGSQL_DSN` are set; see CONTRIBUTING.md.
+
 - [FIX] An Insert with no columns no longer throws a TypeError; it now
   renders `INSERT INTO t DEFAULT VALUES` (or `INSERT INTO t () VALUES ()`
   on MySQL, which does not support DEFAULT VALUES), letting the database

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ DB_PGSQL_USER=postgres DB_PGSQL_PASS=postgres \
 ./vendor/bin/phpunit --testsuite integration
 ```
 
-The tests drop and recreate their own `test_*` tables in that database, so do
-not point them at anything you care about. CI runs the same suite against
-MySQL and Postgres service containers.
+The database itself must already exist; the tests create their own `test_*`
+tables in it once per test class and drop them again afterwards, so the
+database is left as it was found. Each individual test runs inside a
+transaction that is rolled back, so no test data survives either. Even so, do
+not point the suite at a database you care about — it drops any table whose
+name it wants to use. CI runs the same suite against MySQL and Postgres
+service containers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,29 @@ We are happy to review any contributions you want to make. When contributing, pl
 The time between submitting a contribution and its review one may be extensive; do not be discouraged if there is not immediate feedback.
 
 Thanks!
+
+## Running the tests
+
+```
+composer install
+./vendor/bin/phpunit
+```
+
+That runs two suites: `unit` (string assertions on the generated SQL) and
+`integration` (the generated SQL executed against a real server).
+
+The integration suite always runs its SQLite cases, using an in-memory
+database. The MySQL and PostgreSQL cases are skipped unless you point them at
+a server with an existing, throwaway database:
+
+```
+DB_MYSQL_DSN='mysql:host=127.0.0.1;port=3306;dbname=aura_sqlquery_test' \
+DB_MYSQL_USER=root DB_MYSQL_PASS=root \
+DB_PGSQL_DSN='pgsql:host=127.0.0.1;port=5432;dbname=aura_sqlquery_test' \
+DB_PGSQL_USER=postgres DB_PGSQL_PASS=postgres \
+./vendor/bin/phpunit --testsuite integration
+```
+
+The tests drop and recreate their own `test_*` tables in that database, so do
+not point them at anything you care about. CI runs the same suite against
+MySQL and Postgres service containers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks!
 
 ## Running the tests
 
-```
+```sh
 composer install
 ./vendor/bin/phpunit
 ```
@@ -20,7 +20,7 @@ The integration suite always runs its SQLite cases, using an in-memory
 database. The MySQL and PostgreSQL cases are skipped unless you point them at
 a server with an existing, throwaway database:
 
-```
+```sh
 DB_MYSQL_DSN='mysql:host=127.0.0.1;port=3306;dbname=aura_sqlquery_test' \
 DB_MYSQL_USER=root DB_MYSQL_PASS=root \
 DB_PGSQL_DSN='pgsql:host=127.0.0.1;port=5432;dbname=aura_sqlquery_test' \

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     },
     "scripts": {
         "test": "phpunit",
+        "test-integration": "phpunit --testsuite integration",
         "test-coverage": "php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover=coverage.xml",
         "analyse": "phpstan analyse"
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,10 +3,16 @@
          bootstrap="./phpunit.php"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd">
     <testsuites>
-        <testsuite name="Aura.SqlQuery test suite">
+        <testsuite name="unit">
             <directory>./tests</directory>
             <!-- abstract base class, not a runnable test -->
             <exclude>./tests/AbstractQueryTest.php</exclude>
+            <exclude>./tests/Integration</exclude>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>./tests/Integration</directory>
+            <!-- abstract base class, not a runnable test -->
+            <exclude>./tests/Integration/AbstractIntegrationTest.php</exclude>
         </testsuite>
     </testsuites>
     <source>

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -22,6 +22,15 @@ abstract class AbstractIntegrationTest extends TestCase
     protected QueryFactory $query_factory;
 
     /**
+     * One connection per test class, keyed by class name so that each dialect
+     * keeps its own. The schema is built once on that connection and every
+     * test runs inside a transaction that is rolled back afterwards.
+     *
+     * @var array<string, PDO>
+     */
+    private static array $connections = [];
+
+    /**
      * Returns a connection, or skips the test when the server is unavailable.
      */
     abstract protected function newPdo(): PDO;
@@ -41,35 +50,72 @@ abstract class AbstractIntegrationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->pdo = $this->newPdo();
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo = $this->getConnection();
         $this->query_factory = new QueryFactory($this->db_type);
-        $this->dropTables();
-        foreach ($this->getCreateTables() as $stm) {
-            $this->pdo->exec($stm);
-        }
+
+        // seed inside the transaction, so the rollback in tearDown() undoes
+        // the seed rows along with whatever the test itself wrote
+        $this->pdo->beginTransaction();
         $this->seed();
     }
 
     protected function tearDown(): void
     {
-        $this->dropTables();
+        if (isset($this->pdo) && $this->pdo->inTransaction()) {
+            $this->pdo->rollBack();
+        }
         parent::tearDown();
     }
 
-    protected function getTableNames(): array
+    /**
+     * Drops the tables this class created, leaving the database as it was
+     * found. The schema cannot live inside the per-test transaction: MySQL
+     * implicitly commits DDL, so a rollback would not undo it.
+     */
+    public static function tearDownAfterClass(): void
+    {
+        $pdo = self::$connections[static::class] ?? null;
+        if ($pdo !== null) {
+            static::dropTables($pdo);
+            unset(self::$connections[static::class]);
+        }
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * Returns this class's connection, building the schema on first use.
+     */
+    protected function getConnection(): PDO
+    {
+        if (isset(self::$connections[static::class])) {
+            return self::$connections[static::class];
+        }
+
+        $pdo = $this->newPdo();
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        // a previous run may have died before its teardown
+        static::dropTables($pdo);
+        foreach ($this->getCreateTables() as $stm) {
+            $pdo->exec($stm);
+        }
+
+        self::$connections[static::class] = $pdo;
+        return $pdo;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected static function getTableNames(): array
     {
         return ['test_employee', 'test_dept', 'test_defaults'];
     }
 
-    protected function dropTables(): void
+    protected static function dropTables(PDO $pdo): void
     {
-        if (! isset($this->pdo)) {
-            // the connection was skipped, so there is nothing to drop
-            return;
-        }
-        foreach ($this->getTableNames() as $table) {
-            $this->pdo->exec("DROP TABLE IF EXISTS {$table}");
+        foreach (static::getTableNames() as $table) {
+            $pdo->exec("DROP TABLE IF EXISTS {$table}");
         }
     }
 

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -1,0 +1,333 @@
+<?php
+namespace Aura\SqlQuery\Integration;
+
+use Aura\SqlQuery\QueryFactory;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ *
+ * Runs the SQL this library generates against a real database server, rather
+ * than asserting on the generated string. Subclasses provide the connection
+ * and the dialect-specific DDL; the test methods here are shared by all of
+ * them, so a dialect that renders valid-looking-but-unexecutable SQL fails.
+ *
+ */
+abstract class AbstractIntegrationTest extends TestCase
+{
+    protected string $db_type;
+
+    protected PDO $pdo;
+
+    protected QueryFactory $query_factory;
+
+    /**
+     * Returns a connection, or skips the test when the server is unavailable.
+     */
+    abstract protected function newPdo(): PDO;
+
+    /**
+     * Returns the CREATE TABLE statements for this dialect.
+     *
+     * @return string[]
+     */
+    abstract protected function getCreateTables(): array;
+
+    /**
+     * Returns an expression casting $expr to a string type in this dialect.
+     */
+    abstract protected function castToChar(string $expr): string;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pdo = $this->newPdo();
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->query_factory = new QueryFactory($this->db_type);
+        $this->dropTables();
+        foreach ($this->getCreateTables() as $stm) {
+            $this->pdo->exec($stm);
+        }
+        $this->seed();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropTables();
+        parent::tearDown();
+    }
+
+    protected function getTableNames(): array
+    {
+        return ['test_employee', 'test_dept', 'test_defaults'];
+    }
+
+    protected function dropTables(): void
+    {
+        if (! isset($this->pdo)) {
+            // the connection was skipped, so there is nothing to drop
+            return;
+        }
+        foreach ($this->getTableNames() as $table) {
+            $this->pdo->exec("DROP TABLE IF EXISTS {$table}");
+        }
+    }
+
+    protected function seed(): void
+    {
+        $depts = [
+            [1, 'Engineering'],
+            [2, 'Sales'],
+        ];
+        $stm = $this->pdo->prepare(
+            'INSERT INTO test_dept (id, name) VALUES (?, ?)'
+        );
+        foreach ($depts as $dept) {
+            $stm->execute($dept);
+        }
+
+        $employees = [
+            ['Anna', 1, 100, 1],
+            ['Betty', 1, 200, 2],
+            ['Clara', 2, 300, 3],
+            ['Donna', 2, 400, 4],
+        ];
+        $stm = $this->pdo->prepare(
+            'INSERT INTO test_employee (name, dept_id, salary, seq) VALUES (?, ?, ?, ?)'
+        );
+        foreach ($employees as $employee) {
+            $stm->execute($employee);
+        }
+    }
+
+    /**
+     * Prepares and executes a query object.
+     */
+    protected function perform($query): \PDOStatement
+    {
+        $sth = $this->pdo->prepare($query->getStatement());
+        foreach ($query->getBindValues() as $name => $value) {
+            // bind with an explicit type the way a connection library would;
+            // SQLite in particular will not compare an integer expression
+            // against a string-bound value
+            $sth->bindValue($name, $value, $this->getParamType($value));
+        }
+        $sth->execute();
+        return $sth;
+    }
+
+    protected function getParamType($value): int
+    {
+        return match (true) {
+            is_int($value) => PDO::PARAM_INT,
+            is_bool($value) => PDO::PARAM_BOOL,
+            $value === null => PDO::PARAM_NULL,
+            default => PDO::PARAM_STR,
+        };
+    }
+
+    /**
+     * Executes a query object and returns all rows.
+     */
+    protected function fetchAll($query): array
+    {
+        return $this->perform($query)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Executes a query object and returns the affected row count.
+     */
+    protected function exec($query): int
+    {
+        return $this->perform($query)->rowCount();
+    }
+
+    protected function fetchNames(?string $where = null): array
+    {
+        $stm = 'SELECT name FROM test_employee';
+        if ($where !== null) {
+            $stm .= " WHERE {$where}";
+        }
+        $stm .= ' ORDER BY seq';
+        return $this->pdo->query($stm)->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    public function testSelectWhereOrderLimitOffset()
+    {
+        $select = $this->query_factory->newSelect()
+            ->cols(['name', 'salary'])
+            ->from('test_employee')
+            ->where('salary > :min', ['min' => 100])
+            ->orderBy(['salary DESC'])
+            ->limit(2)
+            ->offset(1);
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(['Clara', 'Betty'], array_column($actual, 'name'));
+    }
+
+    public function testSelectJoinGroupByHaving()
+    {
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_dept.name AS dept_name', 'COUNT(*) AS employee_count'])
+            ->from('test_dept')
+            ->innerJoin('test_employee', 'test_employee.dept_id = test_dept.id')
+            ->groupBy(['test_dept.name'])
+            ->having('COUNT(*) > :least', ['least' => 1])
+            ->orderBy(['test_dept.name']);
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(
+            ['Engineering', 'Sales'],
+            array_column($actual, 'dept_name')
+        );
+        $this->assertSame([2, 2], array_map('intval', array_column($actual, 'employee_count')));
+    }
+
+    public function testSelectSubSelectInWhere()
+    {
+        $sub = $this->query_factory->newSelect()
+            ->cols(['id'])
+            ->from('test_dept')
+            ->where('name = :dept_name', ['dept_name' => 'Sales']);
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['name'])
+            ->from('test_employee')
+            ->where('dept_id IN (' . $sub->getStatement() . ')', $sub->getBindValues())
+            ->orderBy(['seq']);
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(['Clara', 'Donna'], array_column($actual, 'name'));
+    }
+
+    public function testSelectFromSubSelect()
+    {
+        $sub = $this->query_factory->newSelect()
+            ->cols(['name', 'salary'])
+            ->from('test_employee')
+            ->where('salary >= :min', ['min' => 300]);
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['name'])
+            ->fromSubSelect($sub, 'well_paid')
+            ->orderBy(['name']);
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(['Clara', 'Donna'], array_column($actual, 'name'));
+    }
+
+    public function testSelectDistinctAndUnion()
+    {
+        $select = $this->query_factory->newSelect()
+            ->distinct()
+            ->cols(['dept_id'])
+            ->from('test_employee')
+            ->where('salary < :max', ['max' => 300])
+            ->union()
+            ->cols(['dept_id'])
+            ->from('test_employee')
+            ->where('salary > :min', ['min' => 300]);
+
+        $actual = $this->fetchAll($select);
+        $dept_ids = array_map('intval', array_column($actual, 'dept_id'));
+        sort($dept_ids);
+        $this->assertSame([1, 2], $dept_ids);
+    }
+
+    public function testSelectCastExpression()
+    {
+        // regression for #157: the quoter must not mangle a CAST() type name
+        $select = $this->query_factory->newSelect()
+            ->cols([$this->castToChar('test_employee.salary') . ' AS salary_text'])
+            ->from('test_employee')
+            ->where('name = :name', ['name' => 'Anna']);
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame('100', (string) $actual[0]['salary_text']);
+    }
+
+    public function testInsert()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_employee')
+            ->cols([
+                'name' => 'Edna',
+                'dept_id' => 1,
+                'salary' => 500,
+                'seq' => 5,
+            ]);
+
+        $this->assertSame(1, $this->exec($insert));
+        $this->assertSame('Edna', $this->fetchNames('seq = 5')[0]);
+    }
+
+    public function testInsertBulkRows()
+    {
+        $insert = $this->query_factory->newInsert();
+        $insert->into('test_employee')
+            ->addRows([
+                ['name' => 'Edna', 'dept_id' => 1, 'salary' => 500, 'seq' => 5],
+                ['name' => 'Fiona', 'dept_id' => 2, 'salary' => 600, 'seq' => 6],
+            ]);
+
+        $this->assertSame(2, $this->exec($insert));
+        $this->assertSame(
+            ['Anna', 'Betty', 'Clara', 'Donna', 'Edna', 'Fiona'],
+            $this->fetchNames()
+        );
+    }
+
+    public function testInsertNullValue()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_employee')
+            ->cols([
+                'name' => 'Edna',
+                'dept_id' => null,
+                'salary' => 500,
+                'seq' => 5,
+            ]);
+
+        $this->exec($insert);
+
+        $sth = $this->pdo->query('SELECT dept_id FROM test_employee WHERE seq = 5');
+        $this->assertNull($sth->fetchColumn());
+    }
+
+    public function testInsertDefaultValues()
+    {
+        // regression for #149: an insert with no columns must still be valid
+        $insert = $this->query_factory->newInsert()->into('test_defaults');
+        $this->assertSame(1, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_defaults');
+        $this->assertSame('anon', $sth->fetchColumn());
+    }
+
+    public function testUpdate()
+    {
+        $update = $this->query_factory->newUpdate()
+            ->table('test_employee')
+            ->cols(['salary' => 999])
+            ->set('name', 'test_employee.name')
+            ->where('seq = :seq', ['seq' => 1]);
+
+        $this->assertSame(1, $this->exec($update));
+
+        $sth = $this->pdo->query('SELECT name, salary FROM test_employee WHERE seq = 1');
+        $row = $sth->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('Anna', $row['name']);
+        $this->assertSame(999, (int) $row['salary']);
+    }
+
+    public function testDelete()
+    {
+        $delete = $this->query_factory->newDelete()
+            ->from('test_employee')
+            ->where('salary >= :min', ['min' => 300]);
+
+        $this->assertSame(2, $this->exec($delete));
+        $this->assertSame(['Anna', 'Betty'], $this->fetchNames());
+    }
+}

--- a/tests/Integration/MysqlIntegrationTest.php
+++ b/tests/Integration/MysqlIntegrationTest.php
@@ -1,0 +1,121 @@
+<?php
+namespace Aura\SqlQuery\Integration;
+
+use PDO;
+
+/**
+ *
+ * Runs against a real MySQL/MariaDB server. Set DB_MYSQL_DSN (plus
+ * DB_MYSQL_USER and DB_MYSQL_PASS as needed) to enable; the test is skipped
+ * when they are absent.
+ *
+ */
+class MysqlIntegrationTest extends AbstractIntegrationTest
+{
+    protected string $db_type = 'mysql';
+
+    protected function newPdo(): PDO
+    {
+        $dsn = getenv('DB_MYSQL_DSN');
+        if ($dsn === false || $dsn === '') {
+            $this->markTestSkipped('DB_MYSQL_DSN is not set.');
+        }
+
+        $user = getenv('DB_MYSQL_USER') ?: null;
+        $pass = getenv('DB_MYSQL_PASS') ?: null;
+
+        return new PDO($dsn, $user, $pass);
+    }
+
+    protected function getCreateTables(): array
+    {
+        return [
+            'CREATE TABLE test_dept (
+                id   INT PRIMARY KEY,
+                name VARCHAR(50) NOT NULL
+            )',
+            'CREATE TABLE test_employee (
+                id      INT AUTO_INCREMENT PRIMARY KEY,
+                name    VARCHAR(50) NOT NULL,
+                dept_id INT NULL,
+                salary  INT NOT NULL,
+                seq     INT NOT NULL
+            )',
+            "CREATE TABLE test_defaults (
+                id   INT AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(50) NOT NULL DEFAULT 'anon'
+            )",
+        ];
+    }
+
+    protected function castToChar(string $expr): string
+    {
+        return "CAST({$expr} AS CHAR)";
+    }
+
+    public function testInsertIgnore()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->ignore()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Duplicate']);
+
+        $this->assertSame(0, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Engineering', $sth->fetchColumn());
+    }
+
+    public function testInsertOnDuplicateKeyUpdate()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Ignored'])
+            ->onDuplicateKeyUpdateCol('name', 'Updated');
+
+        $this->exec($insert);
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Updated', $sth->fetchColumn());
+    }
+
+    public function testInsertOrReplace()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->orReplace()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Replaced']);
+
+        $this->exec($insert);
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Replaced', $sth->fetchColumn());
+    }
+
+    public function testUpdateOrderByLimit()
+    {
+        $update = $this->query_factory->newUpdate()
+            ->table('test_employee')
+            ->cols(['salary' => 1])
+            ->where('salary > :min', ['min' => 0])
+            ->orderBy(['salary DESC'])
+            ->limit(1);
+
+        $this->assertSame(1, $this->exec($update));
+
+        $sth = $this->pdo->query('SELECT salary FROM test_employee WHERE seq = 4');
+        $this->assertSame(1, (int) $sth->fetchColumn());
+    }
+
+    public function testDeleteOrderByLimit()
+    {
+        $delete = $this->query_factory->newDelete()
+            ->from('test_employee')
+            ->where('salary > :min', ['min' => 0])
+            ->orderBy(['salary DESC'])
+            ->limit(1);
+
+        $this->assertSame(1, $this->exec($delete));
+        $this->assertSame(['Anna', 'Betty', 'Clara'], $this->fetchNames());
+    }
+}

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -1,0 +1,106 @@
+<?php
+namespace Aura\SqlQuery\Integration;
+
+use PDO;
+
+/**
+ *
+ * Runs against a real PostgreSQL server. Set DB_PGSQL_DSN (plus DB_PGSQL_USER
+ * and DB_PGSQL_PASS as needed) to enable; the test is skipped when they are
+ * absent.
+ *
+ */
+class PgsqlIntegrationTest extends AbstractIntegrationTest
+{
+    protected string $db_type = 'pgsql';
+
+    protected function newPdo(): PDO
+    {
+        $dsn = getenv('DB_PGSQL_DSN');
+        if ($dsn === false || $dsn === '') {
+            $this->markTestSkipped('DB_PGSQL_DSN is not set.');
+        }
+
+        $user = getenv('DB_PGSQL_USER') ?: null;
+        $pass = getenv('DB_PGSQL_PASS') ?: null;
+
+        return new PDO($dsn, $user, $pass);
+    }
+
+    protected function getCreateTables(): array
+    {
+        return [
+            'CREATE TABLE test_dept (
+                id   INTEGER PRIMARY KEY,
+                name VARCHAR(50) NOT NULL
+            )',
+            'CREATE TABLE test_employee (
+                id      SERIAL PRIMARY KEY,
+                name    VARCHAR(50) NOT NULL,
+                dept_id INTEGER NULL,
+                salary  INTEGER NOT NULL,
+                seq     INTEGER NOT NULL
+            )',
+            "CREATE TABLE test_defaults (
+                id   SERIAL PRIMARY KEY,
+                name VARCHAR(50) NOT NULL DEFAULT 'anon'
+            )",
+        ];
+    }
+
+    protected function castToChar(string $expr): string
+    {
+        return "CAST({$expr} AS VARCHAR)";
+    }
+
+    public function testInsertReturning()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_employee')
+            ->cols(['name' => 'Edna', 'dept_id' => 1, 'salary' => 500, 'seq' => 5])
+            ->returning(['id', 'name']);
+
+        $row = $this->fetchAll($insert)[0];
+        $this->assertSame('Edna', $row['name']);
+        $this->assertGreaterThan(0, (int) $row['id']);
+    }
+
+    public function testUpdateReturning()
+    {
+        $update = $this->query_factory->newUpdate()
+            ->table('test_employee')
+            ->cols(['salary' => 999])
+            ->where('seq = :seq', ['seq' => 1])
+            ->returning(['name', 'salary']);
+
+        $rows = $this->fetchAll($update);
+        $this->assertSame('Anna', $rows[0]['name']);
+        $this->assertSame(999, (int) $rows[0]['salary']);
+    }
+
+    public function testDeleteReturning()
+    {
+        $delete = $this->query_factory->newDelete()
+            ->from('test_employee')
+            ->where('salary >= :min', ['min' => 300])
+            ->returning(['name']);
+
+        $rows = $this->fetchAll($delete);
+        $names = array_column($rows, 'name');
+        sort($names);
+        $this->assertSame(['Clara', 'Donna'], $names);
+    }
+
+    public function testGetLastInsertIdName()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_employee')
+            ->cols(['name' => 'Edna', 'dept_id' => 1, 'salary' => 500, 'seq' => 5]);
+
+        $this->exec($insert);
+
+        $name = $insert->getLastInsertIdName('id');
+        $this->assertSame('test_employee_id_seq', $name);
+        $this->assertGreaterThan(0, (int) $this->pdo->lastInsertId($name));
+    }
+}

--- a/tests/Integration/SqliteIntegrationTest.php
+++ b/tests/Integration/SqliteIntegrationTest.php
@@ -1,0 +1,69 @@
+<?php
+namespace Aura\SqlQuery\Integration;
+
+use PDO;
+
+class SqliteIntegrationTest extends AbstractIntegrationTest
+{
+    protected string $db_type = 'sqlite';
+
+    protected function newPdo(): PDO
+    {
+        if (! in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            $this->markTestSkipped('pdo_sqlite is not available.');
+        }
+        return new PDO('sqlite::memory:');
+    }
+
+    protected function getCreateTables(): array
+    {
+        return [
+            'CREATE TABLE test_dept (
+                id   INTEGER PRIMARY KEY,
+                name VARCHAR(50) NOT NULL
+            )',
+            'CREATE TABLE test_employee (
+                id      INTEGER PRIMARY KEY AUTOINCREMENT,
+                name    VARCHAR(50) NOT NULL,
+                dept_id INTEGER NULL,
+                salary  INTEGER NOT NULL,
+                seq     INTEGER NOT NULL
+            )',
+            "CREATE TABLE test_defaults (
+                id   INTEGER PRIMARY KEY AUTOINCREMENT,
+                name VARCHAR(50) NOT NULL DEFAULT 'anon'
+            )",
+        ];
+    }
+
+    protected function castToChar(string $expr): string
+    {
+        return "CAST({$expr} AS TEXT)";
+    }
+
+    public function testInsertIgnore()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->ignore()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Duplicate']);
+
+        $this->assertSame(0, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Engineering', $sth->fetchColumn());
+    }
+
+    public function testInsertOrReplace()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->orReplace()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Replaced']);
+
+        $this->exec($insert);
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Replaced', $sth->fetchColumn());
+    }
+}


### PR DESCRIPTION
Until now only SQLite actually executed anything (a single `testActual` in `tests/Sqlite/UpdateTest.php`); every other dialect was asserted as a string. This adds an integration suite that runs the generated SQL against real servers, so dialect output has to be executable, not merely match an expected string.

## What runs

`tests/Integration/AbstractIntegrationTest.php` holds the cases shared by every dialect — where/order/limit/offset, join + group by + having, subselect in WHERE, `fromSubSelect`, distinct + union, a CAST expression (#157 regression), insert, bulk `addRows`, a NULL bind, a no-column DEFAULT VALUES insert (#149 regression), update with a qualified right-hand side, and delete. It seeds two tables, drops and recreates them per test, and binds values with explicit PDO param types the way a connection library does.

Each subclass adds what only exists in that dialect:

- **Sqlite** — `ignore()`, `orReplace()`
- **MySQL** — `ignore()`, `ON DUPLICATE KEY UPDATE`, `orReplace()`, update/delete with ORDER BY + LIMIT
- **Postgres** — `RETURNING` on insert/update/delete, `getLastInsertIdName()` against a real sequence

## How it's wired

`phpunit.xml.dist` now defines two suites, `unit` and `integration`; a plain `phpunit` runs both. The SQLite cases always execute (in-memory), and the MySQL/Postgres cases skip unless `DB_MYSQL_DSN` / `DB_PGSQL_DSN` are set, so nothing changes for a contributor without servers running. `composer test-integration` runs the suite on its own, and CONTRIBUTING.md documents the env vars — including that the suite drops its own `test_*` tables.

CI gains an `integration` job using service containers, matrixed over MySQL 8.4 + Postgres 17 and MySQL 8.0 + Postgres 15.

## Verification

All 47 integration tests pass locally against MySQL 9.7, Postgres 18, and SQLite; the full suite (505 tests) and PHPStan are green.

One note from writing it: the HAVING case first failed on SQLite because PDO binds `1` as a string and SQLite will not compare an integer expression against text. That is caller-side typing rather than a library bug — hence the explicit `bindValue()` types in the base class — but it is the kind of thing string assertions cannot surface.

No `src/` changes, so this is independent of #219 and #220. Once #219 lands, the Postgres `ignore()` (`ON CONFLICT DO NOTHING`) and `Sqlite\Update::ignore()` deserve integration cases too — a small follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database integration testing for SQLite, MySQL, and PostgreSQL.
  * Added coverage for query generation, inserts, updates, deletes, joins, subqueries, returning clauses, and database-specific behavior.
  * Added a dedicated command for running integration tests.

* **Documentation**
  * Added local test-running instructions, database configuration guidance, and integration test details.

* **CI**
  * Integration tests now run automatically across supported MySQL and PostgreSQL versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->