### PR TITLE
Do not treat a space inside parentheses as an alias separator

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -270,16 +270,34 @@ class Select extends AbstractQuery implements SelectInterface
     {
         $parts = explode(' ', $spec);
         $count = count($parts);
-        if ($count == 2) {
+        if ($count == 2 && $this->isCompleteExpr($parts[0])) {
             // "col alias"
             $this->cols[$parts[1]] = $parts[0];
-        } elseif ($count == 3 && strtoupper($parts[1]) == 'AS') {
+        } elseif ($count == 3 && strtoupper($parts[1]) == 'AS' && $this->isCompleteExpr($parts[0])) {
             // "col AS alias"
             $this->cols[$parts[2]] = $parts[0];
         } else {
             // no recognized alias
             $this->cols[] = $spec;
         }
+    }
+
+    /**
+     *
+     * Is this a whole column expression, rather than the head of one that a
+     * space inside parentheses has cut in two?
+     *
+     * issue #226: 'COUNT(DISTINCT t.c)' is two space-separated words, but
+     * 'COUNT(DISTINCT' is not a column name and 't.c)' is not an alias.
+     *
+     * @param string $expr The leading word of a column specification.
+     *
+     * @return bool
+     *
+     */
+    protected function isCompleteExpr($expr)
+    {
+        return substr_count($expr, '(') === substr_count($expr, ')');
     }
 
     /**

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -309,6 +309,16 @@ class Select extends AbstractQuery implements SelectInterface
             $char = $expr[$i];
 
             if ($quote !== null) {
+                // a backslash escapes the next character on MySQL; on
+                // PostgreSQL, with standard_conforming_strings on, it does
+                // not. Either way an unterminated literal returns false and
+                // the caller keeps the spec whole, so the cost of guessing
+                // wrong is a missed alias, never malformed SQL.
+                if ($char === '\\' && isset($expr[$i + 1])) {
+                    $i ++;
+                    continue;
+                }
+
                 // a doubled quote inside a literal is an escaped one, not
                 // the end of the literal
                 if ($char === $quote && isset($expr[$i + 1]) && $expr[$i + 1] === $quote) {

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -290,6 +290,10 @@ class Select extends AbstractQuery implements SelectInterface
      * issue #226: 'COUNT(DISTINCT t.c)' is two space-separated words, but
      * 'COUNT(DISTINCT' is not a column name and 't.c)' is not an alias.
      *
+     * Parentheses inside a string literal are data, not syntax, so the scan
+     * skips over literals: "CONCAT('(',t.c) alias" is complete, and its
+     * alias is still an alias.
+     *
      * @param string $expr The leading word of a column specification.
      *
      * @return bool
@@ -297,7 +301,38 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function isCompleteExpr($expr)
     {
-        return substr_count($expr, '(') === substr_count($expr, ')');
+        $depth = 0;
+        $quote = null;
+        $len = strlen($expr);
+
+        for ($i = 0; $i < $len; $i ++) {
+            $char = $expr[$i];
+
+            if ($quote !== null) {
+                // a doubled quote inside a literal is an escaped one, not
+                // the end of the literal
+                if ($char === $quote && isset($expr[$i + 1]) && $expr[$i + 1] === $quote) {
+                    $i ++;
+                } elseif ($char === $quote) {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ($char === "'" || $char === '"') {
+                $quote = $char;
+            } elseif ($char === '(') {
+                $depth ++;
+            } elseif ($char === ')') {
+                $depth --;
+                // a close with nothing open before it is not a column name
+                if ($depth < 0) {
+                    return false;
+                }
+            }
+        }
+
+        return $depth === 0 && $quote === null;
     }
 
     /**

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -885,12 +885,17 @@ class SelectTest extends AbstractQueryTest
             "CONCAT('(',t1.c3,')') AS wrapped",
             // a doubled quote is an escaped one, not the end of the literal
             "CONCAT('it''s(',t1.c4) escaped",
+            // as is a backslashed one, on the dialects that escape that way.
+            // the quoter's own literal scan does not follow backslash
+            // escapes, so t1.c5 is left unquoted; the alias is still an alias
+            "CONCAT('it\\'s(',t1.c5) backslashed",
         ));
 
         $this->assertTrue($this->query->hasCol('opener'));
         $this->assertTrue($this->query->hasCol('closer'));
         $this->assertTrue($this->query->hasCol('wrapped'));
         $this->assertTrue($this->query->hasCol('escaped'));
+        $this->assertTrue($this->query->hasCol('backslashed'));
 
         $actual = $this->query->__toString();
         $expect = "
@@ -898,7 +903,8 @@ class SelectTest extends AbstractQueryTest
                 CONCAT('(',<<t1>>.<<c1>>) AS <<opener>>,
                 CONCAT(<<t1>>.<<c2>>,')') AS <<closer>>,
                 CONCAT('(',<<t1>>.<<c3>>,')') AS <<wrapped>>,
-                CONCAT('it''s(',<<t1>>.<<c4>>) AS <<escaped>>
+                CONCAT('it''s(',<<t1>>.<<c4>>) AS <<escaped>>,
+                CONCAT('it\\'s(',t1.c5) AS <<backslashed>>
         ";
         $this->assertSameSql($expect, $actual);
     }

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -822,6 +822,57 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    /**
+     * issue #226: a space inside parentheses is not an alias separator.
+     * 'COUNT(DISTINCT t1.c1)' is two space-separated tokens, but the first
+     * is not a column name and the second is not an alias.
+     */
+    public function testAddColWithSpaceInsideParens()
+    {
+        $this->query->cols(array(
+            'COUNT(DISTINCT t1.c1)',
+            'COUNT(DISTINCT c2)',
+            'COUNT(DISTINCT t1.c3) AS c3_count',
+            // an implicit alias on a multi-word expression is passed through
+            // as the caller wrote it: still valid SQL, just not quoted
+            'COUNT(DISTINCT t1.c4) c4_count',
+            'convert_tz(t1.open_from, t1.time_zone, @@session.time_zone) open_now',
+        ));
+
+        $actual = $this->query->__toString();
+        $expect = '
+            SELECT
+                COUNT(DISTINCT <<t1>>.<<c1>>),
+                COUNT(DISTINCT c2),
+                COUNT(DISTINCT <<t1>>.<<c3>>) AS <<c3_count>>,
+                COUNT(DISTINCT <<t1>>.<<c4>>) c4_count,
+                convert_tz(<<t1>>.<<open_from>>, <<t1>>.<<time_zone>>, @@session.time_zone) open_now
+        ';
+        $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     * A balanced call is still a column name, so the two-token alias form
+     * keeps working for it.
+     */
+    public function testAddColWithAliasAfterBalancedParens()
+    {
+        $this->query->cols(array(
+            'COUNT(*) tally',
+            'COUNT(*) AS total',
+            'MAX(t1.c1) hi',
+        ));
+
+        $actual = $this->query->__toString();
+        $expect = '
+            SELECT
+                COUNT(*) AS <<tally>>,
+                COUNT(*) AS <<total>>,
+                MAX(<<t1>>.<<c1>>) AS <<hi>>
+        ';
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testGetCols()
     {
         $this->query->cols(array('valueBar' => 'aliasFoo'));

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -873,6 +873,54 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    /**
+     * A parenthesis inside a string literal is data, not syntax, so it must
+     * not make the expression look unbalanced: the alias is still an alias.
+     */
+    public function testAddColWithAliasAndParenInsideLiteral()
+    {
+        $this->query->cols(array(
+            "CONCAT('(',t1.c1) opener",
+            "CONCAT(t1.c2,')') closer",
+            "CONCAT('(',t1.c3,')') AS wrapped",
+            // a doubled quote is an escaped one, not the end of the literal
+            "CONCAT('it''s(',t1.c4) escaped",
+        ));
+
+        $this->assertTrue($this->query->hasCol('opener'));
+        $this->assertTrue($this->query->hasCol('closer'));
+        $this->assertTrue($this->query->hasCol('wrapped'));
+        $this->assertTrue($this->query->hasCol('escaped'));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            SELECT
+                CONCAT('(',<<t1>>.<<c1>>) AS <<opener>>,
+                CONCAT(<<t1>>.<<c2>>,')') AS <<closer>>,
+                CONCAT('(',<<t1>>.<<c3>>,')') AS <<wrapped>>,
+                CONCAT('it''s(',<<t1>>.<<c4>>) AS <<escaped>>
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     * A closing parenthesis with nothing open before it is not a column
+     * name, so the two-word form is not an alias either.
+     */
+    public function testAddColWithUnopenedParen()
+    {
+        $this->query->cols(array('t1.c1) alias'));
+
+        $this->assertFalse($this->query->hasCol('alias'));
+
+        $actual = $this->query->__toString();
+        $expect = '
+            SELECT
+                <<t1>>.<<c1>>) alias
+        ';
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testGetCols()
     {
         $this->query->cols(array('valueBar' => 'aliasFoo'));

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -56,6 +56,16 @@ abstract class AbstractIntegrationTest extends TestCase
      */
     abstract protected function inCsv(string $col, string $param): string;
 
+    /**
+     * Returns the pagination clause this dialect renders for a query limited
+     * to 2 rows starting at offset 1. Most dialects spell it LIMIT/OFFSET;
+     * SQL Server has no LIMIT and overrides this.
+     */
+    protected function getLimitOffsetSql(): string
+    {
+        return 'LIMIT 2 OFFSET 1';
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -286,7 +296,7 @@ abstract class AbstractIntegrationTest extends TestCase
             ->limit(2)
             ->offset(1);
 
-        $this->assertStatementContains('LIMIT 2 OFFSET 1', $select);
+        $this->assertStatementContains($this->getLimitOffsetSql(), $select);
 
         $actual = $this->fetchAll($select);
         $this->assertSame(['Clara', 'Betty'], array_column($actual, 'name'));

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -451,6 +451,32 @@ abstract class AbstractIntegrationTest extends TestCase
         $this->assertSame('100', (string) $actual[0]['salary_text']);
     }
 
+    public function testSelectCountDistinct()
+    {
+        // issue #226: a space inside parentheses is not an alias separator.
+        // 'COUNT(DISTINCT x)' used to render as 'COUNT(DISTINCT AS x)',
+        // which is a syntax error on every dialect, so this only passes if
+        // the statement actually executes.
+        $select = $this->query_factory->newSelect()
+            ->cols([
+                'COUNT(DISTINCT test_employee.dept_id)',
+                // a balanced call is still a column name, so the two-word
+                // form keeps working as an alias
+                'COUNT(*) row_count',
+            ])
+            ->from('test_employee');
+
+        $this->assertStatementContains(
+            'COUNT(DISTINCT <<test_employee>>.<<dept_id>>)',
+            $select
+        );
+        $this->assertStatementContains('COUNT(*) AS <<row_count>>', $select);
+
+        $row = $this->fetchAll($select)[0];
+        $this->assertSame(2, (int) array_values($row)[0]);
+        $this->assertSame(4, (int) $row['row_count']);
+    }
+
     public function testInsert()
     {
         $insert = $this->query_factory->newInsert()

--- a/tests/Integration/SqlsrvIntegrationTest.php
+++ b/tests/Integration/SqlsrvIntegrationTest.php
@@ -79,4 +79,11 @@ class SqlsrvIntegrationTest extends AbstractIntegrationTest
         // and takes the string to split as a parameter
         return "{$col} IN (SELECT value FROM STRING_SPLIT({$param}, ','))";
     }
+
+    protected function getLimitOffsetSql(): string
+    {
+        // SQL Server has no LIMIT; it pages with the ANSI OFFSET/FETCH form,
+        // which is why the shared expectation cannot be used as-is
+        return 'OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY';
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of column specifications so `expr alias` isn’t misdetected when spaces appear inside balanced parentheses (e.g., `COUNT(DISTINCT ...)`).
  * Avoided treating invalid/unbalanced parenthesis patterns as alias separators.
  * Preserved correct handling of explicit aliases, including `COUNT(*) alias` and `AS`-based aliases, and ignored parentheses inside string literals.
* **Tests**
  * Added unit and integration coverage for the above scenarios, including exact SQL generation checks and a `COUNT(DISTINCT ...)` runtime verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->