### PR TITLE
Document WHERE grouping and subquery conditions; add issue #183 test

### DIFF
--- a/docs/select.md
+++ b/docs/select.md
@@ -121,6 +121,71 @@ You can also use `IN` conditions by binding an array to the placeholder.
     // bind values to the :zims placeholder
     ->where('zims IN (:zims)', ['zims' => ['zim_val', 'zim_val2', 'zim_val3']])
 
+### Grouping Conditions With Parentheses
+
+To group a set of conditions inside parentheses, pass a closure to `where()`
+(or `orWhere()`). The closure receives the query object; any conditions you add
+to it are wrapped in a single parenthesized group, and the group as a whole is
+joined to the rest of the WHERE clause with `AND` (for `where()`) or `OR`
+(for `orWhere()`).
+
+```php
+$select
+    ->where(function ($select) {
+        $select->where('foo > :foo_min')
+            ->where('foo < :foo_max');
+    })
+    ->orWhere(function ($select) {
+        $select->where('bar = :bar')
+            ->orWhere('baz = :baz');
+    });
+// WHERE (
+//     foo > :foo_min
+//     AND foo < :foo_max
+// )
+// OR (
+//     bar = :bar
+//     OR baz = :baz
+// )
+```
+
+The same closure grouping works for `having()` and `orHaving()`.
+
+### EXISTS and Subquery Conditions
+
+To build a `WHERE EXISTS` (or `NOT EXISTS`, `IN (...)`, etc.) condition against
+a subquery, pass a _Select_ object as a bind value. It is inlined as a subquery
+at the matching placeholder, and any values bound to the subquery are merged
+into the outer query's bind values automatically.
+
+```php
+$sub = $queryFactory->newSelect()
+    ->cols(['*'])
+    ->from('orders')
+    ->where('orders.user_id = users.id');
+
+$select = $queryFactory->newSelect()
+    ->cols(['*'])
+    ->from('users')
+    ->where('EXISTS (:sub)', ['sub' => $sub]);
+// SELECT * FROM "users" WHERE EXISTS (SELECT * FROM "orders" WHERE "orders"."user_id" = "users"."id")
+```
+
+The same technique builds `IN`/`NOT IN` conditions against a subquery:
+
+```php
+$sub = $queryFactory->newSelect()
+    ->cols(['id'])
+    ->from('orders')
+    ->where('orders.total > :min_total', ['min_total' => 100]);
+
+$select = $queryFactory->newSelect()
+    ->cols(['*'])
+    ->from('users')
+    ->where('id IN (:sub)', ['sub' => $sub]);
+// the :min_total value bound to the subquery is available on the outer query too
+```
+
 
 ## GROUP BY
 

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -1124,6 +1124,40 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testIssue183WhereWithParentheses()
+    {
+        // two OR-groups combined with AND, e.g. (a OR b) AND (c OR d)
+        $select = $this->query
+            ->cols(['*'])
+            ->from('tests')
+            ->where(function ($select) {
+                $select->where('compound_group IN (:groups)')
+                    ->orWhere('compound_name IN (:names)');
+            })
+            ->where(function ($select) {
+                $select->where('species_genus IN (:genera)')
+                    ->orWhere('species_name IN (:species_names)');
+            });
+
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<tests>>
+            WHERE
+                (
+                    compound_group IN (:groups)
+                    OR compound_name IN (:names)
+                )
+                AND (
+                    species_genus IN (:genera)
+                    OR species_name IN (:species_names)
+                )
+            ';
+        $actual = (string) $select->getStatement();
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testHavingClosure()
     {
         $select = $this->query


### PR DESCRIPTION
Verified the open issues and addressed the two that were resolved in code but missing documentation:

- #143 (WHERE EXISTS / subquery conditions): passing a Select object as a bind value already inlines it as a subquery and merges its bound values. Documented EXISTS and IN-subquery usage in docs/select.md. Behavior is already covered by testWhereExistsSubSelect and testWhereSubSelectImportsBoundValues.

- #183 (WHERE with parentheses): closure-based grouping already produces parenthesized condition groups. Documented it in docs/select.md and added testIssue183WhereWithParentheses covering the reported (a OR b) AND (c OR d) shape.


Claude-Session: https://claude.ai/code/session_01U5oV9pmqhiaBgHPuv25erq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance and PHP examples for grouping multiple WHERE or HAVING conditions with parentheses.
  * Documented subquery-based predicates, including EXISTS, IN, and their negated forms, with bind-value handling.

* **Tests**
  * Added coverage verifying that nested OR conditions are rendered in the correct parenthesized groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->