### PR TITLE
Add MySQL LATERAL joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,16 +38,21 @@
   `cast(col as varchar)`) as a column alias, which produced misquoted
   SQL. Fixes #157.
 
-- [ADD] Pgsql\Select gains `lateralJoinSubSelect()`, rendering
-  `JOIN LATERAL` against an aliased sub-select so the sub-select can
-  reference columns from the tables to its left. The signature matches
-  `joinSubSelect()`. PostgreSQL requires an `ON` clause on every LATERAL
-  join except CROSS and NATURAL, so when no condition is given for the
-  other join types, `ON true` is rendered; conversely, passing a condition
-  to a CROSS or NATURAL join now throws
-  Aura\SqlQuery\Exception\LogicException, since PostgreSQL rejects an `ON`
-  clause there and the statement could only fail at execute time. Thanks
-  to @golgote for the original implementation in #184.
+- [ADD] Pgsql\Select and Mysql\Select gain `lateralJoinSubSelect()`,
+  rendering `JOIN LATERAL` against an aliased sub-select so the
+  sub-select can reference columns from the tables to its left. The
+  signature matches `joinSubSelect()`, and the shared implementation
+  lives in the new Common\LateralJoinTrait. A LATERAL join needs an `ON`
+  clause on every join type except CROSS and NATURAL, so when no
+  condition is given for the other join types, `ON true` is rendered.
+  Conversely, passing a condition to a join type that rejects an `ON`
+  clause now throws Aura\SqlQuery\Exception\LogicException rather than
+  building a statement that could only fail at execute time; that means
+  NATURAL on both dialects, plus CROSS on PostgreSQL, which MySQL allows
+  because CROSS and INNER are synonyms there. Note that LATERAL requires
+  MySQL 8.0.14 or later, and that MariaDB does not support it at all
+  despite sharing the `mysql` query objects. Thanks to @golgote for the
+  original implementation in #184.
 
 - [ADD] Insert-ignore is now spelled `ignore()` on every dialect that
   supports it: Mysql\Insert renders `INSERT IGNORE` and Sqlite\Insert

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -12,6 +12,56 @@ These 'mysql' query objects have additional MySQL-specific behaviors.
 - `bufferResult()` to add or remove `SQL_BUFFER_RESULT` flag
 - `highPriority()` to add or remove `HIGH_PRIORITY` flag
 - `straightJoin()` to add or remove `STRAIGHT_JOIN` flag
+- `lateralJoinSubSelect()` to add a `JOIN LATERAL` against an aliased
+  sub-select
+
+A `LATERAL` join lets the sub-select reference columns from the tables to its
+left, which is how you express "the top row per group":
+
+```php
+$select = $queryFactory->newSelect();
+$select
+    ->cols(['dept.name', 'top.name AS top_earner'])
+    ->from('dept')
+    ->lateralJoinSubSelect(
+        'left',
+        'SELECT name FROM employee
+         WHERE employee.dept_id = dept.id
+         ORDER BY salary DESC LIMIT 1',
+        'top'
+    );
+```
+
+The signature matches `joinSubSelect()`: the join type, the sub-select (a string
+or another _Select_ object), the alias, an optional condition, and optional bind
+values.
+
+MySQL rejects a `LEFT JOIN LATERAL` with no `ON` clause, so when you omit the
+condition, `ON true` is added for you (except on `CROSS` and `NATURAL` joins,
+which take no `ON` clause). The example above renders as:
+
+```sql
+SELECT
+    `dept`.`name`,
+    `top`.`name` AS `top_earner`
+FROM
+    `dept`
+        LEFT JOIN LATERAL (
+            SELECT name FROM employee
+            WHERE employee.dept_id = dept.id
+            ORDER BY salary DESC LIMIT 1
+        ) `top` ON true
+```
+
+Passing a condition to a `NATURAL` lateral join throws
+`Aura\SqlQuery\Exception\LogicException`, because a `NATURAL` join derives its
+condition from the common column names and rejects `ON`. A `CROSS` join *does*
+accept a condition on MySQL, where `CROSS` and `INNER` are synonyms — note that
+this differs from the PostgreSQL objects, which reject it.
+
+> `LATERAL` requires MySQL 8.0.14 or later. MariaDB has no `LATERAL` support at
+> all, so do not use this method against a MariaDB server even though it shares
+> the `mysql` query objects.
 
 ## INSERT
 

