### PR TITLE
Replace flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,14 @@
   combination now throws Exception\LogicException when the statement is
   built, whichever order the two methods were called in.
 
+- [FIX] The Sqlite conflict clauses -- `orAbort()`, `orFail()`,
+  `ignore()`/`orIgnore()`, `orReplace()` and `orRollback()` -- are
+  alternatives to each other, but setting two of them stacked both into the
+  statement (`INSERT OR IGNORE OR REPLACE`), which SQLite rejects. Setting
+  more than one now throws Exception\LogicException when the statement is
+  built, on both Sqlite\Insert and Sqlite\Update; switching clauses still
+  works by turning the first one off.
+
 - [FIX] The quoter now recognizes `#` as an identifier character (legal
   on DB2 / IBM i, in any position), so `table.col#` quotes as
   `"table"."col#"` instead of the broken `"table"."col"#`. Fixes #177.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@
   combination now throws Exception\LogicException when the statement is
   built, whichever order the two methods were called in.
 
+- [FIX] Mysql\Insert accepted two priority modifiers at once, building
+  `INSERT LOW_PRIORITY HIGH_PRIORITY INTO` and the like; MySQL takes at
+  most one of LOW_PRIORITY, HIGH_PRIORITY and DELAYED, on REPLACE as well
+  as INSERT. Setting more than one now throws Exception\LogicException
+  when the statement is built. Mysql\Update and Mysql\Delete are
+  unaffected, having only the one priority modifier between them.
+
 - [FIX] The Sqlite conflict clauses -- `orAbort()`, `orFail()`,
   `ignore()`/`orIgnore()`, `orReplace()` and `orRollback()` -- are
   alternatives to each other, but setting two of them stacked both into the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@
   deprecated aliases. Sqlsrv, which has no equivalent, keeps throwing
   Exception\BadMethodCallException. Fixes #172; related to #158.
 
