### PR TITLE
Add Postgres LATERAL joins (port of #184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@
   `cast(col as varchar)`) as a column alias, which produced misquoted
   SQL. Fixes #157.
 
+- [ADD] Pgsql\Select gains `lateralJoinSubSelect()`, rendering
+  `JOIN LATERAL` against an aliased sub-select so the sub-select can
+  reference columns from the tables to its left. The signature matches
+  `joinSubSelect()`. PostgreSQL requires an `ON` clause on every LATERAL
+  join except CROSS and NATURAL, so when no condition is given for the
+  other join types, `ON true` is rendered. Thanks to @golgote for the
+  original implementation in #184.
+
 - [ADD] Insert-ignore is now spelled `ignore()` on every dialect that
   supports it: Mysql\Insert renders `INSERT IGNORE` and Sqlite\Insert
   renders `INSERT OR IGNORE` (both as before); Pgsql\Insert gains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,11 @@
   reference columns from the tables to its left. The signature matches
   `joinSubSelect()`. PostgreSQL requires an `ON` clause on every LATERAL
   join except CROSS and NATURAL, so when no condition is given for the
-  other join types, `ON true` is rendered. Thanks to @golgote for the
-  original implementation in #184.
+  other join types, `ON true` is rendered; conversely, passing a condition
+  to a CROSS or NATURAL join now throws
+  Aura\SqlQuery\Exception\LogicException, since PostgreSQL rejects an `ON`
+  clause there and the statement could only fail at execute time. Thanks
+  to @golgote for the original implementation in #184.
 
 - [ADD] Insert-ignore is now spelled `ignore()` on every dialect that
   supports it: Mysql\Insert renders `INSERT IGNORE` and Sqlite\Insert

--- a/docs/pgsql.md
+++ b/docs/pgsql.md
@@ -2,6 +2,49 @@
 
 These 'pgsql' query objects have additional PostgreSQL-specific behaviors.
 
+## SELECT
+
+- `lateralJoinSubSelect()` to add a `JOIN LATERAL` against an aliased
+  sub-select
+
+A `LATERAL` join lets the sub-select reference columns from the tables to its
+left, which is how you express "the top row per group":
+
+```php
+$select = $queryFactory->newSelect();
+$select
+    ->cols(['dept.name', 'top.name AS top_earner'])
+    ->from('dept')
+    ->lateralJoinSubSelect(
+        'left',
+        'SELECT name FROM employee
+         WHERE employee.dept_id = dept.id
+         ORDER BY salary DESC LIMIT 1',
+        'top'
+    );
+```
+
+The signature matches `joinSubSelect()`: the join type, the sub-select (a string
+or another _Select_ object), the alias, an optional condition, and optional bind
+values.
+
+PostgreSQL requires an `ON` clause on every `LATERAL` join except `CROSS` and
+`NATURAL`. When you omit the condition for the other join types, `ON true` is
+added for you, so the example above renders as:
+
+```sql
+SELECT
+    "dept"."name",
+    "top"."name" AS "top_earner"
+FROM
+    "dept"
+        LEFT JOIN LATERAL (
+            SELECT name FROM employee
+            WHERE employee.dept_id = dept.id
+            ORDER BY salary DESC LIMIT 1
+        ) "top" ON true
+```
+
 ## INSERT
 
 - `returning()` to add a `RETURNING` clause

--- a/docs/pgsql.md
+++ b/docs/pgsql.md
@@ -29,8 +29,8 @@ or another _Select_ object), the alias, an optional condition, and optional bind
 values.
 
 PostgreSQL requires an `ON` clause on every `LATERAL` join except `CROSS` and
-`NATURAL`. When you omit the condition for the other join types, `ON true` is
-added for you, so the example above renders as:
+`NATURAL`, which reject one. When you omit the condition for the other join
+types, `ON true` is added for you, so the example above renders as:
 
 ```sql
 SELECT
@@ -44,6 +44,10 @@ FROM
             ORDER BY salary DESC LIMIT 1
         ) "top" ON true
 ```
