### PR TITLE
Do not quote the dot in @-prefixed variables (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@
   on DB2 / IBM i, in any position), so `table.col#` quotes as
   `"table"."col#"` instead of the broken `"table"."col"#`. Fixes #177.
 
+- [FIX] The quoter no longer treats the dot in a variable as a table/column
+  separator. `@@session.time_zone` came out with each half backticked, as
+  if `session` were a table, which no server can run; the same went for
+  `@@global.x` and for user variables such as `@a.b`, whose names may
+  legally contain dots and `$`. A token introduced by `@` is now returned
+  as written, however many dots it has, while real column references beside
+  it are quoted as before. Fixes #226.
+
 - [FIX] The quoter now leaves an identifier the caller already quoted as
   written, instead of splitting it on the dot inside it. A MySQL column
   named `compound.group` has to be written with backticks by hand, and

--- a/docs/select.md
+++ b/docs/select.md
@@ -182,6 +182,21 @@ $select
 // WHERE tests."compound.group" = :compound_group
 ```
 
+A name introduced by `@` is a variable rather than an identifier, and the dot
+in one separates scope from name, so the quoter leaves the whole of it alone.
+Column references beside it are still quoted (MySQL again, for `convert_tz()`
+and the session variable):
+
+```php
+$select
+    ->from('customer')
+    ->cols(['convert_tz(open_from, customer.time_zone, @@session.time_zone) open_now']);
+// SELECT
+//     convert_tz(open_from, `customer`.`time_zone`, @@session.time_zone) open_now
+// FROM
+//     `customer`
+```
+
 ### EXISTS and Subquery Conditions
 
 To build a `WHERE EXISTS` (or `NOT EXISTS`, `IN (...)`, etc.) condition against

--- a/src/Common/Quoter.php
+++ b/src/Common/Quoter.php
@@ -326,20 +326,28 @@ class Quoter implements QuoterInterface
         // word boundary next to a '#'
         $word = "[a-z_#][a-z0-9_#]*";
 
-        $find = "/(?<![\\w#])($word)\\.($word)(?![\\w#])/i";
+        // issue #226: '@' introduces a variable, not an identifier, and any
+        // dots in one belong to its name: '@@session.time_zone' names the
+        // session time_zone variable, not a time_zone column on a session
+        // table, and '@a.b' is a single user variable. A variable is matched
+        // first, and returned as it was written, so that the identifier
+        // branch never sees inside one.
+        $variable = '@@?[a-z0-9_$.#]*';
 
-        $repl = $this->quote_name_prefix
-              . '$1'
-              . $this->quote_name_suffix
-              . '.'
-              . $this->quote_name_prefix
-              . '$2'
-              . $this->quote_name_suffix
-              ;
+        $find = "/({$variable})|(?<![\\w#])($word)\\.($word)(?![\\w#])/i";
 
-        $text = preg_replace($find, $repl, $text);
-
-        return $text;
+        return preg_replace_callback($find, function ($matches) {
+            if ($matches[1] !== '') {
+                return $matches[1];
+            }
+            return $this->quote_name_prefix
+                 . $matches[2]
+                 . $this->quote_name_suffix
+                 . '.'
+                 . $this->quote_name_prefix
+                 . $matches[3]
+                 . $this->quote_name_suffix;
+        }, $text);
     }
 
 }

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -222,6 +222,33 @@ class QuoterTest extends TestCase
                 "t.c = '@a.b'",
                 "{p}t{s}.{p}c{s} = '@a.b'",
             ],
+            // PostgreSQL spells its text-search match and its JSONPath
+            // predicate check '@@'. The variable pattern stops at the space,
+            // so a bare '@@' is passed through as the operator it is and the
+            // name after it is still quoted.
+            'pgsql text search operator' => [
+                't.doc @@ q.tsq',
+                '{p}t{s}.{p}doc{s} @@ {p}q{s}.{p}tsq{s}',
+            ],
+            'pgsql jsonpath predicate operator' => [
+                't.payload @@ p.expr',
+                '{p}t{s}.{p}payload{s} @@ {p}p{s}.{p}expr{s}',
+            ],
+            'pgsql operator before a function call' => [
+                't.doc @@ to_tsquery(u.cfg, :q)',
+                '{p}t{s}.{p}doc{s} @@ to_tsquery({p}u{s}.{p}cfg{s}, :q)',
+            ],
+            'pgsql containment operator' => [
+                't.payload @> u.filter',
+                '{p}t{s}.{p}payload{s} @> {p}u{s}.{p}filter{s}',
+            ],
+            // known limitation: with no space, '@@x.y' is indistinguishable
+            // from a variable named '@@x.y', so the name is left alone. Write
+            // the operator with spaces around it.
+            'pgsql operator with no space after it' => [
+                't.doc @@x.y',
+                '{p}t{s}.{p}doc{s} @@x.y',
+            ],
             // the #183 and #226 rules meet: one name quoted by hand, one
             // variable, and a plain reference to quote between them
             'pre-quoted name and a variable' => [

--- a/tests/Common/QuoterTest.php
+++ b/tests/Common/QuoterTest.php
@@ -188,6 +188,54 @@ class QuoterTest extends TestCase
                 'legacy invalid as alias still works',
                 'legacy invalid AS {p}alias still works{s}',
             ],
+            // issue #226: the dot in a variable is a scope separator, not a
+            // table/column separator
+            'session variable' => ['@@session.time_zone', '@@session.time_zone'],
+            'global variable' => [
+                '@@global.max_connections',
+                '@@global.max_connections',
+            ],
+            // a MySQL user variable name may itself contain dots, '$' and
+            // '_', so the whole token is left alone, not just the part
+            // right after the '@'
+            'user variable' => ['@var.name', '@var.name'],
+            'user variable with two dots' => ['@a.b.c', '@a.b.c'],
+            'user variable with a dollar sign' => ['@my$var.name', '@my$var.name'],
+            'variable then a real name' => [
+                '@x.y = t.a',
+                '@x.y = {p}t{s}.{p}a{s}',
+            ],
+            'real name then a variable' => [
+                't.a = @x.y',
+                '{p}t{s}.{p}a{s} = @x.y',
+            ],
+            'variable beside a real name' => [
+                'convert_tz(t.open_from, t.time_zone, @@session.time_zone)',
+                'convert_tz({p}t{s}.{p}open_from{s}, {p}t{s}.{p}time_zone{s}, @@session.time_zone)',
+            ],
+            'variable with an alias' => [
+                '@@session.time_zone AS tz',
+                '@@session.time_zone AS {p}tz{s}',
+            ],
+            'variable with no dot' => ['@@ROWCOUNT', '@@ROWCOUNT'],
+            'variable inside a string literal' => [
+                "t.c = '@a.b'",
+                "{p}t{s}.{p}c{s} = '@a.b'",
+            ],
+            // the #183 and #226 rules meet: one name quoted by hand, one
+            // variable, and a plain reference to quote between them
+            'pre-quoted name and a variable' => [
+                't.{p}a.b{s} = @v.x AND u.c = :p',
+                't.{p}a.b{s} = @v.x AND {p}u{s}.{p}c{s} = :p',
+            ],
+            'pre-quoted name containing an at sign' => [
+                '{p}@weird.col{s} = t.a',
+                '{p}@weird.col{s} = {p}t{s}.{p}a{s}',
+            ],
+            'count distinct' => [
+                'COUNT(DISTINCT t.x)',
+                'COUNT(DISTINCT {p}t{s}.{p}x{s})',
+            ],
             'empty string' => ['', ''],
             'only a space' => [' ', ' '],
             // issue #183: a name the caller quoted by hand, because the name

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -1204,6 +1204,59 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testIssue226SessionVariableInCols()
+    {
+        // the query as reported on issue #226: the column reference is
+        // quoted, the session variable beside it is not
+        $select = $this->query
+            ->from('customer')
+            ->cols(['convert_tz(open_from, customer.time_zone, @@session.time_zone) open_now'])
+            ->where('customer.id = :id');
+
+        $expect = '
+            SELECT
+                convert_tz(open_from, <<customer>>.<<time_zone>>, @@session.time_zone) open_now
+            FROM
+                <<customer>>
+            WHERE
+                <<customer>>.<<id>> = :id
+            ';
+        $actual = (string) $select->getStatement();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testIssue226VariableInEveryClause()
+    {
+        // GROUP BY, HAVING and ORDER BY quote their text through separate
+        // call sites from cols() and where(); a variable survives all of them
+        $select = $this->query
+            ->cols(['t.a'])
+            ->from('t')
+            ->where('t.a = @v.x')
+            ->groupBy(['@v.x', 't.a'])
+            ->having('COUNT(*) > @v.n')
+            ->orderBy(['@v.x DESC', 't.a']);
+
+        $expect = '
+            SELECT
+                <<t>>.<<a>>
+            FROM
+                <<t>>
+            WHERE
+                <<t>>.<<a>> = @v.x
+            GROUP BY
+                @v.x,
+                <<t>>.<<a>>
+            HAVING
+                COUNT(*) > @v.n
+            ORDER BY
+                @v.x DESC,
+                <<t>>.<<a>>
+            ';
+        $actual = (string) $select->getStatement();
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testHavingClosure()
     {
         $select = $this->query

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -7,10 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 /**
  *
- * Runs the SQL this library generates against a real database server, rather
- * than asserting on the generated string. Subclasses provide the connection
- * and the dialect-specific DDL; the test methods here are shared by all of
- * them, so a dialect that renders valid-looking-but-unexecutable SQL fails.
+ * Runs the SQL this library generates against a real database server, instead
+ * of only asserting on the generated string. Each test pins the shape of the
+ * SQL and then executes it, so that a dialect which renders
+ * valid-looking-but-unexecutable SQL fails, and so does one that runs but
+ * quotes the wrong thing. Subclasses provide the connection and the
+ * dialect-specific DDL; the test methods here are shared by all of them.
  *
  */
 abstract class AbstractIntegrationTest extends TestCase
@@ -233,6 +235,22 @@ abstract class AbstractIntegrationTest extends TestCase
     }
 
     /**
+     * Asserts that the generated SQL contains $expect, in which '<<' and
+     * '>>' stand for this dialect's identifier quotes. Executing a query
+     * proves it runs and returns the right rows; this pins the shape of the
+     * SQL that did so, which the rows alone cannot show.
+     */
+    protected function assertStatementContains(string $expect, $query): void
+    {
+        $expect = str_replace(
+            ['<<', '>>'],
+            [$query->getQuoteNamePrefix(), $query->getQuoteNameSuffix()],
+            $expect
+        );
+        $this->assertStringContainsString($expect, (string) $query->getStatement());
+    }
+
+    /**
      * Executes a query object and returns all rows.
      */
     protected function fetchAll($query): array
@@ -268,6 +286,8 @@ abstract class AbstractIntegrationTest extends TestCase
             ->limit(2)
             ->offset(1);
 
+        $this->assertStatementContains('LIMIT 2 OFFSET 1', $select);
+
         $actual = $this->fetchAll($select);
         $this->assertSame(['Clara', 'Betty'], array_column($actual, 'name'));
     }
@@ -281,6 +301,11 @@ abstract class AbstractIntegrationTest extends TestCase
             ->groupBy(['test_dept.name'])
             ->having('COUNT(*) > :least', ['least' => 1])
             ->orderBy(['test_dept.name']);
+
+        $this->assertStatementContains(
+            'INNER JOIN <<test_employee>> ON <<test_employee>>.<<dept_id>> = <<test_dept>>.<<id>>',
+            $select
+        );
 
         $actual = $this->fetchAll($select);
         $this->assertSame(
@@ -306,6 +331,8 @@ abstract class AbstractIntegrationTest extends TestCase
                     ->orWhere('name = :second', ['second' => 'Donna']);
             })
             ->orderBy(['seq']);
+
+        $this->assertStatementContains('AND (', $select);
 
         // without the parentheses this would also match Betty
         $actual = $this->fetchAll($select);
@@ -337,6 +364,11 @@ abstract class AbstractIntegrationTest extends TestCase
             })
             ->orderBy(['test_compound.id']);
 
+        // the hand-quoted names survive, and the two groups are parenthesized
+        $this->assertStatementContains('<<compound.group>>', $select);
+        $this->assertStatementContains('<<species.genus>>', $select);
+        $this->assertStatementContains('AND (', $select);
+
         // row 3 satisfies the first group only, so it comes back too if the
         // parentheses are lost to AND binding tighter than OR
         $actual = $this->fetchAll($select);
@@ -356,6 +388,8 @@ abstract class AbstractIntegrationTest extends TestCase
             ->where('dept_id IN (' . $sub->getStatement() . ')', $sub->getBindValues())
             ->orderBy(['seq']);
 
+        $this->assertStatementContains('dept_id IN (SELECT', $select);
+
         $actual = $this->fetchAll($select);
         $this->assertSame(['Clara', 'Donna'], array_column($actual, 'name'));
     }
@@ -371,6 +405,8 @@ abstract class AbstractIntegrationTest extends TestCase
             ->cols(['name'])
             ->fromSubSelect($sub, 'well_paid')
             ->orderBy(['name']);
+
+        $this->assertStatementContains(') AS <<well_paid>>', $select);
 
         $actual = $this->fetchAll($select);
         $this->assertSame(['Clara', 'Donna'], array_column($actual, 'name'));
@@ -388,6 +424,9 @@ abstract class AbstractIntegrationTest extends TestCase
             ->from('test_employee')
             ->where('salary > :min', ['min' => 300]);
 
+        $this->assertStatementContains('SELECT DISTINCT', $select);
+        $this->assertStatementContains('UNION', $select);
+
         $actual = $this->fetchAll($select);
         $dept_ids = array_map('intval', array_column($actual, 'dept_id'));
         sort($dept_ids);
@@ -401,6 +440,12 @@ abstract class AbstractIntegrationTest extends TestCase
             ->cols([$this->castToChar('test_employee.salary') . ' AS salary_text'])
             ->from('test_employee')
             ->where('name = :name', ['name' => 'Anna']);
+
+        // the CAST type name must not be quoted as an identifier
+        $this->assertStatementContains(
+            $this->castToChar('<<test_employee>>.<<salary>>') . ' AS <<salary_text>>',
+            $select
+        );
 
         $actual = $this->fetchAll($select);
         $this->assertSame('100', (string) $actual[0]['salary_text']);
@@ -417,6 +462,9 @@ abstract class AbstractIntegrationTest extends TestCase
                 'seq' => 5,
             ]);
 
+        $this->assertStatementContains('INSERT INTO <<test_employee>>', $insert);
+        $this->assertStatementContains('<<name>>', $insert);
+
         $this->assertSame(1, $this->exec($insert));
         $this->assertSame('Edna', $this->fetchNames('seq = 5')[0]);
     }
@@ -429,6 +477,11 @@ abstract class AbstractIntegrationTest extends TestCase
                 ['name' => 'Edna', 'dept_id' => 1, 'salary' => 500, 'seq' => 5],
                 ['name' => 'Fiona', 'dept_id' => 2, 'salary' => 600, 'seq' => 6],
             ]);
+
+        $this->assertStatementContains(
+            '(:name_0, :dept_id_0, :salary_0, :seq_0),',
+            $insert
+        );
 
         $this->assertSame(2, $this->exec($insert));
         $this->assertSame(
@@ -448,6 +501,8 @@ abstract class AbstractIntegrationTest extends TestCase
                 'seq' => 5,
             ]);
 
+        $this->assertStatementContains('<<dept_id>>', $insert);
+
         $this->exec($insert);
 
         $sth = $this->pdo->query('SELECT dept_id FROM test_employee WHERE seq = 5');
@@ -458,6 +513,7 @@ abstract class AbstractIntegrationTest extends TestCase
     {
         // regression for #149: an insert with no columns must still be valid
         $insert = $this->query_factory->newInsert()->into('test_defaults');
+        $this->assertStatementContains('INSERT INTO <<test_defaults>>', $insert);
         $this->assertSame(1, $this->exec($insert));
 
         $sth = $this->pdo->query('SELECT name FROM test_defaults');
@@ -472,6 +528,12 @@ abstract class AbstractIntegrationTest extends TestCase
             ->set('name', 'test_employee.name')
             ->where('seq = :seq', ['seq' => 1]);
 
+        // set() takes a raw expression, so the column reference is quoted
+        $this->assertStatementContains(
+            '<<name>> = <<test_employee>>.<<name>>',
+            $update
+        );
+
         $this->assertSame(1, $this->exec($update));
 
         $sth = $this->pdo->query('SELECT name, salary FROM test_employee WHERE seq = 1');
@@ -485,6 +547,8 @@ abstract class AbstractIntegrationTest extends TestCase
         $delete = $this->query_factory->newDelete()
             ->from('test_employee')
             ->where('salary >= :min', ['min' => 300]);
+
+        $this->assertStatementContains('DELETE FROM <<test_employee>>', $delete);
 
         $this->assertSame(2, $this->exec($delete));
         $this->assertSame(['Anna', 'Betty'], $this->fetchNames());

--- a/tests/Integration/MysqlIntegrationTest.php
+++ b/tests/Integration/MysqlIntegrationTest.php
@@ -69,12 +69,96 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
         return "find_in_set({$col}, {$param})";
     }
 
+    public function testSelectSessionVariable()
+    {
+        // issue #226: quoting the parts of @@session.time_zone made this
+        // unrunnable; the server has no 'session' table
+        $select = $this->query_factory->newSelect()
+            ->cols(['@@session.time_zone AS tz'])
+            ->from('test_employee')
+            ->where('seq = :seq', ['seq' => 1]);
+
+        $this->assertStatementContains('@@session.time_zone AS <<tz>>', $select);
+
+        $actual = $this->fetchAll($select);
+        $this->assertNotSame('', (string) $actual[0]['tz']);
+    }
+
+    public function testSelectSessionVariableBesideColumn()
+    {
+        // the shape from the issue: a real column reference and a session
+        // variable in one expression, only the first of which is quoted
+        $select = $this->query_factory->newSelect()
+            ->cols([
+                'test_employee.name',
+                'convert_tz(:when, @@session.time_zone, @@session.time_zone) AS converted',
+                "convert_tz(:when, '+00:00', '+05:30') AS shifted",
+            ])
+            ->from('test_employee')
+            ->where('test_employee.seq = :seq', [
+                'seq' => 1,
+                'when' => '2020-01-01 00:00:00',
+            ]);
+
+        $this->assertStatementContains(
+            'convert_tz(:when, @@session.time_zone, @@session.time_zone) AS <<converted>>',
+            $select
+        );
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame('Anna', $actual[0]['name']);
+        // converting from the session zone to itself is a no-op, so this
+        // holds whatever the server is set to
+        $this->assertSame('2020-01-01 00:00:00', $actual[0]['converted']);
+        $this->assertSame('2020-01-01 05:30:00', $actual[0]['shifted']);
+    }
+
+    public function testSelectUserVariable()
+    {
+        // a user variable name may contain dots and '$'; the whole of it is
+        // one name, so quoting any part of it is a syntax error
+        $this->pdo->exec('SET @var.name = 42, @my$var.name = 7');
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['@var.name AS dotted', '@my$var.name AS dollared'])
+            ->from('test_employee')
+            ->where('seq = :seq', ['seq' => 1]);
+
+        $this->assertStatementContains('@var.name AS <<dotted>>', $select);
+        $this->assertStatementContains('@my$var.name AS <<dollared>>', $select);
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(42, (int) $actual[0]['dotted']);
+        $this->assertSame(7, (int) $actual[0]['dollared']);
+    }
+
+    public function testSelectUserVariableBesideColumn()
+    {
+        $this->pdo->exec("SET @wanted.name = 'Clara'");
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_employee.name'])
+            ->from('test_employee')
+            ->where('test_employee.name = @wanted.name');
+
+        // the column is quoted, the variable beside it is not
+        $this->assertStatementContains(
+            '<<test_employee>>.<<name>> = @wanted.name',
+            $select
+        );
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(['Clara'], array_column($actual, 'name'));
+    }
+
     public function testInsertIgnore()
     {
         $insert = $this->query_factory->newInsert()
             ->ignore()
             ->into('test_dept')
             ->cols(['id' => 1, 'name' => 'Duplicate']);
+
+        $this->assertStatementContains('INSERT IGNORE INTO <<test_dept>>', $insert);
 
         $this->assertSame(0, $this->exec($insert));
 
@@ -89,6 +173,8 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
             ->cols(['id' => 1, 'name' => 'Ignored'])
             ->onDuplicateKeyUpdateCol('name', 'Updated');
 
+        $this->assertStatementContains('ON DUPLICATE KEY UPDATE', $insert);
+
         $this->exec($insert);
 
         $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
@@ -101,6 +187,8 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
             ->orReplace()
             ->into('test_dept')
             ->cols(['id' => 1, 'name' => 'Replaced']);
+
+        $this->assertStatementContains('REPLACE INTO <<test_dept>>', $insert);
 
         $this->exec($insert);
 
@@ -117,6 +205,8 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
             ->orderBy(['salary DESC'])
             ->limit(1);
 
+        $this->assertStatementContains('LIMIT 1', $update);
+
         $this->assertSame(1, $this->exec($update));
 
         $sth = $this->pdo->query('SELECT salary FROM test_employee WHERE seq = 4');
@@ -130,6 +220,8 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
             ->where('salary > :min', ['min' => 0])
             ->orderBy(['salary DESC'])
             ->limit(1);
+
+        $this->assertStatementContains('LIMIT 1', $delete);
 
         $this->assertSame(1, $this->exec($delete));
         $this->assertSame(['Anna', 'Betty', 'Clara'], $this->fetchNames());

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -77,6 +77,8 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
             ->cols(['name' => 'Edna', 'dept_id' => 1, 'salary' => 500, 'seq' => 5])
             ->returning(['id', 'name']);
 
+        $this->assertStatementContains('RETURNING', $insert);
+
         $row = $this->fetchAll($insert)[0];
         $this->assertSame('Edna', $row['name']);
         $this->assertGreaterThan(0, (int) $row['id']);
@@ -90,6 +92,8 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
             ->where('seq = :seq', ['seq' => 1])
             ->returning(['name', 'salary']);
 
+        $this->assertStatementContains('RETURNING', $update);
+
         $rows = $this->fetchAll($update);
         $this->assertSame('Anna', $rows[0]['name']);
         $this->assertSame(999, (int) $rows[0]['salary']);
@@ -102,6 +106,8 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
             ->where('salary >= :min', ['min' => 300])
             ->returning(['name']);
 
+        $this->assertStatementContains('RETURNING', $delete);
+
         $rows = $this->fetchAll($delete);
         $names = array_column($rows, 'name');
         sort($names);
@@ -113,6 +119,8 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
         $insert = $this->query_factory->newInsert()
             ->into('test_employee')
             ->cols(['name' => 'Edna', 'dept_id' => 1, 'salary' => 500, 'seq' => 5]);
+
+        $this->assertStatementContains('INSERT INTO <<test_employee>>', $insert);
 
         $this->exec($insert);
 

--- a/tests/Integration/SqliteIntegrationTest.php
+++ b/tests/Integration/SqliteIntegrationTest.php
@@ -65,6 +65,8 @@ class SqliteIntegrationTest extends AbstractIntegrationTest
             ->into('test_dept')
             ->cols(['id' => 1, 'name' => 'Duplicate']);
 
+        $this->assertStatementContains('INSERT OR IGNORE INTO <<test_dept>>', $insert);
+
         $this->assertSame(0, $this->exec($insert));
 
         $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
@@ -77,6 +79,8 @@ class SqliteIntegrationTest extends AbstractIntegrationTest
             ->orReplace()
             ->into('test_dept')
             ->cols(['id' => 1, 'name' => 'Replaced']);
+
+        $this->assertStatementContains('INSERT OR REPLACE INTO <<test_dept>>', $insert);
 
         $this->exec($insert);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SQL generation now preserves MySQL session, global, and user variables—including variables containing dots—without incorrectly quoting or splitting them.
  - Real table and column references adjacent to variables continue to be quoted correctly.
  - Variable expressions remain intact across selection, filtering, grouping, sorting, and other query clauses.

- **Documentation**
  - Added clearer guidance and examples for using `@`-prefixed variables, including timezone conversion expressions.

- **Tests**
  - Expanded coverage across MySQL, PostgreSQL, SQLite, and general SQL generation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->