+- [FIX] Mysql\Insert::orReplace() combined with highPriority() or ignore()
+  built `REPLACE HIGH_PRIORITY INTO` / `REPLACE IGNORE INTO`, which MySQL
+  rejects at parse time: rewriting the INSERT keyword left the flags in
+  place, and REPLACE accepts only LOW_PRIORITY and DELAYED. The
+  combination now throws Exception\LogicException when the statement is
+  built, whichever order the two methods were called in.
+
 - [FIX] The quoter now recognizes `#` as an identifier character (legal
   on DB2 / IBM i, in any position), so `table.col#` quotes as
   `"table"."col#"` instead of the broken `"table"."col"#`. Fixes #177.

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -226,6 +226,43 @@ class Insert extends Common\Insert
 
     /**
      *
+     * The priority modifiers; a statement takes at most one of them. REPLACE
+     * accepts a narrower set than INSERT, which assertReplaceFlags() covers.
+     *
+     * @var string[]
+     *
+     */
+    protected $priority_flags = ['LOW_PRIORITY', 'HIGH_PRIORITY', 'DELAYED'];
+
+    /**
+     *
+     * Throws if more than one priority modifier was set; they are
+     * alternatives to each other, so MySQL rejects a statement carrying two.
+     *
+     * @return void
+     *
+     * @throws Exception\LogicException
+     *
+     */
+    protected function assertOnePriorityFlag()
+    {
+        $set = [];
+        foreach ($this->priority_flags as $flag) {
+            if ($this->hasFlag($flag)) {
+                $set[] = $flag;
+            }
+        }
+
+        if (count($set) > 1) {
+            throw new Exception\LogicException(
+                'A statement takes only one priority modifier; got '
+                . implode(' and ', $set) . '.'
+            );
+        }
+    }
+
+    /**
+     *
      * Builds this query object into a string.
      *
      * @return string
@@ -234,6 +271,8 @@ class Insert extends Common\Insert
     protected function build()
     {
         $stm = parent::build();
+
+        $this->assertOnePriorityFlag();
 
         if ($this->use_replace) {
             $this->assertReplaceFlags();

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -9,6 +9,7 @@
 namespace Aura\SqlQuery\Mysql;
 
 use Aura\SqlQuery\Common;
+use Aura\SqlQuery\Exception;
 
 /**
  *
@@ -193,6 +194,38 @@ class Insert extends Common\Insert
 
     /**
      *
+     * The flags REPLACE will not accept; the rest of the INSERT flags carry
+     * over unchanged.
+     *
+     * @var string[]
+     *
+     */
+    protected $replace_forbids_flags = ['HIGH_PRIORITY', 'IGNORE'];
+
+    /**
+     *
+     * Throws if a flag was set that REPLACE does not accept; rewriting the
+     * INSERT keyword leaves the flags in place, so the statement would reach
+     * the database as a parse error.
+     *
+     * @return void
+     *
+     * @throws Exception\LogicException
+     *
+     */
+    protected function assertReplaceFlags()
+    {
+        foreach ($this->replace_forbids_flags as $flag) {
+            if ($this->hasFlag($flag)) {
+                throw new Exception\LogicException(
+                    "A REPLACE cannot take the $flag flag."
+                );
+            }
+        }
+    }
+
+    /**
+     *
      * Builds this query object into a string.
      *
      * @return string
@@ -203,6 +236,7 @@ class Insert extends Common\Insert
         $stm = parent::build();
 
         if ($this->use_replace) {
+            $this->assertReplaceFlags();
             // change INSERT to REPLACE
             $stm = 'REPLACE' . substr($stm, 6);
         }

--- a/src/Sqlite/Insert.php
+++ b/src/Sqlite/Insert.php
@@ -19,6 +19,21 @@ use Aura\SqlQuery\Common;
  */
 class Insert extends Common\Insert
 {
+    use OrConflictTrait;
+
+    /**
+     *
+     * Builds the statement.
+     *
+     * @return string
+     *
+     */
+    protected function build()
+    {
+        $this->assertOneOrConflictFlag();
+        return parent::build();
+    }
+
     /**
      *
      * Adds or removes OR ABORT flag.

--- a/src/Sqlite/OrConflictTrait.php
+++ b/src/Sqlite/OrConflictTrait.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Sqlite;
+
+use Aura\SqlQuery\Exception;
+
+/**
+ *
+ * Common code for the SQLite conflict clauses, which INSERT and UPDATE
+ * both accept.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait OrConflictTrait
+{
+    /**
+     *
+     * The conflict clauses; a statement takes at most one of them.
+     *
+     * @var string[]
+     *
+     */
+    protected $or_conflict_flags = [
+        'OR ABORT',
+        'OR FAIL',
+        'OR IGNORE',
+        'OR REPLACE',
+        'OR ROLLBACK',
+    ];
+
+    /**
+     *
+     * Throws if more than one conflict clause was set; they are alternatives
+     * to each other, so SQLite rejects a statement carrying two.
+     *
+     * @return void
+     *
+     * @throws Exception\LogicException
+     *
+     */
+    protected function assertOneOrConflictFlag()
+    {
+        $set = [];
+        foreach ($this->or_conflict_flags as $flag) {
+            if ($this->hasFlag($flag)) {
+                $set[] = $flag;
+            }
+        }
+
+        if (count($set) > 1) {
+            throw new Exception\LogicException(
+                'A statement takes only one conflict clause; got '
+                . implode(' and ', $set) . '.'
+            );
+        }
+    }
+}