+
+Passing a condition to a `CROSS` or `NATURAL` lateral join throws
+`Aura\SqlQuery\Exception\LogicException`, because PostgreSQL rejects an `ON`
+clause on those and the statement could only fail at execute time.
 
 ## INSERT
 

--- a/src/Pgsql/Select.php
+++ b/src/Pgsql/Select.php
@@ -19,4 +19,37 @@ use Aura\SqlQuery\Common;
  */
 class Select extends Common\Select
 {
+    /**
+     *
+     * Adds a LATERAL JOIN to an aliased subselect and columns to the query.
+     *
+     * @param string $join The join type: inner, left, natural, etc.
+     *
+     * @param string|Select $spec If a Select
+     * object, use as the sub-select; if a string, the sub-select
+     * command string.
+     *
+     * @param string $name The alias name for the sub-select.
+     *
+     * @param string $cond Join on this condition.
+     *
+     * @param array $bind Values to bind to ?-placeholders in the condition.
+     *
+     * @return $this
+     *
+     * @throws Exception
+     *
+     */
+    public function lateralJoinSubSelect($join, $spec, $name, $cond = null, array $bind = array())
+    {
+        $join = strtoupper(ltrim("$join JOIN LATERAL"));
+        $this->addTableRef("$join (SELECT ...) AS", $name);
+
+        $spec = $this->subSelect($spec, '            ');
+        $name = $this->quoter->quoteName($name);
+        $cond = $this->fixJoinCondition($cond, $bind);
+
+        $text = rtrim("$join ($spec        ) AS $name $cond");
+        return $this->addJoin('        ' . $text);
+    }
 }

--- a/src/Pgsql/Select.php
+++ b/src/Pgsql/Select.php
@@ -49,7 +49,7 @@ class Select extends Common\Select
         $name = $this->quoter->quoteName($name);
         $cond = $this->fixJoinCondition($cond, $bind);
 
-        $text = rtrim("$join ($spec        ) AS $name $cond");
+        $text = rtrim("$join ($spec        ) $name $cond");
         return $this->addJoin('        ' . $text);
     }
 }

--- a/src/Pgsql/Select.php
+++ b/src/Pgsql/Select.php
@@ -31,7 +31,9 @@ class Select extends Common\Select
      *
      * @param string $name The alias name for the sub-select.
      *
-     * @param string $cond Join on this condition.
+     * @param string $cond Join on this condition. Postgres requires an ON
+     * clause on every LATERAL join except CROSS and NATURAL, so when no
+     * condition is given for those other join types, "ON true" is used.
      *
      * @param array $bind Values to bind to ?-placeholders in the condition.
      *
@@ -40,16 +42,35 @@ class Select extends Common\Select
      * @throws Exception
      *
      */
-    public function lateralJoinSubSelect($join, $spec, $name, $cond = null, array $bind = array())
+    public function lateralJoinSubSelect($join, $spec, $name, $cond = null, array $bind = [])
     {
         $join = strtoupper(ltrim("$join JOIN LATERAL"));
-        $this->addTableRef("$join (SELECT ...) AS", $name);
+        $this->addTableRef("$join (SELECT ...)", $name);
 
         $spec = $this->subSelect($spec, '            ');
         $name = $this->quoter->quoteName($name);
         $cond = $this->fixJoinCondition($cond, $bind);
 
+        if ($cond === '' && ! $this->isUnconditionalJoin($join)) {
+            $cond = 'ON true';
+        }
+
         $text = rtrim("$join ($spec        ) $name $cond");
         return $this->addJoin('        ' . $text);
+    }
+
+    /**
+     *
+     * Does this join type forbid an ON clause?
+     *
+     * @param string $join The upper-cased join clause.
+     *
+     * @return bool
+     *
+     */
+    protected function isUnconditionalJoin($join)
+    {
+        return str_starts_with($join, 'CROSS ')
+            || str_starts_with($join, 'NATURAL ');
     }
 }

