### PR TITLE
Leave hand-quoted identifiers alone in the quoter (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@
   on DB2 / IBM i, in any position), so `table.col#` quotes as
   `"table"."col#"` instead of the broken `"table"."col"#`. Fixes #177.
 
+- [FIX] The quoter now leaves an identifier the caller already quoted as
+  written, instead of splitting it on the dot inside it. A MySQL column
+  named `compound.group` has to be written with backticks by hand, and
+  the quoter turned that into nested backticks the server could not
+  parse. String literals were already exempt, so PostgreSQL and SQLite
+  (double quotes) were unaffected; MySQL (backticks) and SQL Server
+  (brackets) were not. Reported in #183.
+
 - [CHG] An Update with no columns now throws
   Aura\SqlQuery\Exception\LogicException with
   a clear message, instead of a TypeError; an UPDATE with an empty SET

--- a/docs/select.md
+++ b/docs/select.md
@@ -151,6 +151,37 @@ $select
 
 The same closure grouping works for `having()` and `orHaving()`.
 
+If a column name itself contains a dot, quote it yourself and the quoter will
+leave it alone, rather than reading the dot as a table/column separator. Use
+the identifier delimiters of the dialect you are building for: backticks on
+MySQL, double quotes on PostgreSQL and SQLite, square brackets on SQL Server.
+
+The example below is MySQL — both the backticks and `find_in_set()` are MySQL
+syntax:
+
+```php
+$select
+    ->from('tests')
+    ->where(function ($select) {
+        $select->where('find_in_set(tests.`compound.group`, :compound_groups)')
+            ->orWhere('find_in_set(tests.`compound.name`, :compound_names)');
+    });
+// WHERE (
+//     find_in_set(tests.`compound.group`, :compound_groups)
+//     OR find_in_set(tests.`compound.name`, :compound_names)
+// )
+```
+
+The same column on PostgreSQL or SQLite, which quote identifiers with double
+quotes:
+
+```php
+$select
+    ->from('tests')
+    ->where('tests."compound.group" = :compound_group');
+// WHERE tests."compound.group" = :compound_group
+```
+
 ### EXISTS and Subquery Conditions
 
 To build a `WHERE EXISTS` (or `NOT EXISTS`, `IN (...)`, etc.) condition against

--- a/src/Common/Quoter.php
+++ b/src/Common/Quoter.php
@@ -166,8 +166,19 @@ class Quoter implements QuoterInterface
         // match closing quotes against the same number of opening quotes.
         $apos = "'";
         $quot = '"';