--- a/src/Sqlite/Update.php
+++ b/src/Sqlite/Update.php
@@ -20,6 +20,7 @@ use Aura\SqlQuery\Common;
 class Update extends Common\Update implements Common\OrderByInterface, Common\LimitOffsetInterface
 {
     use Common\LimitOffsetTrait;
+    use OrConflictTrait;
 
     /**
      *
@@ -30,6 +31,7 @@ class Update extends Common\Update implements Common\OrderByInterface, Common\Li
      */
     protected function build()
     {
+        $this->assertOneOrConflictFlag();
         return parent::build()
             . $this->builder->buildLimitOffset($this->getLimit(), $this->offset);
     }

--- a/tests/Integration/MysqlIntegrationTest.php
+++ b/tests/Integration/MysqlIntegrationTest.php
@@ -2,6 +2,7 @@
 namespace Aura\SqlQuery\Integration;
 
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  *
@@ -320,6 +321,38 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
 
         $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
         $this->assertSame('Replaced', $sth->fetchColumn());
+    }
+
+    /**
+     * REPLACE accepts LOW_PRIORITY and DELAYED, and nothing else; the flags
+     * MySQL rejects cannot be built at all, so they are covered by the unit
+     * tests instead. DELAYED is obsolete but still parses -- the server
+     * converts it and warns.
+     */
+    #[DataProvider('provideReplaceFlagAllowed')]
+    public function testInsertOrReplaceWithFlag($method, $flag)
+    {
+        $insert = $this->query_factory->newInsert()
+            ->orReplace()
+            ->$method()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Replaced']);
+
+        $this->assertStatementContains("REPLACE {$flag} INTO <<test_dept>>", $insert);
+
+        // two rows affected: the old one deleted, the new one inserted
+        $this->assertSame(2, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Replaced', $sth->fetchColumn());
+    }
+
+    public static function provideReplaceFlagAllowed(): array
+    {
+        return [
+            ['lowPriority', 'LOW_PRIORITY'],
+            ['delayed', 'DELAYED'],
+        ];
     }
 
     public function testUpdateOrderByLimit()

--- a/tests/Integration/SqliteIntegrationTest.php
+++ b/tests/Integration/SqliteIntegrationTest.php
@@ -87,4 +87,30 @@ class SqliteIntegrationTest extends AbstractIntegrationTest
         $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
         $this->assertSame('Replaced', $sth->fetchColumn());
     }
+
+    /**
+     * An UPDATE carries a conflict clause too. Moving Sales onto the key
+     * Engineering holds would violate the primary key; OR REPLACE resolves
+     * it by dropping the row that was in the way.
+     */
+    public function testUpdateOrReplace()
+    {
+        // the condition cannot reuse :id -- cols() already binds that name
+        // for the SET clause, and the second binding would win
+        $update = $this->query_factory->newUpdate()
+            ->orReplace()
+            ->table('test_dept')
+            ->cols(['id' => 1])
+            ->where('id = :old_id', ['old_id' => 2]);
+
+        $this->assertStatementContains('UPDATE OR REPLACE <<test_dept>>', $update);
+
+        $this->assertSame(1, $this->exec($update));
+
+        $sth = $this->pdo->query('SELECT id, name FROM test_dept ORDER BY id');
+        $this->assertSame(
+            [['id' => 1, 'name' => 'Sales']],
+            $sth->fetchAll(PDO::FETCH_ASSOC)
+        );
+    }
 }

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -2,6 +2,7 @@
 namespace Aura\SqlQuery\Mysql;
 
 use Aura\SqlQuery\Common;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class InsertTest extends Common\InsertTest
 {
@@ -64,6 +65,22 @@ class InsertTest extends Common\InsertTest
         )
     ";
 