--- a/src/Pgsql/Select.php
+++ b/src/Pgsql/Select.php
@@ -9,6 +9,7 @@
 namespace Aura\SqlQuery\Pgsql;
 
 use Aura\SqlQuery\Common;
+use Aura\SqlQuery\Exception;
 
 /**
  *
@@ -45,6 +46,13 @@ class Select extends Common\Select
     public function lateralJoinSubSelect($join, $spec, $name, $cond = null, array $bind = [])
     {
         $join = strtoupper(ltrim("$join JOIN LATERAL"));
+
+        if ($cond && $this->joinForbidsCondition($join)) {
+            throw new Exception\LogicException(
+                "A $join cannot take a condition."
+            );
+        }
+
         $this->addTableRef("$join (SELECT ...)", $name);
 
         $spec = $this->subSelect($spec, '            ');
@@ -61,7 +69,8 @@ class Select extends Common\Select
 
     /**
      *
-     * Does this join type forbid an ON clause?
+     * Does this join type render without an ON clause when no condition is
+     * given?
      *
      * @param string $join The upper-cased join clause.
      *
@@ -69,6 +78,27 @@ class Select extends Common\Select
      *
      */
     protected function isUnconditionalJoin($join)
+    {
+        return str_starts_with($join, 'CROSS ')
+            || str_starts_with($join, 'NATURAL ');
+    }
+
+    /**
+     *
+     * Does this join type reject an ON clause outright, so that supplying a
+     * condition can only produce a syntax error?
+     *
+     * PostgreSQL rejects ON on both CROSS and NATURAL joins. Other dialects
+     * differ -- MySQL accepts it on CROSS, where CROSS and INNER are
+     * synonyms -- so this is separate from isUnconditionalJoin() and meant to
+     * be overridden.
+     *
+     * @param string $join The upper-cased join clause.
+     *
+     * @return bool
+     *
+     */
+    protected function joinForbidsCondition($join)
     {
         return str_starts_with($join, 'CROSS ')
             || str_starts_with($join, 'NATURAL ');

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -114,6 +114,91 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
         $this->assertSame(['Clara', 'Donna'], $names);
     }
 
+    public function testLateralJoinSubSelect()
+    {
+        // the top earner in each department
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_dept.name AS dept_name', 'top.name AS employee_name'])
+            ->from('test_dept')
+            ->lateralJoinSubSelect(
+                'left',
+                'SELECT name, salary FROM test_employee
+                 WHERE test_employee.dept_id = test_dept.id
+                 ORDER BY salary DESC LIMIT 1',
+                'top',
+                'true'
+            )
+            ->orderBy(['test_dept.name']);
+
+        $this->assertStatementContains('LEFT JOIN LATERAL', $select);
+
+        $rows = $this->fetchAll($select);
+        $this->assertSame(
+            [
+                ['dept_name' => 'Engineering', 'employee_name' => 'Betty'],
+                ['dept_name' => 'Sales', 'employee_name' => 'Donna'],
+            ],
+            array_map(
+                fn ($row) => [
+                    'dept_name' => $row['dept_name'],
+                    'employee_name' => $row['employee_name'],
+                ],
+                $rows
+            )
+        );
+    }
+
+    /**
+     * A LATERAL join with no condition has to emit "ON true" or Postgres
+     * rejects the statement outright.
+     */
+    public function testLateralJoinSubSelect_noCondition()
+    {
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_dept.name AS dept_name', 'top.name AS employee_name'])
+            ->from('test_dept')
+            ->lateralJoinSubSelect(
+                'left',
+                'SELECT name FROM test_employee
+                 WHERE test_employee.dept_id = test_dept.id
+                 ORDER BY salary DESC LIMIT 1',
+                'top'
+            )
+            ->orderBy(['test_dept.name']);
+
+        $this->assertStatementContains('ON true', $select);
+
+        $rows = $this->fetchAll($select);
+        $this->assertSame(
+            ['Betty', 'Donna'],
+            array_column($rows, 'employee_name')
+        );
+    }
+
+    public function testLateralJoinSubSelect_cross()
+    {
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_dept.name AS dept_name', 'top.name AS employee_name'])
+            ->from('test_dept')
+            ->lateralJoinSubSelect(
+                'cross',
+                'SELECT name FROM test_employee
+                 WHERE test_employee.dept_id = test_dept.id
+                 ORDER BY salary DESC LIMIT 1',
+                'top'
+            )
+            ->orderBy(['test_dept.name']);
+
+        $this->assertStatementContains('CROSS JOIN LATERAL', $select);
+        $this->assertStringNotContainsString('ON true', (string) $select);
+
+        $rows = $this->fetchAll($select);
+        $this->assertSame(
+            ['Betty', 'Donna'],
+            array_column($rows, 'employee_name')
+        );
+    }
+
     public function testGetLastInsertIdName()
     {
         $insert = $this->query_factory->newInsert()

--- a/tests/Pgsql/SelectTest.php
+++ b/tests/Pgsql/SelectTest.php
@@ -110,6 +110,75 @@ class SelectTest extends Common\SelectTest
         $this->assertSameSql($expect, $actual);
     }
 
