### PR TITLE
Add SQL Server integration tests and a CI service container

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,6 +121,96 @@ jobs:
           DB_PGSQL_PASS: postgres
         run: ./vendor/bin/phpunit --testsuite integration
 
+  integration-sqlsrv:
+    name: Integration (SQL Server ${{ matrix.mssql }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        mssql: ['2022-latest', '2019-latest']
+
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:${{ matrix.mssql }}
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: 'Aura!Passw0rd'
+          SA_PASSWORD: 'Aura!Passw0rd'
+        ports:
+          - 1433:1433
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo_sqlsrv, pdo_sqlite
+          coverage: none
+          tools: composer:v2
+
+      # setup-php installs the pdo_sqlsrv extension but not the ODBC driver it
+      # talks to, and the runner image does not ship one; without this the
+      # first connection fails with SQLSTATE[IMSSP]
+      - name: Install the Microsoft ODBC driver
+        run: |
+          # the repo's own package, so that the keyring lands where the
+          # generated sources list expects it (/usr/share/keyrings)
+          curl -fsSL -O "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt-get update
+          sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc
+          # fail loudly here rather than at the first connection
+          odbcinst -q -d | grep -q 'ODBC Driver 18 for SQL Server'
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      # the mssql image ships no health-check command that is stable across
+      # versions, so poll the port from PHP instead of using --health-cmd
+      - name: Wait for SQL Server and create the database
+        env:
+          DB_SQLSRV_PASS: 'Aura!Passw0rd'
+        run: |
+          cat > /tmp/wait-for-sqlsrv.php <<'PHP'
+          <?php
+          $dsn = 'sqlsrv:Server=127.0.0.1,1433;TrustServerCertificate=1';
+          $last = 'no attempt made';
+          for ($i = 1; $i <= 90; $i++) {
+              try {
+                  $pdo = new PDO($dsn, 'sa', getenv('DB_SQLSRV_PASS'));
+                  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                  $pdo->exec("IF DB_ID('aura_sqlquery_test') IS NULL CREATE DATABASE aura_sqlquery_test");
+                  echo "SQL Server ready after {$i} attempt(s)\n";
+                  exit(0);
+              } catch (Exception $e) {
+                  $last = $e->getMessage();
+                  sleep(2);
+              }
+          }
+          fwrite(STDERR, "SQL Server never became ready: {$last}\n");
+          exit(1);
+          PHP
+          php /tmp/wait-for-sqlsrv.php
+
+      # --fail-on-skipped, so that a missing driver or an unreachable server
+      # fails the job instead of quietly skipping every test in it
+      - name: Run SQL Server integration tests
+        env:
+          DB_SQLSRV_DSN: 'sqlsrv:Server=127.0.0.1,1433;Database=aura_sqlquery_test;TrustServerCertificate=1'
+          DB_SQLSRV_USER: sa
+          DB_SQLSRV_PASS: 'Aura!Passw0rd'
+        run: ./vendor/bin/phpunit tests/Integration/SqlsrvIntegrationTest.php --fail-on-skipped
+
   phpstan:
     name: Static Analysis
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@
   yoast/phpunit-polyfills).
 
 - [CHG] Added an `integration` test suite that executes the generated SQL
-  against real MySQL and PostgreSQL servers (in addition to SQLite), so
-  dialect output is proven to run and not merely to match a string. CI
-  runs it against MySQL 8.4/8.0 and Postgres 17/15 service containers.
-  Locally the MySQL and Postgres cases skip unless `DB_MYSQL_DSN` /
-  `DB_PGSQL_DSN` are set; see CONTRIBUTING.md.
+  against real MySQL, PostgreSQL and SQL Server servers (in addition to
+  SQLite), so dialect output is proven to run and not merely to match a
+  string. CI runs it against MySQL 8.4/8.0, Postgres 17/15 and SQL Server
+  2022/2019 service containers. Locally those cases skip unless
+  `DB_MYSQL_DSN` / `DB_PGSQL_DSN` / `DB_SQLSRV_DSN` are set; see
+  CONTRIBUTING.md.
 
 - [FIX] An Insert with no columns no longer throws a TypeError; it now
   renders `INSERT INTO t DEFAULT VALUES` (or `INSERT INTO t () VALUES ()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,21 +17,27 @@ That runs two suites: `unit` (string assertions on the generated SQL) and
 `integration` (the generated SQL executed against a real server).
 
 The integration suite always runs its SQLite cases, using an in-memory
-database. The MySQL and PostgreSQL cases are skipped unless you point them at
-a server with an existing, throwaway database:
+database. The MySQL, PostgreSQL and SQL Server cases are skipped unless you
+point them at a server with an existing, throwaway database:
 
 ```sh
 DB_MYSQL_DSN='mysql:host=127.0.0.1;port=3306;dbname=aura_sqlquery_test' \
 DB_MYSQL_USER=root DB_MYSQL_PASS=root \
 DB_PGSQL_DSN='pgsql:host=127.0.0.1;port=5432;dbname=aura_sqlquery_test' \
 DB_PGSQL_USER=postgres DB_PGSQL_PASS=postgres \
+DB_SQLSRV_DSN='sqlsrv:Server=127.0.0.1,1433;Database=aura_sqlquery_test;TrustServerCertificate=1' \
+DB_SQLSRV_USER=sa DB_SQLSRV_PASS='Aura!Passw0rd' \
 ./vendor/bin/phpunit --testsuite integration
 ```
+
+The SQL Server cases need the `pdo_sqlsrv` extension, which is not packaged
+for every platform; on a machine without it they skip like any other missing
+server, and CI is the reference environment for that dialect.
 
 The database itself must already exist; the tests create their own `test_*`
 tables in it once per test class and drop them again afterwards, so the
 database is left as it was found. Each individual test runs inside a
 transaction that is rolled back, so no test data survives either. Even so, do
 not point the suite at a database you care about — it drops any table whose
-name it wants to use. CI runs the same suite against MySQL and Postgres
-service containers.
+name it wants to use. CI runs the same suite against MySQL, Postgres and SQL
+Server service containers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,22 @@ DB_SQLSRV_USER=sa DB_SQLSRV_PASS='Aura!Passw0rd' \
 ./vendor/bin/phpunit --testsuite integration
 ```
 
-The SQL Server cases need the `pdo_sqlsrv` extension, which is not packaged
-for every platform; on a machine without it they skip like any other missing
-server, and CI is the reference environment for that dialect.
+The SQL Server cases need two pieces, not one: the `pdo_sqlsrv` extension, and
+Microsoft's ODBC Driver 18 for SQL Server, which the extension talks through.
+Neither is packaged for every platform, and installing the extension alone is
+not enough — connecting without the driver fails with
+`SQLSTATE[IMSSP]: This extension requires the Microsoft ODBC Driver for SQL
+Server`. See Microsoft's [install instructions][odbc]; CI installs
+`msodbcsql18` from `packages.microsoft.com` and is the reference environment
+for this dialect.
+
+[odbc]: https://learn.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server
+
+A test class skips only when its `DB_*_DSN` is unset. Once a DSN is set, the
+tests try to connect for real, and anything wrong from there on — a missing
+extension, a missing ODBC driver, an unreachable server, a bad password —
+surfaces as an error, not a skip. That is deliberate: a configured dialect
+that quietly skipped would look like a passing run while testing nothing.
 
 The database itself must already exist; the tests create their own `test_*`
 tables in it once per test class and drop them again afterwards, so the

--- a/tests/Integration/SqlsrvIntegrationTest.php
+++ b/tests/Integration/SqlsrvIntegrationTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Aura\SqlQuery\Integration;
+
+use PDO;
+
+/**
+ *
+ * Runs against a real SQL Server. Set DB_SQLSRV_DSN (plus DB_SQLSRV_USER and
+ * DB_SQLSRV_PASS as needed) to enable; the test is skipped when they are
+ * absent. CI runs it against a mssql/server service container; there is no
+ * SQL Server build for every developer platform, so locally it usually skips.
+ *
+ */
+class SqlsrvIntegrationTest extends AbstractIntegrationTest
+{
+    protected string $db_type = 'sqlsrv';
+
+    protected function newPdo(): PDO
+    {
+        $dsn = getenv('DB_SQLSRV_DSN');
+        if ($dsn === false || $dsn === '') {
+            $this->markTestSkipped('DB_SQLSRV_DSN is not set.');
+        }
+
+        $user = getenv('DB_SQLSRV_USER') ?: null;
+        $pass = getenv('DB_SQLSRV_PASS') ?: null;
+
+        return new PDO($dsn, $user, $pass);
+    }
+
+    protected function getCreateTables(): array
+    {
+        return [
+            'CREATE TABLE test_dept (
+                id   INT PRIMARY KEY,
+                name VARCHAR(50) NOT NULL
+            )',
+            'CREATE TABLE test_employee (
+                id      INT IDENTITY(1,1) PRIMARY KEY,
+                name    VARCHAR(50) NOT NULL,
+                dept_id INT NULL,
+                salary  INT NOT NULL,
+                seq     INT NOT NULL
+            )',
+            "CREATE TABLE test_defaults (
+                id   INT IDENTITY(1,1) PRIMARY KEY,
+                name VARCHAR(50) NOT NULL DEFAULT 'anon'
+            )",
+            'CREATE TABLE test_isolate (
+                id               INT PRIMARY KEY,
+                [species.genus]  VARCHAR(50) NOT NULL,
+                [species.name]   VARCHAR(50) NOT NULL
+            )',
+            'CREATE TABLE test_compound (
+                id                INT PRIMARY KEY,
+                isolate_id        INT NOT NULL,
+                [compound.group]  VARCHAR(50) NOT NULL,
+                [compound.name]   VARCHAR(50) NOT NULL
+            )',
+        ];
+    }
+
+    protected function castToChar(string $expr): string
+    {
+        return "CAST({$expr} AS VARCHAR(50))";
+    }
+
+    protected function inCsv(string $col, string $param): string
+    {
+        // SQL Server has no find_in_set(); STRING_SPLIT() is the equivalent,
+        // and takes the string to split as a parameter
+        return "{$col} IN (SELECT value FROM STRING_SPLIT({$param}, ','))";
+    }
+}