--- a/src/Common/LateralJoinTrait.php
+++ b/src/Common/LateralJoinTrait.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+use Aura\SqlQuery\Exception;
+
+/**
+ *
+ * Common code for LATERAL joins, on the dialects that support them.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait LateralJoinTrait
+{
+    /**
+     *
+     * Adds a LATERAL JOIN to an aliased subselect and columns to the query.
+     *
+     * A LATERAL join lets the sub-select reference columns from the tables to
+     * its left.
+     *
+     * @param string $join The join type: inner, left, cross, etc.
+     *
+     * @param string|SelectInterface $spec If a Select object, use as the
+     * sub-select; if a string, the sub-select command string.
+     *
+     * @param string $name The alias name for the sub-select.
+     *
+     * @param string $cond Join on this condition. A LATERAL join requires an
+     * ON clause except on the join types that forbid one, so when no
+     * condition is given for the other types, "ON true" is used.
+     *
+     * @param array $bind Values to bind to ?-placeholders in the condition.
+     *
+     * @return $this
+     *
+     * @throws Exception\LogicException
+     *
+     */
+    public function lateralJoinSubSelect($join, $spec, $name, $cond = null, array $bind = [])
+    {
+        $join = strtoupper(ltrim("$join JOIN LATERAL"));
+
+        if ($cond && $this->joinForbidsCondition($join)) {
+            throw new Exception\LogicException(
+                "A $join cannot take a condition."
+            );
+        }
+
+        $this->addTableRef("$join (SELECT ...)", $name);
+
+        $spec = $this->subSelect($spec, '            ');
+        $name = $this->quoter->quoteName($name);
+        $cond = $this->fixJoinCondition($cond, $bind);
+
+        if ($cond === '' && ! $this->isUnconditionalJoin($join)) {
+            $cond = 'ON true';
+        }
+
+        $text = rtrim("$join ($spec        ) $name $cond");
+        return $this->addJoin('        ' . $text);
+    }
+
+    /**
+     *
+     * Does this join type render without an ON clause when no condition is
+     * given?
+     *
+     * CROSS and NATURAL joins stand alone on every dialect that supports
+     * LATERAL, so no default condition is supplied for them.
+     *
+     * @param string $join The upper-cased join clause.
+     *
+     * @return bool
+     *
+     */
+    protected function isUnconditionalJoin($join)
+    {
+        return str_starts_with($join, 'CROSS ')
+            || str_starts_with($join, 'NATURAL ');
+    }
+
+    /**
+     *
+     * Does this join type reject an ON clause outright, so that supplying a
+     * condition can only produce a syntax error?
+     *
+     * A NATURAL join derives its condition from the common column names and
+     * rejects ON on every dialect. CROSS is dialect-specific: PostgreSQL
+     * rejects ON there as well, whereas MySQL accepts it, since CROSS and
+     * INNER are synonyms there. This default is the strict PostgreSQL rule;
+     * Mysql\Select loosens it.
+     *
+     * @param string $join The upper-cased join clause.
+     *
+     * @return bool
+     *
+     */
+    protected function joinForbidsCondition($join)
+    {
+        return str_starts_with($join, 'CROSS ')
+            || str_starts_with($join, 'NATURAL ');
+    }
+}