+    /**
+     * Postgres rejects an ON clause on a CROSS join, so supplying a condition
+     * could only ever produce a syntax error at execute time. Fail loudly
+     * while building instead.
+     */
+    public function testLateralJoinSubSelect_crossWithConditionThrows()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage('CROSS JOIN LATERAL cannot take a condition');
+
+        $this->query->lateralJoinSubSelect(
+            'cross',
+            'SELECT * FROM t2',
+            'a2',
+            't1.c1 = a2.c1'
+        );
+    }
+
+    /**
+     * @see testLateralJoinSubSelect_crossWithConditionThrows()
+     */
+    public function testLateralJoinSubSelect_naturalWithConditionThrows()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage('NATURAL JOIN LATERAL cannot take a condition');
+
+        $this->query->lateralJoinSubSelect(
+            'natural',
+            'SELECT * FROM t2',
+            'a2',
+            't1.c1 = a2.c1'
+        );
+    }
+
+    /**
+     * A rejected join must not leave a table reference behind, or a caught
+     * exception would corrupt the query.
+     */
+    public function testLateralJoinSubSelect_rejectedJoinLeavesNoTableRef()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+
+        try {
+            $this->query->lateralJoinSubSelect('cross', 'SELECT * FROM t2', 'a2', 'true');
+            $this->fail('expected a LogicException');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            // the alias is still free, so this must not throw
+            $this->query->lateralJoinSubSelect('cross', 'SELECT * FROM t2', 'a2');
+        }
+
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    CROSS JOIN LATERAL (
+                        SELECT * FROM t2
+                    ) <<a2>>
+        ';
+        $this->assertSameSql($expect, $this->query->__toString());
+    }
+
     public function testLateralJoinSubSelect_duplicateRef()
     {
         $this->query->cols(['*']);

--- a/tests/Pgsql/SelectTest.php
+++ b/tests/Pgsql/SelectTest.php
@@ -6,4 +6,117 @@ use Aura\SqlQuery\Common;
 class SelectTest extends Common\SelectTest
 {
     protected $db_type = 'pgsql';
+
+    public function testLateralJoinSubSelect()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect(
+            'left',
+            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
+            'a2',
+            't2.c1 = a2.c1'
+        );
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    LEFT JOIN LATERAL (
+                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
+                    ) <<a2>> ON <<t2>>.<<c1>> = <<a2>>.<<c1>>
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testLateralJoinSubSelect_selectObject()
+    {
+        $sub = $this->newQuery();
+        $sub->cols(['*'])->from('t2')->where('t2.c2 = :v', ['v' => 9]);
+
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect('inner', $sub, 'a2', 't2.c1 = a2.c1');
+
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    INNER JOIN LATERAL (
+                        SELECT
+                            *
+                        FROM
+                            <<t2>>
+                        WHERE
+                            <<t2>>.<<c2>> = :v
+                    ) <<a2>> ON <<t2>>.<<c1>> = <<a2>>.<<c1>>
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+
+        $this->assertSame(['v' => 9], $this->query->getBindValues());
+    }
+
+    /**
+     * Postgres requires an ON clause on LEFT/INNER JOIN LATERAL; without a
+     * condition the query is a syntax error, so default to ON true.
+     */
+    public function testLateralJoinSubSelect_noCondition()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect(
+            'left',
+            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
+            'a2'
+        );
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    LEFT JOIN LATERAL (
+                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
+                    ) <<a2>> ON true
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     * CROSS JOIN LATERAL takes no ON clause at all.
+     */
+    public function testLateralJoinSubSelect_cross()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect(
+            'cross',
+            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
+            'a2'
+        );
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    CROSS JOIN LATERAL (
+                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
+                    ) <<a2>>
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testLateralJoinSubSelect_duplicateRef()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect('left', 'SELECT * FROM t2', 'a2', 't2.c1 = a2.c1');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->query->lateralJoinSubSelect('left', 'SELECT * FROM t3', 'a2', 't3.c1 = a2.c1');
+    }
 }