--- a/tests/Integration/SqlsrvIntegrationTest.php
+++ b/tests/Integration/SqlsrvIntegrationTest.php
@@ -6,9 +6,17 @@ use PDO;
 /**
  *
  * Runs against a real SQL Server. Set DB_SQLSRV_DSN (plus DB_SQLSRV_USER and
- * DB_SQLSRV_PASS as needed) to enable; the test is skipped when they are
- * absent. CI runs it against a mssql/server service container; there is no
- * SQL Server build for every developer platform, so locally it usually skips.
+ * DB_SQLSRV_PASS as needed) to enable; the tests skip when DB_SQLSRV_DSN is
+ * unset, and only then.
+ *
+ * Connecting needs both the pdo_sqlsrv extension and Microsoft's ODBC Driver
+ * 18 for SQL Server behind it. With the DSN set but either piece missing,
+ * newPdo() does not skip: new PDO() throws, and every test in the class
+ * errors — SQLSTATE[IMSSP] names the missing ODBC driver specifically. That
+ * is on purpose, so a configured dialect cannot silently test nothing.
+ *
+ * CI runs this against a mssql/server service container and installs the
+ * driver itself; see CONTRIBUTING.md for a local setup.
  *
  */
 class SqlsrvIntegrationTest extends AbstractIntegrationTest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL Server integration test coverage alongside MySQL and PostgreSQL.
  * CI now runs SQL Server tests against versions 2022 and 2019.

* **Documentation**
  * Updated testing guidance with SQL Server configuration requirements, environment variables, and driver prerequisites.
  * Updated the changelog to reflect expanded database coverage and supported SQL Server test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->