--- a/src/Mysql/Select.php
+++ b/src/Mysql/Select.php
@@ -19,6 +19,26 @@ use Aura\SqlQuery\Common;
  */
 class Select extends Common\Select
 {
+    use Common\LateralJoinTrait;
+
+    /**
+     *
+     * Does this join type reject an ON clause outright?
+     *
+     * MySQL treats CROSS JOIN and INNER JOIN as synonyms and accepts an ON
+     * clause on either, so only NATURAL is rejected here -- unlike the
+     * PostgreSQL default in the trait.
+     *
+     * @param string $join The upper-cased join clause.
+     *
+     * @return bool
+     *
+     */
+    protected function joinForbidsCondition($join)
+    {
+        return str_starts_with($join, 'NATURAL ');
+    }
+
     /**
      *
      * Adds or removes SQL_CALC_FOUND_ROWS flag.

--- a/src/Pgsql/Select.php
+++ b/src/Pgsql/Select.php
@@ -9,7 +9,6 @@
 namespace Aura\SqlQuery\Pgsql;
 
 use Aura\SqlQuery\Common;
-use Aura\SqlQuery\Exception;
 
 /**
  *
@@ -20,87 +19,5 @@ use Aura\SqlQuery\Exception;
  */
 class Select extends Common\Select
 {
-    /**
-     *
-     * Adds a LATERAL JOIN to an aliased subselect and columns to the query.
-     *
-     * @param string $join The join type: inner, left, natural, etc.
-     *
-     * @param string|Select $spec If a Select
-     * object, use as the sub-select; if a string, the sub-select
-     * command string.
-     *
-     * @param string $name The alias name for the sub-select.
-     *
-     * @param string $cond Join on this condition. Postgres requires an ON
-     * clause on every LATERAL join except CROSS and NATURAL, so when no
-     * condition is given for those other join types, "ON true" is used.
-     *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
-     *
-     * @return $this
-     *
-     * @throws Exception
-     *
-     */
-    public function lateralJoinSubSelect($join, $spec, $name, $cond = null, array $bind = [])
-    {
-        $join = strtoupper(ltrim("$join JOIN LATERAL"));
-
-        if ($cond && $this->joinForbidsCondition($join)) {
-            throw new Exception\LogicException(
-                "A $join cannot take a condition."
-            );
-        }
-
-        $this->addTableRef("$join (SELECT ...)", $name);
-
-        $spec = $this->subSelect($spec, '            ');
-        $name = $this->quoter->quoteName($name);
-        $cond = $this->fixJoinCondition($cond, $bind);
-
-        if ($cond === '' && ! $this->isUnconditionalJoin($join)) {
-            $cond = 'ON true';
-        }
-
-        $text = rtrim("$join ($spec        ) $name $cond");
-        return $this->addJoin('        ' . $text);
-    }
-
-    /**
-     *
-     * Does this join type render without an ON clause when no condition is
-     * given?
-     *
-     * @param string $join The upper-cased join clause.
-     *
-     * @return bool
-     *
-     */
-    protected function isUnconditionalJoin($join)
-    {
-        return str_starts_with($join, 'CROSS ')
-            || str_starts_with($join, 'NATURAL ');
-    }
-
-    /**
-     *
-     * Does this join type reject an ON clause outright, so that supplying a
-     * condition can only produce a syntax error?
-     *
-     * PostgreSQL rejects ON on both CROSS and NATURAL joins. Other dialects
-     * differ -- MySQL accepts it on CROSS, where CROSS and INNER are
-     * synonyms -- so this is separate from isUnconditionalJoin() and meant to
-     * be overridden.
-     *
-     * @param string $join The upper-cased join clause.
-     *
-     * @return bool
-     *
-     */
-    protected function joinForbidsCondition($join)
-    {
-        return str_starts_with($join, 'CROSS ')
-            || str_starts_with($join, 'NATURAL ');
-    }
+    use Common\LateralJoinTrait;
 }

--- a/tests/Common/LateralJoinTestTrait.php
+++ b/tests/Common/LateralJoinTestTrait.php
@@ -1,0 +1,177 @@
+<?php
+namespace Aura\SqlQuery\Common;
+
+/**
+ *
+ * Shared LATERAL join assertions for the dialects that support them.
+ *
+ */
+trait LateralJoinTestTrait
+{
+    public function testLateralJoinSubSelect()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect(
+            'left',
+            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
+            'a2',
+            't2.c1 = a2.c1'
+        );
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    LEFT JOIN LATERAL (
+                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
+                    ) <<a2>> ON <<t2>>.<<c1>> = <<a2>>.<<c1>>
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testLateralJoinSubSelect_selectObject()
+    {
+        $sub = $this->newQuery();
+        $sub->cols(['*'])->from('t2')->where('t2.c2 = :v', ['v' => 9]);
+
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect('inner', $sub, 'a2', 't2.c1 = a2.c1');
+
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    INNER JOIN LATERAL (
+                        SELECT
+                            *
+                        FROM
+                            <<t2>>
+                        WHERE
+                            <<t2>>.<<c2>> = :v
+                    ) <<a2>> ON <<t2>>.<<c1>> = <<a2>>.<<c1>>
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+
+        $this->assertSame(['v' => 9], $this->query->getBindValues());
+    }
+
+    /**
+     * A LATERAL join needs an ON clause on every join type except CROSS and
+     * NATURAL; without one the statement is a syntax error.
+     */
+    public function testLateralJoinSubSelect_noCondition()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect(
+            'left',
+            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
+            'a2'
+        );
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    LEFT JOIN LATERAL (
+                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
+                    ) <<a2>> ON true
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     * CROSS JOIN LATERAL takes no ON clause at all.
+     */
+    public function testLateralJoinSubSelect_cross()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect(
+            'cross',
+            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
+            'a2'
+        );
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    CROSS JOIN LATERAL (
+                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
+                    ) <<a2>>
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     * A NATURAL join derives its condition from the common column names and
+     * rejects ON on every dialect, so supplying a condition could only ever
+     * produce a syntax error at execute time. Fail loudly while building
+     * instead.
+     *
+     * CROSS is not covered here because the dialects disagree: Postgres
+     * rejects a condition, MySQL accepts one. See the per-dialect tests.
+     */
+    public function testLateralJoinSubSelect_naturalWithConditionThrows()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage('NATURAL JOIN LATERAL cannot take a condition');
+
+        $this->query->lateralJoinSubSelect(
+            'natural',
+            'SELECT * FROM t2',
+            'a2',
+            't1.c1 = a2.c1'
+        );
+    }
+
+    /**
+     * A rejected join must not leave a table reference behind, or a caught
+     * exception would corrupt the query.
+     */
+    public function testLateralJoinSubSelect_rejectedJoinLeavesNoTableRef()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+
+        try {
+            $this->query->lateralJoinSubSelect('natural', 'SELECT * FROM t2', 'a2', 'true');
+            $this->fail('expected a LogicException');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            // the alias is still free, so this must not throw
+            $this->query->lateralJoinSubSelect('natural', 'SELECT * FROM t2', 'a2');
+        }
+
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    NATURAL JOIN LATERAL (
+                        SELECT * FROM t2
+                    ) <<a2>>
+        ';
+        $this->assertSameSql($expect, $this->query->__toString());
+    }
+
+    public function testLateralJoinSubSelect_duplicateRef()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect('left', 'SELECT * FROM t2', 'a2', 't2.c1 = a2.c1');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->query->lateralJoinSubSelect('left', 'SELECT * FROM t3', 'a2', 't3.c1 = a2.c1');
+    }
+}