### PR DESCRIPTION
Ports @golgote's #184 to 6.x. His two commits are cherry-picked with original authorship intact; the follow-up commit adds tests, docs, and a correctness fix.

## The fix

The original emitted no `ON` clause when no condition was given, which PostgreSQL rejects. Verified against PostgreSQL 18.4:

| join type | no `ON` | `ON true` |
| --- | --- | --- |
| (plain) / INNER / LEFT | syntax error | ok |
| CROSS / NATURAL | ok | syntax error |

So `lateralJoinSubSelect()` now renders `ON true` when no condition is given, except for CROSS and NATURAL which forbid an `ON` clause.

## Usage

```php
$select
    ->cols(['dept.name', 'top.name AS top_earner'])
    ->from('dept')
    ->lateralJoinSubSelect(
        'left',
        'SELECT name FROM employee
         WHERE employee.dept_id = dept.id
         ORDER BY salary DESC LIMIT 1',
        'top'
    );
```

The signature matches `joinSubSelect()`.

## Tests

Unit tests in `tests/Pgsql/SelectTest.php` (condition, Select-object sub-select with bind values, no-condition, cross, duplicate-ref) plus three integration tests that execute the generated SQL against a real server — the point being that the bug was invalid SQL, which a string-comparison test alone would not have caught.

633 unit + 78 integration tests pass; PHPStan clean.

## Not included

MySQL 8.0.14+ also supports `JOIN LATERAL` (verified locally on 9.7.1), and SQL Server has `CROSS APPLY` / `OUTER APPLY` as its equivalent. Both left for a follow-up to keep this PR to what #184 proposed.

Closes #184.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PostgreSQL `JOIN LATERAL` support via `lateralJoinSubSelect()` for sub-selects (string or query), with correct aliasing, bind handling, and join-type behavior.
  - Renders `ON true` when no condition is provided for applicable lateral joins; omits `ON` for `CROSS`/`NATURAL`.
  - Rejects supplying a condition for `CROSS` or `NATURAL` lateral joins with a `LogicException`.
- **Documentation**
  - Updated `CHANGELOG` and PostgreSQL SELECT docs with usage and SQL examples.
- **Tests**
  - Added integration and unit coverage for SQL generation, execution, bindings, and error/edge cases (including duplicate references).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->