+    protected $expected_replace_sql_with_flag = "
+        REPLACE %s INTO <<t1>> (
+            <<c1>>,
+            <<c2>>,
+            <<c3>>,
+            <<c4>>,
+            <<c5>>
+        ) VALUES (
+            :c1,
+            :c2,
+            :c3,
+            NOW(),
+            NULL
+        )
+    ";
+
     public function testHighPriority()
     {
         $this->query->highPriority()
@@ -88,6 +105,98 @@ class InsertTest extends Common\InsertTest
 
         $actual = $this->query->__toString();
         $this->assertSameSql($this->expected_replace_sql, $actual);
+    }
+
+    /**
+     * REPLACE takes LOW_PRIORITY and DELAYED, so those still build.
+     */
+    #[DataProvider('provideReplaceFlagAllowed')]
+    public function testOrReplaceWithAllowedFlag($method, $flag)
+    {
+        $this->query->orReplace()
+                    ->$method()
+                    ->into('t1')
+                    ->cols(array('c1', 'c2', 'c3'))
+                    ->set('c4', 'NOW()')
+                    ->set('c5', null);
+
+        $actual = $this->query->__toString();
+        $expect = sprintf($this->expected_replace_sql_with_flag, $flag);
+
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public static function provideReplaceFlagAllowed()
+    {
+        return array(
+            array('lowPriority', 'LOW_PRIORITY'),
+            array('delayed', 'DELAYED'),
+        );
+    }
+
+    public static function provideReplaceFlagForbidden()
+    {
+        return array(
+            array('highPriority', 'HIGH_PRIORITY'),
+            array('ignore', 'IGNORE'),
+        );
+    }
+
+    /**
+     * HIGH_PRIORITY and IGNORE are INSERT-only; combining them with REPLACE
+     * used to build a statement MySQL rejects at parse time.
+     */
+    #[DataProvider('provideReplaceFlagForbidden')]
+    public function testOrReplaceWithForbiddenFlag($method, $flag)
+    {
+        $this->query->orReplace()
+                    ->$method()
+                    ->into('t1')
+                    ->cols(array('c1'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage("A REPLACE cannot take the $flag flag.");
+        $this->query->__toString();
+    }
+
+    /**
+     * The flag order must not matter -- the check happens at build time, so
+     * it catches the flag whether it was set before or after orReplace().
+     */
+    #[DataProvider('provideReplaceFlagForbidden')]
+    public function testForbiddenFlagBeforeOrReplace($method, $flag)
+    {
+        $this->query->$method()
+                    ->orReplace()
+                    ->into('t1')
+                    ->cols(array('c1'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage("A REPLACE cannot take the $flag flag.");
+        $this->query->__toString();
+    }
+
+    /**
+     * Unsetting the flag again clears the way, and unsetting orReplace()
+     * leaves the plain INSERT alone.
+     */
+    public function testForbiddenFlagDisabled()
+    {
+        $this->query->orReplace()
+                    ->ignore()
+                    ->ignore(false)
+                    ->into('t1')
+                    ->cols(array('c1', 'c2', 'c3'))
+                    ->set('c4', 'NOW()')
+                    ->set('c5', null);
+
+        $this->assertSameSql($this->expected_replace_sql, $this->query->__toString());
+
+        $this->query->orReplace(false);
+        $this->assertSameSql(
+            str_replace('%s ', '', $this->expected_sql_with_flag),
+            $this->query->__toString()
+        );
     }
 
     public function testLowPriority()

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -177,6 +177,56 @@ class InsertTest extends Common\InsertTest
     }
 
     /**
+     * LOW_PRIORITY, HIGH_PRIORITY and DELAYED are alternatives to each
+     * other on INSERT as much as on REPLACE, so two of them is a syntax
+     * error either way. Each pair is given in both orders.
+     */
+    #[DataProvider('providePriorityModifierPair')]
+    public function testTwoPriorityModifiers($first, $second, $message)
+    {
+        $this->query->$first()
+                    ->$second()
+                    ->into('t1')
+                    ->cols(array('c1'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage($message);
+        $this->query->__toString();
+    }
+
+    public static function providePriorityModifierPair()
+    {
+        $pairs = array(
+            array('lowPriority', 'highPriority', 'LOW_PRIORITY and HIGH_PRIORITY'),
+            array('lowPriority', 'delayed', 'LOW_PRIORITY and DELAYED'),
+            array('highPriority', 'delayed', 'HIGH_PRIORITY and DELAYED'),
+        );
+
+        $both_orders = array();
+        foreach ($pairs as $pair) {
+            $both_orders[] = $pair;
+            $both_orders[] = array($pair[1], $pair[0], $pair[2]);
+        }
+        return $both_orders;
+    }
+
+    /**
+     * REPLACE takes LOW_PRIORITY or DELAYED, but still only one of them.
+     */
+    public function testOrReplaceWithTwoPriorityModifiers()
+    {
+        $this->query->orReplace()
+                    ->lowPriority()
+                    ->delayed()
+                    ->into('t1')
+                    ->cols(array('c1'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('LOW_PRIORITY and DELAYED');
+        $this->query->__toString();
+    }
+
+    /**
      * Unsetting the flag again clears the way, and unsetting orReplace()
      * leaves the plain INSERT alone.
      */

--- a/tests/Sqlite/InsertTest.php
+++ b/tests/Sqlite/InsertTest.php
@@ -2,6 +2,7 @@
 namespace Aura\SqlQuery\Sqlite;
 
 use Aura\SqlQuery\Common;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class InsertTest extends Common\InsertTest
 {
@@ -105,5 +106,58 @@ class InsertTest extends Common\InsertTest
         $expect = sprintf($this->expected_sql_with_flag, 'OR ROLLBACK');
 
         $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     * The OR clauses are alternatives to each other, so asking for two of
+     * them used to stack both into the statement.
+     */
+    #[DataProvider('provideConflictClausePair')]
+    public function testTwoConflictClauses($first, $second, $message)
+    {
+        $this->query->$first()
+                    ->$second()
+                    ->into('t1')
+                    ->cols(array('c1'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage($message);
+        $this->query->__toString();
+    }
+
+    public static function provideConflictClausePair()
+    {
+        return array(
+            array('orIgnore', 'orReplace', 'OR IGNORE and OR REPLACE'),
+            array('ignore', 'orReplace', 'OR IGNORE and OR REPLACE'),
+            array('orAbort', 'orFail', 'OR ABORT and OR FAIL'),
+            array('orRollback', 'orAbort', 'OR ABORT and OR ROLLBACK'),
+        );
+    }
+
+    /**
+     * Switching from one clause to another is fine as long as the first is
+     * turned off, and all three of them being off is a plain INSERT.
+     */
+    public function testSwitchConflictClause()
+    {
+        $this->query->orIgnore()
+                    ->orIgnore(false)
+                    ->orReplace()
+                    ->into('t1')
+                    ->cols(array('c1', 'c2', 'c3'))
+                    ->set('c4', 'NOW()')
+                    ->set('c5', null);
+
+        $this->assertSameSql(
+            sprintf($this->expected_sql_with_flag, 'OR REPLACE'),
+            $this->query->__toString()
+        );
+
+        $this->query->orReplace(false);
+        $this->assertSameSql(
+            str_replace('%s ', '', $this->expected_sql_with_flag),
+            $this->query->__toString()
+        );
     }
 }

--- a/tests/Sqlite/UpdateTest.php
+++ b/tests/Sqlite/UpdateTest.php
@@ -3,6 +3,7 @@ namespace Aura\SqlQuery\Sqlite;
 
 use Aura\SqlQuery\Common;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UpdateTest extends Common\UpdateTest
 {
@@ -254,5 +255,32 @@ class UpdateTest extends Common\UpdateTest
 
         $this->assertSame(10, $this->query->getLimit());
         $this->assertSame(5, $this->query->getOffset());
+    }
+
+    /**
+     * The OR clauses are alternatives to each other, so asking for two of
+     * them used to stack both into the statement.
+     */
+    #[DataProvider('provideConflictClausePair')]
+    public function testTwoConflictClauses($first, $second, $message)
+    {
+        $this->query->$first()
+                    ->$second()
+                    ->table('t1')
+                    ->cols(array('c1'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage($message);
+        $this->query->__toString();
+    }
+
+    public static function provideConflictClausePair()
+    {
+        return array(
+            array('orIgnore', 'orReplace', 'OR IGNORE and OR REPLACE'),
+            array('ignore', 'orReplace', 'OR IGNORE and OR REPLACE'),
+            array('orAbort', 'orFail', 'OR ABORT and OR FAIL'),
+            array('orRollback', 'orAbort', 'OR ABORT and OR ROLLBACK'),
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MySQL `REPLACE` statements now reject incompatible modifiers and conflicting priority options with clear build-time errors.
  - SQLite `INSERT` and `UPDATE` statements now prevent multiple conflict clauses from being combined.
  - Switching between SQLite conflict clauses continues to work correctly.
- **Tests**
  - Expanded coverage verifies valid modifiers, invalid combinations, conflict handling, and affected database results.
- **Documentation**
  - Updated the unreleased changelog with these behavior fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->