+
+        // issue #183: an identifier the caller quoted by hand, because the
+        // name itself contains a dot (`compound.group`), is a candidate too;
+        // it is passed through verbatim rather than split on that dot.
+        $prefix = preg_quote($this->quote_name_prefix, '/');
+        $suffix = preg_quote($this->quote_name_suffix, '/');
+        $quoted_name = "{$prefix}[^{$suffix}]*{$suffix}";
+
+        // branch reset, so that either alternative captures the same two
+        // group numbers; quoteNamesIn() skips every third element on that
+        // basis
         return preg_split(
-            "/(($apos+|$quot+|\\$apos+|\\$quot+).*?\\2)/",
+            "/(?|(($apos+|$quot+|\\$apos+|\\$quot+).*?\\2)|(($quoted_name)))/",
             $text,
             -1,
             PREG_SPLIT_DELIM_CAPTURE
@@ -266,6 +277,23 @@ class Quoter implements QuoterInterface
 
     /**
      *
+     * Is this text a single identifier that the caller already quoted?
+     *
+     * @param string $text The text to test.
+     *
+     * @return bool
+     *
+     */
+    protected function isQuotedName($text)
+    {
+        $len = strlen($this->quote_name_prefix) + strlen($this->quote_name_suffix);
+        return strlen($text) >= $len
+            && str_starts_with($text, $this->quote_name_prefix)
+            && str_ends_with($text, $this->quote_name_suffix);
+    }
+
+    /**
+     *
      * Quotes all fully-qualified identifier names ("table.col") in a string.
      *
      * @param string $text The string in which to quote fully-qualified
@@ -281,6 +309,15 @@ class Quoter implements QuoterInterface
         $is_string_literal = strpos($text, "'") !== false
                         || strpos($text, '"') !== false;
         if ($is_string_literal) {
+            return $text;
+        }
+
+        // issue #183: leave an already-quoted identifier as the caller wrote
+        // it. getListForQuoteNamesIn() splits those out on their own, so the
+        // test is that this element *is* one, not merely that it contains a
+        // quote character: an unbalanced quote is not an identifier, and is
+        // quoted the way it always was.
+        if ($this->isQuotedName($text)) {
             return $text;
         }
 

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aura\SqlQuery\Common;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class QuoterTest extends TestCase
@@ -103,6 +104,112 @@ class QuoterTest extends TestCase
 
         $actual = $this->quoter->quoteNamesIn('t.foo#bar');
         $this->assertSame('"t"."foo#bar"', $actual);
+    }
+
+    /**
+     * The same input, through every quoter the package ships. In the input
+     * and the expectation, {p} and {s} stand for the dialect's own quote
+     * prefix and suffix, so one case covers all three.
+     */
+    #[DataProvider('provideQuoteNamesIn')]
+    public function testQuoteNamesInAcrossDialects(string $input, string $expect)
+    {
+        $quoters = [
+            'common' => new Quoter(),
+            'mysql' => new \Aura\SqlQuery\Mysql\Quoter(),
+            'sqlsrv' => new \Aura\SqlQuery\Sqlsrv\Quoter(),
+        ];
+
+        foreach ($quoters as $db_type => $quoter) {
+            $markers = ['{p}', '{s}'];
+            $quotes = [$quoter->getQuoteNamePrefix(), $quoter->getQuoteNameSuffix()];
+            $actual = $quoter->quoteNamesIn(str_replace($markers, $quotes, $input));
+            $this->assertSame(
+                str_replace($markers, $quotes, $expect),
+                $actual,
+                "quoting for {$db_type}"
+            );
+        }
+    }
+
+    public static function provideQuoteNamesIn(): array
+    {
+        return [
+            'star' => ['*', '*'],
+            'star dot star' => ['*.*', '*.*'],
+            'table dot star' => ['t.*', 't.*'],
+            'qualified name' => ['foo.bar', '{p}foo{s}.{p}bar{s}'],
+            'name with alias' => ['foo.bar AS zim', '{p}foo{s}.{p}bar{s} AS {p}zim{s}'],
+            'alias beginning with a digit' => [
+                't.foo AS 2col',
+                '{p}t{s}.{p}foo{s} AS {p}2col{s}',
+            ],
+            'dollar sign in alias' => [
+                't.foo AS foo$bar',
+                '{p}t{s}.{p}foo{s} AS {p}foo$bar{s}',
+            ],
+            // issue #177: '#' is an identifier character on DB2 / IBM i
+            'hash at end' => ['a.g01gl# ASC', '{p}a{s}.{p}g01gl#{s} ASC'],
+            'hash at start of column' => ['lib.#col', '{p}lib{s}.{p}#col{s}'],
+            'hash at start of table' => ['#lib.tab', '{p}#lib{s}.{p}tab{s}'],
+            'hash inside a name' => ['t.foo#bar', '{p}t{s}.{p}foo#bar{s}'],
+            'aggregate' => ['COUNT(*) > :least', 'COUNT(*) > :least'],
+            // issue #157: the 'AS' inside cast() is not an alias
+            'cast' => [
+                'CAST(t.salary AS CHAR) AS salary_text',
+                'CAST({p}t{s}.{p}salary{s} AS CHAR) AS {p}salary_text{s}',
+            ],
+            'function call' => [
+                'find_in_set(t.col, :p)',
+                'find_in_set({p}t{s}.{p}col{s}, :p)',
+            ],
+            'comparison of two names' => [
+                't.a = u.b',
+                '{p}t{s}.{p}a{s} = {p}u{s}.{p}b{s}',
+            ],
+            'placeholder list' => ['t.a IN (:list)', '{p}t{s}.{p}a{s} IN (:list)'],
+            'between' => [
+                't.a BETWEEN :lo AND :hi',
+                '{p}t{s}.{p}a{s} BETWEEN :lo AND :hi',
+            ],
+            'single quoted literal' => ["t.c = 'a.b'", "{p}t{s}.{p}c{s} = 'a.b'"],
+            'escaped single quote' => ["t.c = 'it''s'", "{p}t{s}.{p}c{s} = 'it''s'"],
+            'literal beside a name' => [
+                "t.c LIKE '%.%' AND t.d = u.e",
+                "{p}t{s}.{p}c{s} LIKE '%.%' AND {p}t{s}.{p}d{s} = {p}u{s}.{p}e{s}",
+            ],
+            // the brackets are inside a literal, so even SQL Server, which
+            // quotes with brackets, must leave them alone
+            'bracket class inside a literal' => [
+                "t.c LIKE '[a-c]%'",
+                "{p}t{s}.{p}c{s} LIKE '[a-c]%'",
+            ],
+            'multi-word alias' => [
+                'legacy invalid as alias still works',
+                'legacy invalid AS {p}alias still works{s}',
+            ],
+            'empty string' => ['', ''],
+            'only a space' => [' ', ' '],
+            // issue #183: a name the caller quoted by hand, because the name
+            // itself contains a dot, is passed through as written
+            'pre-quoted dotted name' => [
+                'find_in_set(tests.{p}compound.group{s}, :g)',
+                'find_in_set(tests.{p}compound.group{s}, :g)',
+            ],
+            'two pre-quoted dotted names' => [
+                't.{p}a.b{s} = u.{p}c.d{s}',
+                't.{p}a.b{s} = u.{p}c.d{s}',
+            ],
+            'pre-quoted name beside a literal' => [
+                "t.{p}a.b{s} = 'x.y' AND u.c = v.d",
+                "t.{p}a.b{s} = 'x.y' AND {p}u{s}.{p}c{s} = {p}v{s}.{p}d{s}",
+            ],
+            'pre-quoted name without a dot' => ['t.{p}a{s}', 't.{p}a{s}'],
+            'already quoted output is left alone' => [
+                '{p}t{s}.{p}c{s}',
+                '{p}t{s}.{p}c{s}',
+            ],
+        ];
     }
 
     public function testQuoteNamesInWithMultiWordAlias()

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -1158,6 +1158,52 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testIssue183ReportedQuery()
+    {
+        // the query as reported on issue #183, joining two tables and
+        // filtering on column names that contain a dot ('compound.group'),
+        // which the caller has to quote by hand
+        $q1 = $this->query->getQuoteNamePrefix();
+        $q2 = $this->query->getQuoteNameSuffix();
+
+        $select = $this->query
+            ->cols(['tests.id'])
+            ->from('tests')
+            ->innerJoin('isolates', 'isolates.id = tests.isolate_id')
+            ->where(function ($select) use ($q1, $q2) {
+                $select
+                    ->where("find_in_set(tests.{$q1}compound.group{$q2}, :compound_groups)")
+                    ->orWhere("find_in_set(tests.{$q1}compound.name{$q2}, :compound_names)");
+            })
+            ->where(function ($select) use ($q1, $q2) {
+                $select
+                    ->where("find_in_set(isolates.{$q1}species.genus{$q2}, :species_genera)")
+                    ->orWhere("find_in_set(isolates.{$q1}species.name{$q2}, :species_names)");
+            });
+
+        // the hand-quoted names survive as written; as with a string
+        // literal, the table prefix beside them is left alone rather than
+        // quoted
+        $expect = '
+            SELECT
+                <<tests>>.<<id>>
+            FROM
+                <<tests>>
+            INNER JOIN <<isolates>> ON <<isolates>>.<<id>> = <<tests>>.<<isolate_id>>
+            WHERE
+                (
+                    find_in_set(tests.<<compound.group>>, :compound_groups)
+                    OR find_in_set(tests.<<compound.name>>, :compound_names)
+                )
+                AND (
+                    find_in_set(isolates.<<species.genus>>, :species_genera)
+                    OR find_in_set(isolates.<<species.name>>, :species_names)
+                )
+            ';
+        $actual = (string) $select->getStatement();
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testHavingClosure()
     {
         $select = $this->query

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -47,6 +47,13 @@ abstract class AbstractIntegrationTest extends TestCase
      */
     abstract protected function castToChar(string $expr): string;
 
+    /**
+     * Returns an expression that is true when $col is one of the values in
+     * the comma-separated string bound to $param; MySQL spells this
+     * find_in_set(), the others have no such function.
+     */
+    abstract protected function inCsv(string $col, string $param): string;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -109,7 +116,13 @@ abstract class AbstractIntegrationTest extends TestCase
      */
     protected static function getTableNames(): array
     {
-        return ['test_employee', 'test_dept', 'test_defaults'];
+        return [
+            'test_employee',
+            'test_dept',
+            'test_defaults',
+            'test_compound',
+            'test_isolate',
+        ];
     }
 
     protected static function dropTables(PDO $pdo): void
@@ -144,6 +157,53 @@ abstract class AbstractIntegrationTest extends TestCase
         foreach ($employees as $employee) {
             $stm->execute($employee);
         }
+
+        $this->seedIssue183();
+    }
+
+    /**
+     * Seeds the two tables from issue #183, whose column names contain dots.
+     */
+    protected function seedIssue183(): void
+    {
+        $isolates = [
+            [1, 'Candida', 'albicans'],
+            [2, 'Aspergillus', 'niger'],
+        ];
+        $stm = $this->pdo->prepare(
+            'INSERT INTO test_isolate (id, ' . $this->quoteName('species.genus')
+            . ', ' . $this->quoteName('species.name') . ') VALUES (?, ?, ?)'
+        );
+        foreach ($isolates as $isolate) {
+            $stm->execute($isolate);
+        }
+
+        $compounds = [
+            // matches: an azole, on a Candida isolate
+            [1, 1, 'azole', 'fluconazole'],
+            // the compound half matches, the isolate half does not
+            [2, 2, 'echinocandin', 'caspofungin'],
+            // matches only if the parentheses are missing
+            [3, 2, 'azole', 'fluconazole'],
+        ];
+        $stm = $this->pdo->prepare(
+            'INSERT INTO test_compound (id, isolate_id, '
+            . $this->quoteName('compound.group') . ', '
+            . $this->quoteName('compound.name') . ') VALUES (?, ?, ?, ?)'
+        );
+        foreach ($compounds as $compound) {
+            $stm->execute($compound);
+        }
+    }
+
+    /**
+     * Quotes a single identifier the way this dialect does, for the raw SQL
+     * in the seeds; the query objects do their own quoting.
+     */
+    protected function quoteName(string $name): string
+    {
+        $query = $this->query_factory->newSelect();
+        return $query->getQuoteNamePrefix() . $name . $query->getQuoteNameSuffix();
     }
 
     /**
@@ -250,6 +310,37 @@ abstract class AbstractIntegrationTest extends TestCase
         // without the parentheses this would also match Betty
         $actual = $this->fetchAll($select);
         $this->assertSame(['Anna', 'Donna'], array_column($actual, 'name'));
+    }
+
+    public function testSelectIssue183ReportedQuery()
+    {
+        // issue #183, as reported: two OR-groups combined with AND, over
+        // column names that contain a dot and so are quoted by hand
+        $group = 'test_compound.' . $this->quoteName('compound.group');
+        $name = 'test_compound.' . $this->quoteName('compound.name');
+        $genus = 'test_isolate.' . $this->quoteName('species.genus');
+        $species = 'test_isolate.' . $this->quoteName('species.name');
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_compound.id'])
+            ->from('test_compound')
+            ->innerJoin('test_isolate', 'test_isolate.id = test_compound.isolate_id')
+            ->where(function ($select) use ($group, $name) {
+                $select
+                    ->where($this->inCsv($group, ':compound_groups'), ['compound_groups' => 'azole'])
+                    ->orWhere($this->inCsv($name, ':compound_names'), ['compound_names' => 'caspofungin']);
+            })
+            ->where(function ($select) use ($genus, $species) {
+                $select
+                    ->where($this->inCsv($genus, ':species_genera'), ['species_genera' => 'Candida'])
+                    ->orWhere($this->inCsv($species, ':species_names'), ['species_names' => 'albicans']);
+            })
+            ->orderBy(['test_compound.id']);
+
+        // row 3 satisfies the first group only, so it comes back too if the
+        // parentheses are lost to AND binding tighter than OR
+        $actual = $this->fetchAll($select);
+        $this->assertSame([1], array_map('intval', array_column($actual, 'id')));
     }
 
     public function testSelectSubSelectInWhere()

--- a/tests/Integration/MysqlIntegrationTest.php
+++ b/tests/Integration/MysqlIntegrationTest.php
@@ -45,12 +45,28 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
                 id   INT AUTO_INCREMENT PRIMARY KEY,
                 name VARCHAR(50) NOT NULL DEFAULT 'anon'
             )",
+            'CREATE TABLE test_isolate (
+                id               INT PRIMARY KEY,
+                `species.genus`  VARCHAR(50) NOT NULL,
+                `species.name`   VARCHAR(50) NOT NULL
+            )',
+            'CREATE TABLE test_compound (
+                id                INT PRIMARY KEY,
+                isolate_id        INT NOT NULL,
+                `compound.group`  VARCHAR(50) NOT NULL,
+                `compound.name`   VARCHAR(50) NOT NULL
+            )',
         ];
     }
 
     protected function castToChar(string $expr): string
     {
         return "CAST({$expr} AS CHAR)";
+    }
+
+    protected function inCsv(string $col, string $param): string
+    {
+        return "find_in_set({$col}, {$param})";
     }
 
     public function testInsertIgnore()

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -45,12 +45,29 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
                 id   SERIAL PRIMARY KEY,
                 name VARCHAR(50) NOT NULL DEFAULT 'anon'
             )",
+            'CREATE TABLE test_isolate (
+                id               INTEGER PRIMARY KEY,
+                "species.genus"  VARCHAR(50) NOT NULL,
+                "species.name"   VARCHAR(50) NOT NULL
+            )',
+            'CREATE TABLE test_compound (
+                id                INTEGER PRIMARY KEY,
+                isolate_id        INTEGER NOT NULL,
+                "compound.group"  VARCHAR(50) NOT NULL,
+                "compound.name"   VARCHAR(50) NOT NULL
+            )',
         ];
     }
 
     protected function castToChar(string $expr): string
     {
         return "CAST({$expr} AS VARCHAR)";
+    }
+
+    protected function inCsv(string $col, string $param): string
+    {
+        // PostgreSQL has no find_in_set()
+        return "{$col} = ANY(string_to_array({$param}, ','))";
     }
 
     public function testInsertReturning()

--- a/tests/Integration/SqliteIntegrationTest.php
+++ b/tests/Integration/SqliteIntegrationTest.php
@@ -33,12 +33,29 @@ class SqliteIntegrationTest extends AbstractIntegrationTest
                 id   INTEGER PRIMARY KEY AUTOINCREMENT,
                 name VARCHAR(50) NOT NULL DEFAULT 'anon'
             )",
+            'CREATE TABLE test_isolate (
+                id               INTEGER PRIMARY KEY,
+                "species.genus"  VARCHAR(50) NOT NULL,
+                "species.name"   VARCHAR(50) NOT NULL
+            )',
+            'CREATE TABLE test_compound (
+                id                INTEGER PRIMARY KEY,
+                isolate_id        INTEGER NOT NULL,
+                "compound.group"  VARCHAR(50) NOT NULL,
+                "compound.name"   VARCHAR(50) NOT NULL
+            )',
         ];
     }
 
     protected function castToChar(string $expr): string
     {
         return "CAST({$expr} AS TEXT)";
+    }
+
+    protected function inCsv(string $col, string $param): string
+    {
+        // SQLite has no find_in_set()
+        return "instr(',' || {$param} || ',', ',' || {$col} || ',') > 0";
     }
 
     public function testInsertIgnore()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved identifiers that are already quoted, including dotted column names, without re-processing them.
  * Prevented invalid nested quoting that could lead to SQL parsing errors.
  * Ensured correct quoting behavior for dotted identifiers across supported database systems.
* **Documentation**
  * Clarified that column names containing dots must be explicitly quoted to avoid misinterpreting the dot as a separator.
* **Tests**
  * Added unit and integration coverage reproducing the issue and validating emitted SQL across multiple dialects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->