--- a/tests/Integration/MysqlIntegrationTest.php
+++ b/tests/Integration/MysqlIntegrationTest.php
@@ -69,6 +69,132 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
         return "find_in_set({$col}, {$param})";
     }
 
+    /**
+     * LATERAL arrived in MySQL 8.0.14; MariaDB has no equivalent at all, and
+     * shares this 'mysql' db_type.
+     */
+    protected function skipUnlessLateralSupported(): void
+    {
+        $version = $this->pdo->getAttribute(PDO::ATTR_SERVER_VERSION);
+
+        if (stripos($version, 'mariadb') !== false) {
+            $this->markTestSkipped("MariaDB does not support LATERAL ($version).");
+        }
+
+        if (version_compare($version, '8.0.14', '<')) {
+            $this->markTestSkipped("MySQL $version is older than 8.0.14.");
+        }
+    }
+
+    public function testLateralJoinSubSelect()
+    {
+        $this->skipUnlessLateralSupported();
+
+        // the top earner in each department
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_dept.name AS dept_name', 'top.name AS employee_name'])
+            ->from('test_dept')
+            ->lateralJoinSubSelect(
+                'left',
+                'SELECT name, salary FROM test_employee
+                 WHERE test_employee.dept_id = test_dept.id
+                 ORDER BY salary DESC LIMIT 1',
+                'top',
+                'true'
+            )
+            ->orderBy(['test_dept.name']);
+
+        $this->assertStatementContains('LEFT JOIN LATERAL', $select);
+
+        $rows = $this->fetchAll($select);
+        $this->assertSame(
+            ['Betty', 'Donna'],
+            array_column($rows, 'employee_name')
+        );
+    }
+
+    /**
+     * MySQL rejects a LEFT JOIN LATERAL with no ON clause, so "ON true" has to
+     * be supplied.
+     */
+    public function testLateralJoinSubSelect_noCondition()
+    {
+        $this->skipUnlessLateralSupported();
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_dept.name AS dept_name', 'top.name AS employee_name'])
+            ->from('test_dept')
+            ->lateralJoinSubSelect(
+                'left',
+                'SELECT name FROM test_employee
+                 WHERE test_employee.dept_id = test_dept.id
+                 ORDER BY salary DESC LIMIT 1',
+                'top'
+            )
+            ->orderBy(['test_dept.name']);
+
+        $this->assertStatementContains('ON true', $select);
+
+        $rows = $this->fetchAll($select);
+        $this->assertSame(
+            ['Betty', 'Donna'],
+            array_column($rows, 'employee_name')
+        );
+    }
+
+    public function testLateralJoinSubSelect_cross()
+    {
+        $this->skipUnlessLateralSupported();
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_dept.name AS dept_name', 'top.name AS employee_name'])
+            ->from('test_dept')
+            ->lateralJoinSubSelect(
+                'cross',
+                'SELECT name FROM test_employee
+                 WHERE test_employee.dept_id = test_dept.id
+                 ORDER BY salary DESC LIMIT 1',
+                'top'
+            )
+            ->orderBy(['test_dept.name']);
+
+        $this->assertStatementContains('CROSS JOIN LATERAL', $select);
+        $this->assertStringNotContainsString('ON true', (string) $select);
+
+        $rows = $this->fetchAll($select);
+        $this->assertSame(
+            ['Betty', 'Donna'],
+            array_column($rows, 'employee_name')
+        );
+    }
+
+    /**
+     * MySQL accepts an ON clause on a CROSS join, where Postgres rejects it.
+     * Mysql\Select relaxes joinForbidsCondition() for exactly this, so prove
+     * the relaxed case really runs.
+     */
+    public function testLateralJoinSubSelect_crossWithCondition()
+    {
+        $this->skipUnlessLateralSupported();
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_dept.name AS dept_name', 'top.name AS employee_name'])
+            ->from('test_dept')
+            ->lateralJoinSubSelect(
+                'cross',
+                'SELECT name, dept_id FROM test_employee
+                 ORDER BY salary DESC LIMIT 1',
+                'top',
+                'top.dept_id = test_dept.id'
+            )
+            ->orderBy(['test_dept.name']);
+
+        $this->assertStatementContains('CROSS JOIN LATERAL', $select);
+
+        $rows = $this->fetchAll($select);
+        $this->assertSame(['Donna'], array_column($rows, 'employee_name'));
+    }
+
     public function testSelectSessionVariable()
     {
         // issue #226: quoting the parts of @@session.time_zone made this

--- a/tests/Mysql/SelectTest.php
+++ b/tests/Mysql/SelectTest.php
@@ -5,7 +5,37 @@ use Aura\SqlQuery\Common;
 
 class SelectTest extends Common\SelectTest
 {
+    use Common\LateralJoinTestTrait;
+
     protected $db_type = 'mysql';
+
+    /**
+     * Unlike Postgres, MySQL accepts an ON clause on a CROSS join, because
+     * CROSS and INNER are synonyms there. So a condition is rendered rather
+     * than rejected; see Pgsql\SelectTest for the contrast.
+     */
+    public function testLateralJoinSubSelect_crossWithCondition()
+    {
+        $this->query->cols(['*']);
+        $this->query->from('t1');
+        $this->query->lateralJoinSubSelect(
+            'cross',
+            'SELECT * FROM t2',
+            'a2',
+            't1.c1 = a2.c1'
+        );
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>
+                    CROSS JOIN LATERAL (
+                        SELECT * FROM t2
+                    ) <<a2>> ON <<t1>>.<<c1>> = <<a2>>.<<c1>>
+        ';
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
 
     protected $expected_sql_with_flag = '
         SELECT %s

--- a/tests/Pgsql/SelectTest.php
+++ b/tests/Pgsql/SelectTest.php
@@ -5,115 +5,14 @@ use Aura\SqlQuery\Common;
 
 class SelectTest extends Common\SelectTest
 {
+    use Common\LateralJoinTestTrait;
+
     protected $db_type = 'pgsql';
-
-    public function testLateralJoinSubSelect()
-    {
-        $this->query->cols(['*']);
-        $this->query->from('t1');
-        $this->query->lateralJoinSubSelect(
-            'left',
-            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
-            'a2',
-            't2.c1 = a2.c1'
-        );
-        $expect = '
-            SELECT
-                *
-            FROM
-                <<t1>>
-                    LEFT JOIN LATERAL (
-                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
-                    ) <<a2>> ON <<t2>>.<<c1>> = <<a2>>.<<c1>>
-        ';
-        $actual = $this->query->__toString();
-        $this->assertSameSql($expect, $actual);
-    }
-
-    public function testLateralJoinSubSelect_selectObject()
-    {
-        $sub = $this->newQuery();
-        $sub->cols(['*'])->from('t2')->where('t2.c2 = :v', ['v' => 9]);
-
-        $this->query->cols(['*']);
-        $this->query->from('t1');
-        $this->query->lateralJoinSubSelect('inner', $sub, 'a2', 't2.c1 = a2.c1');
-
-        $expect = '
-            SELECT
-                *
-            FROM
-                <<t1>>
-                    INNER JOIN LATERAL (
-                        SELECT
-                            *
-                        FROM
-                            <<t2>>
-                        WHERE
-                            <<t2>>.<<c2>> = :v
-                    ) <<a2>> ON <<t2>>.<<c1>> = <<a2>>.<<c1>>
-        ';
-        $actual = $this->query->__toString();
-        $this->assertSameSql($expect, $actual);
-
-        $this->assertSame(['v' => 9], $this->query->getBindValues());
-    }
-
-    /**
-     * Postgres requires an ON clause on LEFT/INNER JOIN LATERAL; without a
-     * condition the query is a syntax error, so default to ON true.
-     */
-    public function testLateralJoinSubSelect_noCondition()
-    {
-        $this->query->cols(['*']);
-        $this->query->from('t1');
-        $this->query->lateralJoinSubSelect(
-            'left',
-            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
-            'a2'
-        );
-        $expect = '
-            SELECT
-                *
-            FROM
-                <<t1>>
-                    LEFT JOIN LATERAL (
-                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
-                    ) <<a2>> ON true
-        ';
-        $actual = $this->query->__toString();
-        $this->assertSameSql($expect, $actual);
-    }
-
-    /**
-     * CROSS JOIN LATERAL takes no ON clause at all.
-     */
-    public function testLateralJoinSubSelect_cross()
-    {
-        $this->query->cols(['*']);
-        $this->query->from('t1');
-        $this->query->lateralJoinSubSelect(
-            'cross',
-            'SELECT * FROM t2 WHERE t2.c1 = t1.c1',
-            'a2'
-        );
-        $expect = '
-            SELECT
-                *
-            FROM
-                <<t1>>
-                    CROSS JOIN LATERAL (
-                        SELECT * FROM t2 WHERE t2.c1 = t1.c1
-                    ) <<a2>>
-        ';
-        $actual = $this->query->__toString();
-        $this->assertSameSql($expect, $actual);
-    }
 
     /**
      * Postgres rejects an ON clause on a CROSS join, so supplying a condition
-     * could only ever produce a syntax error at execute time. Fail loudly
-     * while building instead.
+     * could only ever produce a syntax error at execute time. MySQL differs;
+     * see Mysql\SelectTest.
      */
     public function testLateralJoinSubSelect_crossWithConditionThrows()
     {
@@ -129,63 +28,5 @@ class SelectTest extends Common\SelectTest
             'a2',
             't1.c1 = a2.c1'
         );
-    }
-
-    /**
-     * @see testLateralJoinSubSelect_crossWithConditionThrows()
-     */
-    public function testLateralJoinSubSelect_naturalWithConditionThrows()
-    {
-        $this->query->cols(['*']);
-        $this->query->from('t1');
-
-        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
-        $this->expectExceptionMessage('NATURAL JOIN LATERAL cannot take a condition');
-
-        $this->query->lateralJoinSubSelect(
-            'natural',
-            'SELECT * FROM t2',
-            'a2',
-            't1.c1 = a2.c1'
-        );
-    }
-
-    /**
-     * A rejected join must not leave a table reference behind, or a caught
-     * exception would corrupt the query.
-     */
-    public function testLateralJoinSubSelect_rejectedJoinLeavesNoTableRef()
-    {
-        $this->query->cols(['*']);
-        $this->query->from('t1');
-
-        try {
-            $this->query->lateralJoinSubSelect('cross', 'SELECT * FROM t2', 'a2', 'true');
-            $this->fail('expected a LogicException');
-        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
-            // the alias is still free, so this must not throw
-            $this->query->lateralJoinSubSelect('cross', 'SELECT * FROM t2', 'a2');
-        }
-
-        $expect = '
-            SELECT
-                *
-            FROM
-                <<t1>>
-                    CROSS JOIN LATERAL (
-                        SELECT * FROM t2
-                    ) <<a2>>
-        ';
-        $this->assertSameSql($expect, $this->query->__toString());
-    }
-
-    public function testLateralJoinSubSelect_duplicateRef()
-    {
-        $this->query->cols(['*']);
-        $this->query->from('t1');
-        $this->query->lateralJoinSubSelect('left', 'SELECT * FROM t2', 'a2', 't2.c1 = a2.c1');
-
-        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
-        $this->query->lateralJoinSubSelect('left', 'SELECT * FROM t3', 'a2', 't3.c1 = a2.c1');
     }
 }


### PR DESCRIPTION
Follow-up to #231, which deliberately kept to Postgres. **Stacked on `port-lateral-joins`** — retarget to `6.x` once #231 merges, so the diff shown here stays MySQL-only.

## Change

`lateralJoinSubSelect()` moves out of `Pgsql\Select` into a new `Common\LateralJoinTrait`, used by both `Pgsql\Select` and `Mysql\Select`. No behavior change for Postgres.

## The dialects disagree, so one hook is overridable

Verified against real servers (PostgreSQL 18.4, MySQL 9.7.1):

| join type | PG no `ON` | PG `ON` | MySQL no `ON` | MySQL `ON` |
| --- | --- | --- | --- | --- |
| (plain) / INNER | error | ok | ok | ok |
| LEFT | error | ok | error | ok |
| CROSS | ok | **error** | ok | **ok** |
| NATURAL | ok | error | n/a | error |

Two separate concerns, so two methods:

- `isUnconditionalJoin()` — whether to supply the default `ON true`. CROSS/NATURAL on both dialects, so it stays in the trait.
- `joinForbidsCondition()` — whether an explicit condition is rejected (added in #231). NATURAL is universal, but **CROSS diverges**: MySQL accepts `CROSS JOIN LATERAL … ON` because CROSS and INNER are synonyms there. So `Mysql\Select` overrides it to reject NATURAL only.

## Caveats

`LATERAL` needs MySQL 8.0.14+, and **MariaDB has no `LATERAL` at all** despite sharing the `mysql` query objects. The integration tests skip on MariaDB and on MySQL < 8.0.14 via `PDO::ATTR_SERVER_VERSION`, and `docs/mysql.md` calls it out.

## Tests

Shared assertions live in `Common\LateralJoinTestTrait`, used by both dialects' `SelectTest` — they cannot go in `Common\SelectTest`, whose SQLite and Sqlsrv subclasses have no `LATERAL`. The CROSS-with-condition case is deliberately *not* shared: `Pgsql\SelectTest` asserts it throws, `Mysql\SelectTest` asserts it renders. Four MySQL integration tests execute the generated SQL against a real server, including the relaxed CROSS case, so the divergence is proven rather than asserted.

648 unit + 82 integration tests pass; PHPStan clean.