### PR TITLE
Add ON CONFLICT upsert for Postgres and SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,11 @@
   conflict target is Postgres-only -- SQLite accepts a column list and
   nothing else, and rejects that syntax -- so passing it to Sqlite\Insert
   throws Exception\BadMethodCallException instead of building SQL the
-  database cannot parse. Addresses the Postgres half of #124.
+  database cannot parse. An empty target -- `onConflict([])`,
+  `onConflict('')`, a blank column in the array, or the bare keyword
+  `ON CONSTRAINT` -- throws Exception\InvalidArgumentException, rather than
+  rendering `ON CONFLICT ()` for the database to reject. Addresses the
+  Postgres half of #124.
 
 - [CHG] Calling `ignore()`, `orReplace()` or the upsert methods on a
   dialect that does not support them now throws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,11 @@
   renders `ON CONFLICT (...) DO NOTHING` instead of `INSERT OR IGNORE`.
   Note that a raw `doUpdate()` expression must qualify any column it names
   on Postgres, which reads a bare name as ambiguous between the target
-  table and `excluded`; SQLite accepts either. Addresses the Postgres half
-  of #124.
+  table and `excluded`; SQLite accepts either. The `ON CONSTRAINT <name>`
+  conflict target is Postgres-only -- SQLite accepts a column list and
+  nothing else, and rejects that syntax -- so passing it to Sqlite\Insert
+  throws Exception\BadMethodCallException instead of building SQL the
+  database cannot parse. Addresses the Postgres half of #124.
 
 - [CHG] Calling `ignore()`, `orReplace()` or the upsert methods on a
   dialect that does not support them now throws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,34 @@
   deprecated aliases. Sqlsrv, which has no equivalent, keeps throwing
   Exception\BadMethodCallException. Fixes #172; related to #158.
 
+- [ADD] Pgsql\Insert and Sqlite\Insert gain an upsert API:
+  `onConflict()` sets the conflict target (a column, an array of columns,
+  or `ON CONSTRAINT <name>`), and `doUpdateCol()`, `doUpdateCols()`,
+  `doUpdate()` and `doUpdateWhere()` build the `DO UPDATE SET` clause.
+  `doUpdateCols()` refers to the proposed row through the `excluded`
+  pseudo-table, `doUpdateCol()` binds a separate value, and `doUpdate()`
+  takes a raw expression. The two dialects share Common\OnConflictUpdate
+  Trait and Common\BuildOnConflictTrait, since SQLite adopted the Postgres
+  grammar in 3.24. Both databases require a conflict target for DO UPDATE,
+  and combining `ignore()` with the doUpdate methods is contradictory;
+  either throws Exception\LogicException at build time. On SQLite the
+  clause cannot be mixed with the `OR` flags, and `ignore()` with a target
+  renders `ON CONFLICT (...) DO NOTHING` instead of `INSERT OR IGNORE`.
+  Note that a raw `doUpdate()` expression must qualify any column it names
+  on Postgres, which reads a bare name as ambiguous between the target
+  table and `excluded`; SQLite accepts either. Addresses the Postgres half
+  of #124.
+
+- [CHG] Calling `ignore()`, `orReplace()` or the upsert methods on a
+  dialect that does not support them now throws
+  Exception\BadMethodCallException everywhere. Common\Insert::ignore()
+  already did, but there was no counterpart on Common\Update or
+  Common\Delete and none for orReplace(), so most unsupported combinations
+  were a fatal "call to undefined method" instead: ignore() on Pgsql
+  Update/Delete, Sqlsrv Update and Sqlite Delete, and orReplace() on Pgsql
+  and Sqlsrv Insert. These are correct refusals rather than gaps to fill --
+  SQLite's DELETE grammar has no OR clause, and Postgres has no REPLACE.
+
 - [FIX] Mysql\Insert::orReplace() combined with highPriority() or ignore()
   built `REPLACE HIGH_PRIORITY INTO` / `REPLACE IGNORE INTO`, which MySQL
   rejects at parse time: rewriting the INSERT keyword left the flags in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,11 +94,12 @@
   but there was no counterpart on Common\Update or Common\Delete and none
   for orReplace(), so most unsupported combinations were a fatal "call to
   undefined method" instead: `ignore()` on Pgsql Update and Delete, Sqlite
-  Delete, and Sqlsrv Update and Delete; `orReplace()` on Mysql Update,
-  Pgsql Insert and Update, and Sqlsrv Insert and Update. These are correct
-  refusals rather than gaps to fill -- SQLite's DELETE grammar has no OR
-  clause, and Postgres has no REPLACE. `orReplace()` on a Delete remains
-  undefined on every dialect, since no dialect has such a flag there.
+  Delete, and Sqlsrv Update and Delete (since SQL Server has no DELETE
+  IGNORE equivalent); `orReplace()` on Mysql Update, Pgsql Insert and
+  Update, and Sqlsrv Insert and Update. These are correct refusals rather
+  than gaps to fill -- SQLite's DELETE grammar has no OR clause, and
+  Postgres has no REPLACE. `orReplace()` on a Delete remains undefined on
+  every dialect, since no dialect has such a flag there.
 
 - [FIX] Mysql\Insert::orReplace() combined with highPriority() or ignore()
   built `REPLACE HIGH_PRIORITY INTO` / `REPLACE IGNORE INTO`, which MySQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,13 +90,15 @@
 
 - [CHG] Calling `ignore()`, `orReplace()` or the upsert methods on a
   dialect that does not support them now throws
-  Exception\BadMethodCallException everywhere. Common\Insert::ignore()
-  already did, but there was no counterpart on Common\Update or
-  Common\Delete and none for orReplace(), so most unsupported combinations
-  were a fatal "call to undefined method" instead: ignore() on Pgsql
-  Update/Delete, Sqlsrv Update and Sqlite Delete, and orReplace() on Pgsql
-  and Sqlsrv Insert. These are correct refusals rather than gaps to fill --
-  SQLite's DELETE grammar has no OR clause, and Postgres has no REPLACE.
+  Exception\BadMethodCallException. Common\Insert::ignore() already did,
+  but there was no counterpart on Common\Update or Common\Delete and none
+  for orReplace(), so most unsupported combinations were a fatal "call to
+  undefined method" instead: `ignore()` on Pgsql Update and Delete, Sqlite
+  Delete, and Sqlsrv Update and Delete; `orReplace()` on Mysql Update,
+  Pgsql Insert and Update, and Sqlsrv Insert and Update. These are correct
+  refusals rather than gaps to fill -- SQLite's DELETE grammar has no OR
+  clause, and Postgres has no REPLACE. `orReplace()` on a Delete remains
+  undefined on every dialect, since no dialect has such a flag there.
 
 - [FIX] Mysql\Insert::orReplace() combined with highPriority() or ignore()
   built `REPLACE HIGH_PRIORITY INTO` / `REPLACE IGNORE INTO`, which MySQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@
   combination now throws Exception\LogicException when the statement is
   built, whichever order the two methods were called in.
 
+- [FIX] Mysql\Insert::orReplace() combined with the
+  onDuplicateKeyUpdate*() methods built
+  `REPLACE INTO ... ON DUPLICATE KEY UPDATE`, which MySQL rejects with a
+  1064 syntax error: REPLACE resolves a conflict by deleting the old row,
+  so it has no update clause to take. The combination now throws
+  Exception\LogicException when the statement is built.
+
 - [FIX] Mysql\Insert accepted two priority modifiers at once, building
   `INSERT LOW_PRIORITY HIGH_PRIORITY INTO` and the like; MySQL takes at
   most one of LOW_PRIORITY, HIGH_PRIORITY and DELAYED, on REPLACE as well

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,26 @@ for this dialect.
 
 [odbc]: https://learn.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server
 
+## Checking the documentation examples
+
+Every `php` example in `docs/` that is followed by a `sql` block is checked
+against the SQL the builder really emits, so the two cannot drift apart:
+
+```sh
+php ../scripts/verify-doc-examples.php .
+```
+
+The checker is shared between Aura packages and lives outside this repo, in
+`scripts/verify-doc-examples.php` alongside the package checkouts; adjust the
+path if yours sit elsewhere. What it needs from a package is the adapter at
+`tests/doc-examples.php`, which says where the docs are, which query factory an
+example expects, and how to turn the result into SQL.
+
+It exits non-zero on the first mismatch and names the file and line, so a
+changed clause shows up as a failing example rather than as stale docs. Write
+examples as complete statements — the checker evaluates each `php` block on its
+own, so a snippet that continues an earlier one has nothing to build.
+
 A test class skips only when its `DB_*_DSN` is unset. Once a DSN is set, the
 tests try to connect for real, and anything wrong from there on — a missing
 extension, a missing ODBC driver, an unreachable server, a bad password —

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -74,11 +74,11 @@ this differs from the PostgreSQL objects, which reject it.
 In addition, the MySQL _Insert_ object has support for `ON DUPLICATE KEY UPDATE`:
 
 - `onDuplicateKeyUpdate($col, $raw_value)` sets a raw value
-- `onDuplicateKeyUpateCol($col, $value)` is a `col()` equivalent for the update
-- `onDuplicateKeyUpdateCols($cols)` is a `cols()`equivalent for the update
+- `onDuplicateKeyUpdateCol($col, $value)` is a `col()` equivalent for the update
+- `onDuplicateKeyUpdateCols($cols)` is a `cols()` equivalent for the update
 
 Placeholders for bound values in the `ON DUPLICATE KEY UPDATE` portions will be
-automatically suffixed with `__on_duplicate key` to deconflict them from the
+automatically suffixed with `__on_duplicate_key` to deconflict them from the
 insert placeholders.
 
 ## UPDATE

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -71,15 +71,75 @@ this differs from the PostgreSQL objects, which reject it.
 - `ignore()` to add or remove `IGNORE` flag
 - `delayed()` to add or remove `DELAYED` flag
 
+`ignore()` skips a row that would violate a constraint instead of raising an
+error:
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->ignore()
+    ->into('users')
+    ->cols(['email' => 'alice@example.com', 'name' => 'Alice']);
+```
+
+```sql
+INSERT IGNORE INTO `users` (
+    `email`,
+    `name`
+) VALUES (
+    :email,
+    :name
+)
+```
+
+The flags are not all combinable. `REPLACE` accepts only `LOW_PRIORITY` and
+`DELAYED`, so pairing `orReplace()` with `highPriority()` or `ignore()` throws
+`Aura\SqlQuery\Exception\LogicException`; and since `LOW_PRIORITY`,
+`HIGH_PRIORITY` and `DELAYED` are alternatives to one another, asking for two of
+them throws as well. Both are raised when the statement is built, whichever
+order the methods were called in.
+
+### ON DUPLICATE KEY UPDATE
+
 In addition, the MySQL _Insert_ object has support for `ON DUPLICATE KEY UPDATE`:
 
 - `onDuplicateKeyUpdate($col, $raw_value)` sets a raw value
 - `onDuplicateKeyUpdateCol($col, $value)` is a `col()` equivalent for the update
 - `onDuplicateKeyUpdateCols($cols)` is a `cols()` equivalent for the update
 
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->into('users')
+    ->cols(['email' => 'alice@example.com', 'name' => 'Alice', 'hits' => 1])
+    ->onDuplicateKeyUpdateCol('name', 'Updated')
+    ->onDuplicateKeyUpdate('hits', 'hits + 1');
+```
+
+```sql
+INSERT INTO `users` (
+    `email`,
+    `name`,
+    `hits`
+) VALUES (
+    :email,
+    :name,
+    :hits
+) ON DUPLICATE KEY UPDATE
+    `name` = :name__on_duplicate_key,
+    `hits` = hits + 1
+```
+
 Placeholders for bound values in the `ON DUPLICATE KEY UPDATE` portions will be
 automatically suffixed with `__on_duplicate_key` to deconflict them from the
-insert placeholders.
+insert placeholders — here the bind values are `email`, `name` and `hits` for
+the insert, plus `name__on_duplicate_key` for the update.
+
+Unlike MySQL, PostgreSQL and SQLite take an explicit conflict target and spell
+this `ON CONFLICT ... DO UPDATE`; see [the PostgreSQL page](./pgsql.md). Note
+that `onDuplicateKeyUpdateCols(['name'])` with no value emits a *new* placeholder
+for you to bind, where the `doUpdateCols(['name'])` of those dialects reuses the
+value you tried to insert.
 
 ## UPDATE
 
@@ -89,6 +149,26 @@ insert placeholders.
 - `orderBy()` to add an ORDER BY clause flag
 - `limit()` to set a LIMIT count
 
+`ignore()` here skips the rows whose update would violate a constraint, leaving
+the rest of the statement to apply:
+
+```php
+$update = $queryFactory->newUpdate();
+$update
+    ->ignore()
+    ->table('users')
+    ->cols(['email' => 'alice@example.com'])
+    ->where('id = :id', ['id' => 1]);
+```
+
+```sql
+UPDATE IGNORE `users`
+SET
+    `email` = :email
+WHERE
+    id = :id
+```
+
 ## DELETE
 
 - `lowPriority()` to add or remove `LOW_PRIORITY` flag
@@ -96,3 +176,20 @@ insert placeholders.
 - `quick()` to add or remove `QUICK` flag
 - `orderBy()` to add an ORDER BY clause
 - `limit()` to set a LIMIT count
+
+`ignore()` downgrades the errors a delete would raise — a restricting foreign
+key, say — to warnings, leaving the offending rows in place:
+
+```php
+$delete = $queryFactory->newDelete();
+$delete
+    ->ignore()
+    ->from('users')
+    ->where('id = :id', ['id' => 1]);
+```
+
+```sql
+DELETE IGNORE FROM `users`
+WHERE
+    id = :id
+```

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -71,10 +71,21 @@ this differs from the PostgreSQL objects, which reject it.
 - `ignore()` to add or remove `IGNORE` flag
 - `delayed()` to add or remove `DELAYED` flag
 
-`ignore()` downgrades the errors a row would raise into warnings and skips it.
-MySQL casts this net wider than the other dialects: duplicate keys, `NOT NULL`,
-`CHECK` and foreign-key violations are all demoted, so check
-`SHOW WARNINGS` rather than assuming every row landed:
+`ignore()` downgrades the errors a row would raise into warnings. MySQL casts
+this net wider than the other dialects, but the outcome is not always a skipped
+row, so it pays to know which half you are in:
+
+- A *constraint* violation discards the row. Duplicate keys, `CHECK` and
+  foreign-key violations all leave the row uninserted.
+- An *invalid value* is adjusted and the row is inserted anyway. `NULL` for a
+  `NOT NULL` column becomes that type's implicit default (`''` for a string,
+  `0` for a number), and an out-of-range number is clamped — `9999` into a
+  `TINYINT` lands as `127`.
+
+So `SHOW WARNINGS` is worth checking either way, but do not read a warning as
+"the row was skipped": it may equally mean the row landed with a value MySQL
+rewrote for you. Where that matters, validate before inserting rather than
+relying on `IGNORE`.
 
 ```php
 $insert = $queryFactory->newInsert();
@@ -151,8 +162,11 @@ value you tried to insert.
 - `orderBy()` to add an ORDER BY clause flag
 - `limit()` to set a LIMIT count
 
-`ignore()` here skips the rows whose update would violate a constraint, leaving
-the rest of the statement to apply:
+`ignore()` here leaves the rest of the statement to apply when one row fails.
+The same split as for INSERT above applies: a row whose update would violate a
+constraint is left unchanged, while an invalid value is adjusted and written —
+setting a `NOT NULL` column to `NULL` stores the implicit default and counts as
+an updated row rather than a skipped one:
 
 ```php
 $update = $queryFactory->newUpdate();

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -71,8 +71,10 @@ this differs from the PostgreSQL objects, which reject it.
 - `ignore()` to add or remove `IGNORE` flag
 - `delayed()` to add or remove `DELAYED` flag
 
-`ignore()` skips a row that would violate a constraint instead of raising an
-error:
+`ignore()` downgrades the errors a row would raise into warnings and skips it.
+MySQL casts this net wider than the other dialects: duplicate keys, `NOT NULL`,
+`CHECK` and foreign-key violations are all demoted, so check
+`SHOW WARNINGS` rather than assuming every row landed:
 
 ```php
 $insert = $queryFactory->newInsert();

--- a/docs/pgsql.md
+++ b/docs/pgsql.md
@@ -59,7 +59,9 @@ clause on those and the statement could only fail at execute time.
 ### Skipping conflicting rows
 
 `ignore()` renders `ON CONFLICT DO NOTHING`, so a row that would violate a
-constraint is skipped instead of raising an error:
+unique or exclusion constraint is skipped instead of raising an error. Only
+those two kinds of conflict are covered — a `NOT NULL`, `CHECK` or foreign-key
+violation still raises, with or without the clause:
 
 ```php
 $insert = $queryFactory->newInsert();
@@ -80,8 +82,9 @@ INSERT INTO "users" (
 ON CONFLICT DO NOTHING
 ```
 
-On its own it covers a conflict on any constraint. Adding `onConflict()` narrows
-it to one, so conflicts elsewhere still raise:
+On its own it covers a conflict on any unique or exclusion constraint. Adding
+`onConflict()` narrows it to the one named, so a conflict on a different
+constraint still raises:
 
 ```php
 $insert = $queryFactory->newInsert();

--- a/docs/pgsql.md
+++ b/docs/pgsql.md
@@ -56,6 +56,53 @@ clause on those and the statement could only fail at execute time.
 - `onConflict()`, `doUpdateCol()`, `doUpdateCols()`, `doUpdate()` and
   `doUpdateWhere()` to add an `ON CONFLICT ... DO UPDATE SET` clause
 
+### Skipping conflicting rows
+
+`ignore()` renders `ON CONFLICT DO NOTHING`, so a row that would violate a
+constraint is skipped instead of raising an error:
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->ignore()
+    ->into('users')
+    ->cols(['email' => 'alice@example.com', 'name' => 'Alice']);
+```
+
+```sql
+INSERT INTO "users" (
+    "email",
+    "name"
+) VALUES (
+    :email,
+    :name
+)
+ON CONFLICT DO NOTHING
+```
+
+On its own it covers a conflict on any constraint. Adding `onConflict()` narrows
+it to one, so conflicts elsewhere still raise:
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->ignore()
+    ->onConflict('email')
+    ->into('users')
+    ->cols(['email' => 'alice@example.com', 'name' => 'Alice']);
+```
+
+```sql
+INSERT INTO "users" (
+    "email",
+    "name"
+) VALUES (
+    :email,
+    :name
+)
+ON CONFLICT ("email") DO NOTHING
+```
+
 ### Upsert with ON CONFLICT
 
 `onConflict()` names the conflict target, and the `doUpdate*()` methods say what

--- a/docs/pgsql.md
+++ b/docs/pgsql.md
@@ -52,6 +52,63 @@ clause on those and the statement could only fail at execute time.
 ## INSERT
 
 - `returning()` to add a `RETURNING` clause
+- `ignore()` to add an `ON CONFLICT DO NOTHING` clause
+- `onConflict()`, `doUpdateCol()`, `doUpdateCols()`, `doUpdate()` and
+  `doUpdateWhere()` to add an `ON CONFLICT ... DO UPDATE SET` clause
+
+### Upsert with ON CONFLICT
+
+`onConflict()` names the conflict target, and the `doUpdate*()` methods say what
+to change when a row already conflicts:
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->into('users')
+    ->cols(['email' => 'alice@example.com', 'name' => 'Alice'])
+    ->onConflict('email')
+    ->doUpdateCols(['name']);
+```
+
+```sql
+INSERT INTO "users" (
+    "email",
+    "name"
+) VALUES (
+    :email,
+    :name
+)
+ON CONFLICT ("email") DO UPDATE SET
+    "name" = excluded."name"
+```
+
+The target may be one column, an array of columns, or a named constraint written
+as `onConflict('ON CONSTRAINT users_email_key')`. PostgreSQL requires a target
+for `DO UPDATE`; omitting it throws `Aura\SqlQuery\Exception\LogicException`
+rather than failing at execute time. Combining `ignore()` with the `doUpdate*()`
+methods also throws, since a statement cannot both do nothing and update.
+
+`doUpdateCols()` refers to the values you tried to insert through the `excluded`
+pseudo-table. `doUpdateCol()` binds a separate value instead, and `doUpdate()`
+takes a raw expression. `doUpdateWhere()` adds a condition that decides whether
+the conflicting row is updated at all.
+
+### Qualify columns in raw doUpdate() expressions
+
+Inside `DO UPDATE SET`, an unqualified column name is ambiguous between the table
+being inserted into and the `excluded` pseudo-table, and PostgreSQL rejects it:
+
+```php
+// ERROR: column reference "hits" is ambiguous
+$insert->onConflict('id')->doUpdate('hits', 'hits + 1');
+
+// correct
+$insert->onConflict('id')->doUpdate('hits', 'pages.hits + 1');
+```
+
+This applies only to raw expressions passed to `doUpdate()`; `doUpdateCols()` and
+`doUpdateCol()` build qualified references for you. Note that SQLite accepts the
+unqualified form, so an expression that works there can still fail here.
 
 ### Last Insert IDs and Table Inheritance
 

--- a/docs/pgsql.md
+++ b/docs/pgsql.md
@@ -82,16 +82,89 @@ ON CONFLICT ("email") DO UPDATE SET
     "name" = excluded."name"
 ```
 
-The target may be one column, an array of columns, or a named constraint written
-as `onConflict('ON CONSTRAINT users_email_key')`. PostgreSQL requires a target
-for `DO UPDATE`; omitting it throws `Aura\SqlQuery\Exception\LogicException`
-rather than failing at execute time. Combining `ignore()` with the `doUpdate*()`
-methods also throws, since a statement cannot both do nothing and update.
+Here `email` is both an inserted column and the conflict target: the row is
+inserted if that email is new, and its `name` is overwritten with the proposed
+`'Alice'` if the email is already present.
 
-`doUpdateCols()` refers to the values you tried to insert through the `excluded`
-pseudo-table. `doUpdateCol()` binds a separate value instead, and `doUpdate()`
-takes a raw expression. `doUpdateWhere()` adds a condition that decides whether
-the conflicting row is updated at all.
+The target must be covered by a unique index or primary key. It may be one
+column, an array of columns, or a named constraint:
+
+```php
+$insert->onConflict('email');                         // ON CONFLICT ("email")
+$insert->onConflict(['tenant_id', 'email']);          // ON CONFLICT ("tenant_id", "email")
+$insert->onConflict('ON CONSTRAINT users_email_key'); // ON CONFLICT ON CONSTRAINT "users_email_key"
+```
+
+PostgreSQL requires a target for `DO UPDATE`; omitting it throws
+`Aura\SqlQuery\Exception\LogicException` rather than failing at execute time.
+Combining `ignore()` with the `doUpdate*()` methods also throws, since a
+statement cannot both do nothing and update.
+
+#### Setting the updated values
+
+`doUpdateCol()` binds a value of your own rather than reusing the proposed one,
+and `doUpdate()` takes a raw expression, which is not escaped. This statement
+inserts a page row, and on conflict keeps the proposed title, stamps a fixed
+status, and increments the existing hit count:
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->into('pages')
+    ->cols(['slug' => 'home', 'title' => 'Home', 'hits' => 1])
+    ->onConflict('slug')
+    ->doUpdateCols(['title'])
+    ->doUpdateCol('status', 'revised')
+    ->doUpdate('hits', 'pages.hits + 1');
+```
+
+```sql
+INSERT INTO "pages" (
+    "slug",
+    "title",
+    "hits"
+) VALUES (
+    :slug,
+    :title,
+    :hits
+)
+ON CONFLICT ("slug") DO UPDATE SET
+    "title" = excluded."title",
+    "status" = :status__on_conflict,
+    "hits" = "pages"."hits" + 1
+```
+
+The bind values are `slug`, `title` and `hits` for the insert, plus
+`status__on_conflict` for the update; `doUpdateCol()` suffixes its placeholder so
+it cannot collide with the inserted column of the same name.
+
+`doUpdateWhere()` decides whether the conflicting row is updated at all. Without
+it every conflict updates; with it, a conflict whose row fails the condition is
+left untouched:
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->into('pages')
+    ->cols(['slug' => 'home', 'title' => 'Home'])
+    ->onConflict('slug')
+    ->doUpdateCols(['title'])
+    ->doUpdateWhere('pages.locked = :locked', ['locked' => false]);
+```
+
+```sql
+INSERT INTO "pages" (
+    "slug",
+    "title"
+) VALUES (
+    :slug,
+    :title
+)
+ON CONFLICT ("slug") DO UPDATE SET
+    "title" = excluded."title"
+WHERE
+    "pages"."locked" = :locked
+```
 
 ### Qualify columns in raw doUpdate() expressions
 

--- a/docs/pgsql.md
+++ b/docs/pgsql.md
@@ -95,6 +95,9 @@ $insert->onConflict(['tenant_id', 'email']);          // ON CONFLICT ("tenant_id
 $insert->onConflict('ON CONSTRAINT users_email_key'); // ON CONFLICT ON CONSTRAINT "users_email_key"
 ```
 
+The constraint-name form is PostgreSQL-only; SQLite takes a column list and
+nothing else, and rejects it.
+
 PostgreSQL requires a target for `DO UPDATE`; omitting it throws
 `Aura\SqlQuery\Exception\LogicException` rather than failing at execute time.
 Combining `ignore()` with the `doUpdate*()` methods also throws, since a

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -42,6 +42,11 @@ ON CONFLICT ("email") DO UPDATE SET
     "name" = excluded."name"
 ```
 
+The target may be one column or an array of them. Unlike PostgreSQL, SQLite has
+no constraint-name form, so `onConflict('ON CONSTRAINT users_email_key')` throws
+`Aura\SqlQuery\Exception\BadMethodCallException` here; name the indexed columns
+instead.
+
 A conflict target is required for `DO UPDATE`, and the `ON CONFLICT` clause
 cannot be combined with the `OR` flags above; either throws
 `Aura\SqlQuery\Exception\LogicException`. Calling `ignore()` together with a

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -17,7 +17,9 @@ The `OR` flags are alternatives to one another, so setting two of them throws
 
 ### Skipping conflicting rows
 
-`ignore()` renders the older `INSERT OR IGNORE` form:
+`ignore()` renders the older `INSERT OR IGNORE` form, which skips a row
+violating a `UNIQUE`, `NOT NULL` or `CHECK` constraint. Foreign keys are the
+exception: the conflict algorithm does not apply to them, so those still raise.
 
 ```php
 $insert = $queryFactory->newInsert();
@@ -37,8 +39,9 @@ INSERT OR IGNORE INTO "users" (
 )
 ```
 
-Adding `onConflict()` switches it to the newer clause, narrowing the skip to one
-constraint so conflicts elsewhere still raise:
+Adding `onConflict()` switches it to the newer clause. That narrows the skip
+twice over: to the constraint named, and to uniqueness conflicts alone — a
+`NOT NULL` violation that `INSERT OR IGNORE` would have skipped raises here:
 
 ```php
 $insert = $queryFactory->newInsert();

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -9,6 +9,48 @@ These 'sqlite' query objects have additional SQLite-specific behaviors.
 - `orIgnore()` to add or remove an `OR IGNORE` flag
 - `orReplace()` to add or remove an `OR REPLACE` flag
 - `orRollback()` to add or remove an `OR ROLLBACK` flag
+- `onConflict()`, `doUpdateCol()`, `doUpdateCols()`, `doUpdate()` and
+  `doUpdateWhere()` to add an `ON CONFLICT ... DO UPDATE SET` clause
+
+The `OR` flags are alternatives to one another, so setting two of them throws
+`Aura\SqlQuery\Exception\LogicException`.
+
+### Upsert with ON CONFLICT
+
+SQLite adopted the PostgreSQL `ON CONFLICT` grammar in 3.24, and the methods
+here work the same way; see [the PostgreSQL page](./pgsql.md) for the full
+description.
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->into('users')
+    ->cols(['email' => 'alice@example.com', 'name' => 'Alice'])
+    ->onConflict('email')
+    ->doUpdateCols(['name']);
+```
+
+```sql
+INSERT INTO "users" (
+    "email",
+    "name"
+) VALUES (
+    :email,
+    :name
+)
+ON CONFLICT ("email") DO UPDATE SET
+    "name" = excluded."name"
+```
+
+A conflict target is required for `DO UPDATE`, and the `ON CONFLICT` clause
+cannot be combined with the `OR` flags above; either throws
+`Aura\SqlQuery\Exception\LogicException`. Calling `ignore()` together with a
+conflict target renders `ON CONFLICT (...) DO NOTHING` rather than
+`INSERT OR IGNORE`.
+
+Unlike PostgreSQL, SQLite accepts an unqualified column name in a raw
+`doUpdate()` expression, so `doUpdate('hits', 'hits + 1')` runs here but is
+ambiguous on PostgreSQL. Qualify the column if the same code has to run on both.
 
 ## UPDATE
 

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -6,7 +6,7 @@ These 'sqlite' query objects have additional SQLite-specific behaviors.
 
 - `orAbort()` to add or remove an `OR ABORT` flag
 - `orFail()` to add or remove an `OR FAIL` flag
-- `orIgnore()` to add or remove an `OR IGNORE` flag
+- `ignore()`, or the deprecated `orIgnore()`, to add or remove an `OR IGNORE` flag
 - `orReplace()` to add or remove an `OR REPLACE` flag
 - `orRollback()` to add or remove an `OR ROLLBACK` flag
 - `onConflict()`, `doUpdateCol()`, `doUpdateCols()`, `doUpdate()` and
@@ -15,11 +15,56 @@ These 'sqlite' query objects have additional SQLite-specific behaviors.
 The `OR` flags are alternatives to one another, so setting two of them throws
 `Aura\SqlQuery\Exception\LogicException`.
 
+### Skipping conflicting rows
+
+`ignore()` renders the older `INSERT OR IGNORE` form:
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->ignore()
+    ->into('users')
+    ->cols(['email' => 'alice@example.com', 'name' => 'Alice']);
+```
+
+```sql
+INSERT OR IGNORE INTO "users" (
+    "email",
+    "name"
+) VALUES (
+    :email,
+    :name
+)
+```
+
+Adding `onConflict()` switches it to the newer clause, narrowing the skip to one
+constraint so conflicts elsewhere still raise:
+
+```php
+$insert = $queryFactory->newInsert();
+$insert
+    ->ignore()
+    ->onConflict('email')
+    ->into('users')
+    ->cols(['email' => 'alice@example.com', 'name' => 'Alice']);
+```
+
+```sql
+INSERT INTO "users" (
+    "email",
+    "name"
+) VALUES (
+    :email,
+    :name
+)
+ON CONFLICT ("email") DO NOTHING
+```
+
 ### Upsert with ON CONFLICT
 
 SQLite adopted the PostgreSQL `ON CONFLICT` grammar in 3.24, and the methods
-here work the same way; see [the PostgreSQL page](./pgsql.md) for the full
-description.
+here work the same way; see [the PostgreSQL page](./pgsql.md) for
+`doUpdateCol()`, `doUpdate()` and `doUpdateWhere()` examples.
 
 ```php
 $insert = $queryFactory->newInsert();
@@ -61,7 +106,7 @@ ambiguous on PostgreSQL. Qualify the column if the same code has to run on both.
 
 - `orAbort()` to add or remove an `OR ABORT` flag
 - `orFail()` to add or remove an `OR FAIL` flag
-- `orIgnore()` to add or remove an `OR IGNORE` flag
+- `ignore()`, or the deprecated `orIgnore()`, to add or remove an `OR IGNORE` flag
 - `orReplace()` to add or remove an `OR REPLACE` flag
 - `orRollback()` to add or remove an `OR ROLLBACK` flag
 - `orderBy()` to add an ORDER BY clause
@@ -70,11 +115,10 @@ ambiguous on PostgreSQL. Qualify the column if the same code has to run on both.
 
 ## DELETE
 
-- `orAbort()` to add or remove an `OR ABORT` flag
-- `orFail()` to add or remove an `OR FAIL` flag
-- `orIgnore()` to add or remove an `OR IGNORE` flag
-- `orReplace()` to add or remove an `OR REPLACE` flag
-- `orRollback()` to add or remove an `OR ROLLBACK` flag
 - `orderBy()` to add an ORDER BY clause
 - `limit()` to set a LIMIT count
 - `offset()` to set an OFFSET count
+
+SQLite's DELETE grammar has no conflict clause, so none of the `OR` flags above
+are available here; calling `ignore()` throws
+`Aura\SqlQuery\Exception\BadMethodCallException`.

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -40,7 +40,7 @@ INSERT OR IGNORE INTO "users" (
 ```
 
 Adding `onConflict()` switches it to the newer clause. That narrows the skip
-twice over: to the constraint named, and to uniqueness conflicts alone — a
+twice over: to the conflict target given, and to uniqueness conflicts alone — a
 `NOT NULL` violation that `INSERT OR IGNORE` would have skipped raises here:
 
 ```php
@@ -96,10 +96,10 @@ no constraint-name form, so `onConflict('ON CONSTRAINT users_email_key')` throws
 instead.
 
 A conflict target is required for `DO UPDATE`, and the `ON CONFLICT` clause
-cannot be combined with the `OR` flags above; either throws
-`Aura\SqlQuery\Exception\LogicException`. Calling `ignore()` together with a
-conflict target renders `ON CONFLICT (...) DO NOTHING` rather than
-`INSERT OR IGNORE`.
+cannot be combined with the other `OR` flags above; either throws
+`Aura\SqlQuery\Exception\LogicException`. `ignore()` is the one exception:
+calling it together with a conflict target is handled specially and renders
+`ON CONFLICT (...) DO NOTHING` rather than `INSERT OR IGNORE`.
 
 Unlike PostgreSQL, SQLite accepts an unqualified column name in a raw
 `doUpdate()` expression, so `doUpdate('hits', 'hits + 1')` runs here but is

--- a/src/Common/BuildOnConflictTrait.php
+++ b/src/Common/BuildOnConflictTrait.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+use Aura\SqlQuery\Exception;
+
+/**
+ *
+ * A trait to build ON CONFLICT clauses for Postgres and SQLite.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait BuildOnConflictTrait
+{
+    /**
+     *
+     * Builds the `ON CONFLICT` clause of the statement.
+     *
+     * @param string|array $target The conflict target.
+     * @param array $update_values The columns and values to update.
+     * @param array $where Optional WHERE conditions.
+     * @param bool $ignore Whether the ignore clause is enabled.
+     * @return string
+     * @throws Exception\LogicException
+     *
+     */
+    public function buildOnConflict($target, $update_values, $where, $ignore)
+    {
+        if ($ignore && ! empty($update_values)) {
+            throw new Exception\LogicException(
+                'Cannot combine IGNORE / DO NOTHING with DO UPDATE SET.'
+            );
+        }
+
+        if ($ignore) {
+            if (empty($target)) {
+                return PHP_EOL . 'ON CONFLICT DO NOTHING';
+            }
+            return PHP_EOL . 'ON CONFLICT ' . $target . ' DO NOTHING';
+        }
+
+        if (empty($update_values)) {
+            return '';
+        }
+
+        if (empty($target)) {
+            throw new Exception\LogicException(
+                'Database requires a conflict target for DO UPDATE.'
+            );
+        }
+
+        $update_str = $this->buildConflictUpdateValues($update_values);
+        $where_str = $this->buildConflictWhere($where);
+
+        return PHP_EOL . "ON CONFLICT {$target} DO UPDATE SET{$update_str}{$where_str}";
+    }
+
+    /**
+     *
+     * Builds the conflict update values.
+     *
+     * @param array $update_values
+     * @return string
+     *
+     */
+    protected function buildConflictUpdateValues(array $update_values)
+    {
+        $values = array();
+        foreach ($update_values as $key => $row) {
+            $values[] = $key . ' = ' . $row;
+        }
+        return $this->indentCsv($values);
+    }
+
+    /**
+     *
+     * Builds the conflict update WHERE clause.
+     *
+     * @param array $where
+     * @return string
+     *
+     */
+    protected function buildConflictWhere(array $where)
+    {
+        if (empty($where)) {
+            return '';
+        }
+        return PHP_EOL . 'WHERE' . $this->indent($where);
+    }
+}

--- a/src/Common/Delete.php
+++ b/src/Common/Delete.php
@@ -9,6 +9,7 @@
 namespace Aura\SqlQuery\Common;
 
 use Aura\SqlQuery\AbstractDmlQuery;
+use Aura\SqlQuery\Exception\BadMethodCallException;
 
 /**
  *
@@ -43,6 +44,21 @@ class Delete extends AbstractDmlQuery implements DeleteInterface
     {
         $this->from = $this->quoter->quoteName($from);
         return $this;
+    }
+
+    /**
+     *
+     * Adds IGNORE flag depending on DB syntax.
+     *
+     * @param bool $enable Set or unset flag (default true).
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function ignore($enable = true)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support IGNORE flag");
     }
 
     /**

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -293,6 +293,99 @@ class Insert extends AbstractDmlQuery implements InsertInterface
 
     /**
      *
+     * Adds OR REPLACE flag depending on DB syntax.
+     *
+     * @param bool $enable Set or unset flag (default true).
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function orReplace($enable = true)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support OR REPLACE flag");
+    }
+
+    /**
+     *
+     * Sets the conflict target column(s) or constraint name.
+     *
+     * @param string|array $target
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function onConflict($target)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support ON CONFLICT clause");
+    }
+
+    /**
+     *
+     * Sets one column value placeholder for the UPDATE on conflict.
+     *
+     * @param string $col
+     * @param array $value
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function doUpdateCol($col, ...$value)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support DO UPDATE SET clause");
+    }
+
+    /**
+     *
+     * Sets multiple column value placeholders for the UPDATE on conflict.
+     *
+     * @param array $cols
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function doUpdateCols(array $cols)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support DO UPDATE SET clause");
+    }
+
+    /**
+     *
+     * Sets a column value directly for the UPDATE on conflict.
+     *
+     * @param string $col
+     * @param string $value
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function doUpdate($col, $value)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support DO UPDATE SET clause");
+    }
+
+    /**
+     *
+     * Adds a WHERE condition for the UPDATE on conflict.
+     *
+     * @param string $condition
+     * @param array $bind
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function doUpdateWhere($condition, ...$bind)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support ON CONFLICT ... WHERE clause");
+    }
+
+    /**
+     *
      * Finishes off the current row in a bulk insert, collecting the bulk
      * values and resetting for the next row.
      *

--- a/src/Common/OnConflictUpdateInterface.php
+++ b/src/Common/OnConflictUpdateInterface.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+/**
+ *
+ * An interface for UPSERT (ON CONFLICT DO UPDATE) queries.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+interface OnConflictUpdateInterface
+{
+    /**
+     *
+     * Sets the conflict target column(s) or constraint name.
+     *
+     * @param string|array $target The conflict target column(s) or constraint name.
+     *
+     * @return $this
+     *
+     */
+    public function onConflict($target);
+
+    /**
+     *
+     * Sets one column value placeholder for the UPDATE on conflict; if an optional
+     * second parameter is passed, that value is bound to the placeholder.
+     *
+     * @param string $col The column name.
+     *
+     * @param array $value Optional: a value to bind to the placeholder.
+     *
+     * @return $this
+     *
+     */
+    public function doUpdateCol($col, ...$value);
+
+    /**
+     *
+     * Sets multiple column value placeholders for the UPDATE on conflict. If an element
+     * is a key-value pair, the key is treated as the column name and the value is bound
+     * to that column.
+     *
+     * @param array $cols A list of column names, optionally as key-value
+     * pairs where the key is a column name and the value is a bind value for
+     * that column.
+     *
+     * @return $this
+     *
+     */
+    public function doUpdateCols(array $cols);
+
+    /**
+     *
+     * Sets a column value directly for the UPDATE on conflict; the value will not be
+     * escaped, although fully-qualified identifiers in the value will be quoted.
+     *
+     * @param string $col The column name.
+     *
+     * @param string $value The column value expression.
+     *
+     * @return $this
+     *
+     */
+    public function doUpdate($col, $value);
+
+    /**
+     *
+     * Adds a WHERE condition for the UPDATE on conflict.
+     *
+     * @param string $condition The WHERE condition.
+     *
+     * @param array $bind Optional: values to bind to the condition.
+     *
+     * @return $this
+     *
+     */
+    public function doUpdateWhere($condition, ...$bind);
+}

--- a/src/Common/OnConflictUpdateTrait.php
+++ b/src/Common/OnConflictUpdateTrait.php
@@ -73,25 +73,68 @@ trait OnConflictUpdateTrait
         if (is_array($target)) {
             $cols = array();
             foreach ($target as $col) {
-                $cols[] = $this->quoter->quoteName($col);
+                $cols[] = $this->quoter->quoteName($this->assertConflictName($col));
+            }
+            if (empty($cols)) {
+                throw new Exception\InvalidArgumentException(
+                    'onConflict() requires a column name or constraint.'
+                );
             }
             $this->conflict_target = '(' . implode(', ', $cols) . ')';
-        } else {
-            $target = trim($target);
-            if (stripos($target, 'ON CONSTRAINT ') === 0) {
-                if (! $this->allowsConstraintTarget()) {
-                    throw new Exception\BadMethodCallException(
-                        get_class($this)
-                        . " doesn't support a constraint-name conflict target"
-                    );
-                }
-                $constraint = trim(substr($target, 14));
-                $this->conflict_target = 'ON CONSTRAINT ' . $this->quoter->quoteName($constraint);
-            } else {
-                $this->conflict_target = '(' . $this->quoter->quoteName($target) . ')';
-            }
+            return $this;
         }
+
+        $target = trim((string) $target);
+
+        // the keyword with nothing after it; trimming has already taken the
+        // space the prefix test below looks for, so catch it here or it goes
+        // on to be quoted as a column named "ON CONSTRAINT"
+        if (strcasecmp($target, 'ON CONSTRAINT') === 0) {
+            throw new Exception\InvalidArgumentException(
+                'onConflict() requires a column name or constraint.'
+            );
+        }
+
+        if (stripos($target, 'ON CONSTRAINT ') === 0) {
+            if (! $this->allowsConstraintTarget()) {
+                throw new Exception\BadMethodCallException(
+                    get_class($this)
+                    . " doesn't support a constraint-name conflict target"
+                );
+            }
+            $constraint = $this->assertConflictName(substr($target, 14));
+            $this->conflict_target = 'ON CONSTRAINT ' . $this->quoter->quoteName($constraint);
+            return $this;
+        }
+
+        $this->conflict_target = '(' . $this->quoter->quoteName($this->assertConflictName($target)) . ')';
         return $this;
+    }
+
+    /**
+     *
+     * Returns the trimmed name, rejecting an empty one: it would render as
+     * `ON CONFLICT ()` or a zero-length quoted identifier, which the database
+     * refuses to parse.
+     *
+     * @param string $name The column or constraint name.
+     *
+     * @return string
+     *
+     * @throws Exception\InvalidArgumentException
+     *
+     */
+    protected function assertConflictName($name)
+    {
+        $name = trim((string) $name);
+
+        if ($name === '') {
+            throw new Exception\InvalidArgumentException(
+                'onConflict() requires a column name or constraint.'
+            );
+        }
+
+        return $name;
     }
 
     /**

--- a/src/Common/OnConflictUpdateTrait.php
+++ b/src/Common/OnConflictUpdateTrait.php
@@ -8,6 +8,8 @@
  */
 namespace Aura\SqlQuery\Common;
 
+use Aura\SqlQuery\Exception;
+
 /**
  *
  * A trait implementing OnConflictUpdateInterface.
@@ -17,6 +19,19 @@ namespace Aura\SqlQuery\Common;
  */
 trait OnConflictUpdateTrait
 {
+    /**
+     *
+     * Whether this dialect accepts `ON CONSTRAINT <name>` as the conflict
+     * target; SQLite takes only a column list, so it overrides this.
+     *
+     * @return bool
+     *
+     */
+    protected function allowsConstraintTarget()
+    {
+        return true;
+    }
+
     /**
      *
      * The conflict target column(s) or constraint name.
@@ -64,6 +79,12 @@ trait OnConflictUpdateTrait
         } else {
             $target = trim($target);
             if (stripos($target, 'ON CONSTRAINT ') === 0) {
+                if (! $this->allowsConstraintTarget()) {
+                    throw new Exception\BadMethodCallException(
+                        get_class($this)
+                        . " doesn't support a constraint-name conflict target"
+                    );
+                }
                 $constraint = trim(substr($target, 14));
                 $this->conflict_target = 'ON CONSTRAINT ' . $this->quoter->quoteName($constraint);
             } else {

--- a/src/Common/OnConflictUpdateTrait.php
+++ b/src/Common/OnConflictUpdateTrait.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+/**
+ *
+ * A trait implementing OnConflictUpdateInterface.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait OnConflictUpdateTrait
+{
+    /**
+     *
+     * The conflict target column(s) or constraint name.
+     *
+     * @var string|array
+     *
+     */
+    protected $conflict_target;
+
+    /**
+     *
+     * Column values for UPDATE on conflict.
+     *
+     * @var array
+     *
+     */
+    protected $conflict_update_values = [];
+
+    /**
+     *
+     * WHERE conditions for UPDATE on conflict.
+     *
+     * @var array
+     *
+     */
+    protected $conflict_where = [];
+
+    /**
+     *
+     * Sets the conflict target column(s) or constraint name.
+     *
+     * @param string|array $target The conflict target column(s) or constraint name.
+     *
+     * @return $this
+     *
+     */
+    public function onConflict($target)
+    {
+        if (is_array($target)) {
+            $cols = array();
+            foreach ($target as $col) {
+                $cols[] = $this->quoter->quoteName($col);
+            }
+            $this->conflict_target = '(' . implode(', ', $cols) . ')';
+        } else {
+            $target = trim($target);
+            if (stripos($target, 'ON CONSTRAINT ') === 0) {
+                $constraint = trim(substr($target, 14));
+                $this->conflict_target = 'ON CONSTRAINT ' . $this->quoter->quoteName($constraint);
+            } else {
+                $this->conflict_target = '(' . $this->quoter->quoteName($target) . ')';
+            }
+        }
+        return $this;
+    }
+
+    /**
+     *
+     * Sets one column value placeholder for the UPDATE on conflict; if an optional
+     * second parameter is passed, that value is bound to the placeholder.
+     *
+     * @param string $col The column name.
+     *
+     * @param array $value Optional: a value to bind to the placeholder.
+     *
+     * @return $this
+     *
+     */
+    public function doUpdateCol($col, ...$value)
+    {
+        $key = $this->quoter->quoteName($col);
+        if (count($value) > 0) {
+            $bind = $col . '__on_conflict';
+            $this->conflict_update_values[$key] = ":$bind";
+            $this->bindValue($bind, $value[0]);
+        } else {
+            $this->conflict_update_values[$key] = 'excluded.' . $key;
+        }
+        return $this;
+    }
+
+    /**
+     *
+     * Sets multiple column value placeholders for the UPDATE on conflict. If an element
+     * is a key-value pair, the key is treated as the column name and the value is bound
+     * to that column.
+     *
+     * @param array $cols A list of column names, optionally as key-value
+     * pairs where the key is a column name and the value is a bind value for
+     * that column.
+     *
+     * @return $this
+     *
+     */
+    public function doUpdateCols(array $cols)
+    {
+        foreach ($cols as $key => $val) {
+            if (is_int($key)) {
+                $this->doUpdateCol($val);
+            } else {
+                $this->doUpdateCol($key, $val);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     *
+     * Sets a column value directly for the UPDATE on conflict; the value will not be
+     * escaped, although fully-qualified identifiers in the value will be quoted.
+     *
+     * @param string $col The column name.
+     *
+     * @param string $value The column value expression.
+     *
+     * @return $this
+     *
+     */
+    public function doUpdate($col, $value)
+    {
+        if ($value === null) {
+            $value = 'NULL';
+        }
+        $key = $this->quoter->quoteName($col);
+        $value = $this->quoter->quoteNamesIn($value);
+        $this->conflict_update_values[$key] = $value;
+        return $this;
+    }
+
+    /**
+     *
+     * Adds a WHERE condition for the UPDATE on conflict.
+     *
+     * @param string $condition The WHERE condition.
+     *
+     * @param array $bind Optional: values to bind to the condition.
+     *
+     * @return $this
+     *
+     */
+    public function doUpdateWhere($condition, ...$bind)
+    {
+        $condition = $this->quoter->quoteNamesIn($condition);
+        if (count($bind) > 0) {
+            $condition = $this->rebuildCondAndBindValues($condition, $bind[0]);
+        }
+
+        if ($this->conflict_where) {
+            $this->conflict_where[] = "AND $condition";
+        } else {
+            $this->conflict_where[] = $condition;
+        }
+        return $this;
+    }
+}

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -9,6 +9,7 @@
 namespace Aura\SqlQuery\Common;
 
 use Aura\SqlQuery\AbstractDmlQuery;
+use Aura\SqlQuery\Exception\BadMethodCallException;
 use Aura\SqlQuery\Exception\LogicException;
 
 /**
@@ -67,6 +68,36 @@ class Update extends AbstractDmlQuery implements UpdateInterface
             . $this->builder->buildValuesForUpdate($this->col_values)
             . $this->builder->buildWhere($this->where)
             . $this->builder->buildOrderBy($this->order_by);
+    }
+
+    /**
+     *
+     * Adds IGNORE flag depending on DB syntax.
+     *
+     * @param bool $enable Set or unset flag (default true).
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function ignore($enable = true)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support IGNORE flag");
+    }
+
+    /**
+     *
+     * Adds OR REPLACE flag depending on DB syntax.
+     *
+     * @param bool $enable Set or unset flag (default true).
+     * @throws BadMethodCallException
+     * @return static
+     *
+     */
+    public function orReplace($enable = true)
+    {
+        // override in child classes
+        throw new BadMethodCallException(get_class($this) . " doesn't support OR REPLACE flag");
     }
 
     /**

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -270,6 +270,12 @@ class Insert extends Common\Insert
      */
     protected function build()
     {
+        if ($this->use_replace && ! empty($this->col_on_update_values)) {
+            throw new Exception\LogicException(
+                'A REPLACE statement cannot take an ON DUPLICATE KEY UPDATE clause.'
+            );
+        }
+
         $stm = parent::build();
 
         $this->assertOnePriorityFlag();

--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -17,9 +17,10 @@ use Aura\SqlQuery\Common;
  * @package Aura.SqlQuery
  *
  */
-class Insert extends Common\Insert implements ReturningInterface
+class Insert extends Common\Insert implements ReturningInterface, Common\OnConflictUpdateInterface
 {
     use ReturningTrait;
+    use Common\OnConflictUpdateTrait;
 
     /**
      *
@@ -56,7 +57,12 @@ class Insert extends Common\Insert implements ReturningInterface
     protected function build()
     {
         return parent::build()
-            . $this->builder->buildIgnore($this->ignore)
+            . $this->builder->buildOnConflict(
+                $this->conflict_target,
+                $this->conflict_update_values,
+                $this->conflict_where,
+                $this->ignore
+            )
             . $this->builder->buildReturning($this->returning);
     }
 

--- a/src/Pgsql/InsertBuilder.php
+++ b/src/Pgsql/InsertBuilder.php
@@ -21,22 +21,4 @@ class InsertBuilder extends Common\InsertBuilder
 {
     use BuildReturningTrait;
     use Common\BuildOnConflictTrait;
-
-    /**
-     *
-     * Builds the `ON CONFLICT DO NOTHING` clause of the statement.
-     *
-     * @param bool $ignore Whether the clause is enabled.
-     *
-     * @return string
-     *
-     */
-    public function buildIgnore($ignore)
-    {
-        if (! $ignore) {
-            return ''; // not applicable
-        }
-
-        return PHP_EOL . 'ON CONFLICT DO NOTHING';
-    }
 }

--- a/src/Pgsql/InsertBuilder.php
+++ b/src/Pgsql/InsertBuilder.php
@@ -20,6 +20,7 @@ use Aura\SqlQuery\Common;
 class InsertBuilder extends Common\InsertBuilder
 {
     use BuildReturningTrait;
+    use Common\BuildOnConflictTrait;
 
     /**
      *

--- a/src/Sqlite/Insert.php
+++ b/src/Sqlite/Insert.php
@@ -25,6 +25,19 @@ class Insert extends Common\Insert implements Common\OnConflictUpdateInterface
 
     /**
      *
+     * SQLite's UPSERT takes only a column list as the conflict target; the
+     * `ON CONSTRAINT <name>` form is Postgres-only.
+     *
+     * @return bool
+     *
+     */
+    protected function allowsConstraintTarget()
+    {
+        return false;
+    }
+
+    /**
+     *
      * Builds the statement.
      *
      * @return string

--- a/src/Sqlite/Insert.php
+++ b/src/Sqlite/Insert.php
@@ -9,6 +9,7 @@
 namespace Aura\SqlQuery\Sqlite;
 
 use Aura\SqlQuery\Common;
+use Aura\SqlQuery\Exception;
 
 /**
  *
@@ -17,9 +18,10 @@ use Aura\SqlQuery\Common;
  * @package Aura.SqlQuery
  *
  */
-class Insert extends Common\Insert
+class Insert extends Common\Insert implements Common\OnConflictUpdateInterface
 {
     use OrConflictTrait;
+    use Common\OnConflictUpdateTrait;
 
     /**
      *
@@ -30,8 +32,56 @@ class Insert extends Common\Insert
      */
     protected function build()
     {
+        $ignore = false;
+        $has_or_ignore = $this->hasFlag('OR IGNORE');
+        if (!empty($this->conflict_target)) {
+            if ($has_or_ignore) {
+                $this->setFlag('OR IGNORE', false);
+                $ignore = true;
+            }
+            $this->assertNoOrConflictFlags();
+        }
+
         $this->assertOneOrConflictFlag();
-        return parent::build();
+
+        $stm = parent::build();
+
+        if ($has_or_ignore && !empty($this->conflict_target)) {
+            $this->setFlag('OR IGNORE', true);
+        }
+
+        return $stm
+            . $this->builder->buildOnConflict(
+                $this->conflict_target,
+                $this->conflict_update_values,
+                $this->conflict_where,
+                $ignore
+            );
+    }
+
+    /**
+     *
+     * Asserts that no legacy SQLite OR conflict flags are set when using ON CONFLICT.
+     *
+     * @return void
+     * @throws Exception\LogicException
+     *
+     */
+    protected function assertNoOrConflictFlags()
+    {
+        $set = [];
+        foreach ($this->or_conflict_flags as $flag) {
+            if ($this->hasFlag($flag)) {
+                $set[] = $flag;
+            }
+        }
+
+        if (! empty($set)) {
+            throw new Exception\LogicException(
+                'Cannot combine ON CONFLICT clause with SQLite OR conflict flags: '
+                . implode(' and ', $set) . '.'
+            );
+        }
     }
 
     /**

--- a/src/Sqlite/Insert.php
+++ b/src/Sqlite/Insert.php
@@ -48,19 +48,22 @@ class Insert extends Common\Insert implements Common\OnConflictUpdateInterface
         $ignore = false;
         $has_or_ignore = $this->hasFlag('OR IGNORE');
         if (!empty($this->conflict_target)) {
-            if ($has_or_ignore) {
-                $this->setFlag('OR IGNORE', false);
-                $ignore = true;
-            }
             $this->assertNoOrConflictFlags();
         }
 
         $this->assertOneOrConflictFlag();
 
-        $stm = parent::build();
+        if (!empty($this->conflict_target) && $has_or_ignore) {
+            $this->setFlag('OR IGNORE', false);
+            $ignore = true;
+        }
 
-        if ($has_or_ignore && !empty($this->conflict_target)) {
-            $this->setFlag('OR IGNORE', true);
+        try {
+            $stm = parent::build();
+        } finally {
+            if ($has_or_ignore && !empty($this->conflict_target)) {
+                $this->setFlag('OR IGNORE', true);
+            }
         }
 
         return $stm
@@ -84,6 +87,9 @@ class Insert extends Common\Insert implements Common\OnConflictUpdateInterface
     {
         $set = [];
         foreach ($this->or_conflict_flags as $flag) {
+            if ($flag === 'OR IGNORE') {
+                continue;
+            }
             if ($this->hasFlag($flag)) {
                 $set[] = $flag;
             }

--- a/src/Sqlite/InsertBuilder.php
+++ b/src/Sqlite/InsertBuilder.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Sqlite;
+
+use Aura\SqlQuery\Common;
+
+/**
+ *
+ * INSERT builder for SQLite.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+class InsertBuilder extends Common\InsertBuilder
+{
+    use Common\BuildOnConflictTrait;
+}

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -293,6 +293,32 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
     }
 
     /**
+     * RETURNING has to come after the conflict clause, so this pins the
+     * order of the two as much as the result.
+     */
+    public function testInsertOnConflictReturning()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->doUpdateCols(['name'])
+            ->returning(['id', 'name']);
+
+        $this->assertStatementContains('DO UPDATE SET', $insert);
+        $this->assertStatementContains('RETURNING', $insert);
+
+        $rows = $this->fetchAll($insert);
+        $this->assertSame(
+            [['id' => 1, 'name' => 'Attempted']],
+            array_map(
+                fn (array $row) => ['id' => (int) $row['id'], 'name' => $row['name']],
+                $rows
+            )
+        );
+    }
+
+    /**
      * A raw expression in doUpdate() has to qualify any column it names.
      * Inside DO UPDATE SET, a bare column is ambiguous between the target
      * table and the excluded pseudo-table, and Postgres rejects it -- where

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -216,6 +216,123 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
         );
     }
 
+    public function testInsertOnConflictUpdate()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->doUpdateCols(['name']);
+
+        $this->assertStatementContains('ON CONFLICT ("id") DO UPDATE SET', $insert);
+
+        // id 1 already holds Engineering, so the insert turns into an update
+        $this->assertSame(1, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Attempted', $sth->fetchColumn());
+    }
+
+    public function testInsertOnConflictDoNothing()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->ignore();
+
+        $this->assertStatementContains('ON CONFLICT ("id") DO NOTHING', $insert);
+
+        $this->assertSame(0, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Engineering', $sth->fetchColumn());
+    }
+
+    /**
+     * The conflict target may name a constraint instead of its columns.
+     */
+    public function testInsertOnConflictConstraintTarget()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'ByConstraint'])
+            ->onConflict('ON CONSTRAINT test_dept_pkey')
+            ->doUpdateCols(['name']);
+
+        $this->assertStatementContains(
+            'ON CONFLICT ON CONSTRAINT <<test_dept_pkey>> DO UPDATE SET',
+            $insert
+        );
+
+        $this->assertSame(1, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('ByConstraint', $sth->fetchColumn());
+    }
+
+    /**
+     * The WHERE decides whether the conflicting row is updated at all; this
+     * one cannot match, so the existing row survives untouched.
+     */
+    public function testInsertOnConflictDoUpdateWhere()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->doUpdateCols(['name'])
+            ->doUpdateWhere('test_dept.id > :min', ['min' => 100]);
+
+        $this->assertStatementContains('DO UPDATE SET', $insert);
+
+        $this->assertSame(0, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Engineering', $sth->fetchColumn());
+    }
+
+    /**
+     * A raw expression in doUpdate() has to qualify any column it names.
+     * Inside DO UPDATE SET, a bare column is ambiguous between the target
+     * table and the excluded pseudo-table, and Postgres rejects it -- where
+     * SQLite accepts the same expression. See docs/pgsql.md.
+     */
+    public function testInsertOnConflictRawExpressionMustQualifyColumns()
+    {
+        // test_dept has explicit ids; test_employee's come from a SERIAL, and
+        // sequences are not rolled back with the surrounding transaction, so
+        // its ids differ from run to run
+        $unqualified = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->doUpdate('name', "name || '-updated'");
+
+        // Postgres aborts the surrounding transaction on error, so the
+        // failure is isolated behind a savepoint to let the test continue
+        $this->pdo->exec('SAVEPOINT before_ambiguous');
+        try {
+            $this->exec($unqualified);
+            $this->fail('Expected an ambiguous-column error.');
+        } catch (\PDOException $e) {
+            $this->assertStringContainsString('ambiguous', $e->getMessage());
+        }
+        $this->pdo->exec('ROLLBACK TO SAVEPOINT before_ambiguous');
+
+        // qualifying the column resolves it
+        $qualified = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->doUpdate('name', "test_dept.name || '-updated'");
+
+        $this->assertSame(1, $this->exec($qualified));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Engineering-updated', $sth->fetchColumn());
+    }
+
     public function testGetLastInsertIdName()
     {
         $insert = $this->query_factory->newInsert()

--- a/tests/Integration/SqliteIntegrationTest.php
+++ b/tests/Integration/SqliteIntegrationTest.php
@@ -177,4 +177,96 @@ class SqliteIntegrationTest extends AbstractIntegrationTest
         $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
         $this->assertSame('Engineering', $sth->fetchColumn());
     }
+
+    /**
+     * A bound value and a raw expression alongside the proposed one, all in
+     * the same DO UPDATE SET.
+     */
+    public function testInsertOnConflictDoUpdateColAndExpression()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_employee')
+            ->cols(['id' => 1, 'name' => 'Anna', 'dept_id' => 1, 'salary' => 999, 'seq' => 1])
+            ->onConflict('id')
+            ->doUpdateCols(['salary'])
+            ->doUpdateCol('name', 'Renamed')
+            ->doUpdate('seq', 'test_employee.seq + 10');
+
+        $this->assertStatementContains('ON CONFLICT ("id") DO UPDATE SET', $insert);
+
+        $this->assertSame(1, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name, salary, seq FROM test_employee WHERE id = 1');
+        $row = $sth->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('Renamed', $row['name']);
+        $this->assertSame(999, (int) $row['salary']);
+        $this->assertSame(11, (int) $row['seq']);
+    }
+
+    /**
+     * The WHERE decides whether the conflicting row is updated at all; this
+     * one cannot match, so the existing row survives.
+     */
+    public function testInsertOnConflictDoUpdateWhere()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->doUpdateCols(['name'])
+            ->doUpdateWhere('test_dept.id > :min', ['min' => 100]);
+
+        $this->assertSame(0, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Engineering', $sth->fetchColumn());
+    }
+
+    /**
+     * SQLite takes only a column list as the conflict target. The
+     * constraint-name form is Postgres-only and is a syntax error here, so
+     * the builder refuses it rather than letting it reach the database.
+     */
+    public function testInsertOnConflictConstraintTargetNotSupported()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted']);
+
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $insert->onConflict('ON CONSTRAINT test_dept_pkey');
+    }
+
+    /**
+     * The equivalent column-list target, which SQLite does accept, proving
+     * the refusal above is about the syntax and not the intent.
+     */
+    public function testInsertOnConflictMultiColumnTarget()
+    {
+        $this->pdo->exec(
+            'CREATE UNIQUE INDEX test_employee_dept_seq
+                ON test_employee (dept_id, seq)'
+        );
+
+        // Anna is seeded as dept_id 1, seq 1
+        $insert = $this->query_factory->newInsert()
+            ->into('test_employee')
+            ->cols(['name' => 'Replacement', 'dept_id' => 1, 'salary' => 555, 'seq' => 1])
+            ->onConflict(['dept_id', 'seq'])
+            ->doUpdateCols(['name', 'salary']);
+
+        $this->assertStatementContains(
+            'ON CONFLICT (<<dept_id>>, <<seq>>) DO UPDATE SET',
+            $insert
+        );
+
+        $this->assertSame(1, $this->exec($insert));
+
+        $sth = $this->pdo->query(
+            'SELECT name, salary FROM test_employee WHERE dept_id = 1 AND seq = 1'
+        );
+        $row = $sth->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('Replacement', $row['name']);
+        $this->assertSame(555, (int) $row['salary']);
+    }
 }

--- a/tests/Integration/SqliteIntegrationTest.php
+++ b/tests/Integration/SqliteIntegrationTest.php
@@ -143,4 +143,38 @@ class SqliteIntegrationTest extends AbstractIntegrationTest
             $sth->fetchAll(PDO::FETCH_ASSOC)
         );
     }
+
+    public function testInsertOnConflictUpdate()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->doUpdateCols(['name']);
+
+        $this->assertStatementContains('ON CONFLICT ("id") DO UPDATE SET', $insert);
+
+        // id 1 already exists (Engineering). It should be updated to 'Attempted'.
+        $this->exec($insert);
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Attempted', $sth->fetchColumn());
+    }
+
+    public function testInsertOnConflictDoNothing()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Attempted'])
+            ->onConflict('id')
+            ->ignore();
+
+        $this->assertStatementContains('ON CONFLICT ("id") DO NOTHING', $insert);
+
+        // id 1 already exists. It should NOT be updated.
+        $this->exec($insert);
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept WHERE id = 1');
+        $this->assertSame('Engineering', $sth->fetchColumn());
+    }
 }

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -320,4 +320,16 @@ class InsertTest extends Common\InsertTest
         $this->expectExceptionMessage("doesn't support ON CONFLICT clause");
         $this->query->onConflict('id');
     }
+
+    public function testOrReplaceWithOnDuplicateKeyUpdateThrowsException()
+    {
+        $this->query->orReplace()
+                    ->into('t1')
+                    ->cols(array('c1'))
+                    ->onDuplicateKeyUpdate('c1', 'new-val');
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('A REPLACE statement cannot take an ON DUPLICATE KEY UPDATE clause.');
+        $this->query->__toString();
+    }
 }

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -313,4 +313,11 @@ class InsertTest extends Common\InsertTest
         $actual = $this->query->getBindValues();
         $this->assertSame($expect, $actual);
     }
+
+    public function testOnConflictNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support ON CONFLICT clause");
+        $this->query->onConflict('id');
+    }
 }

--- a/tests/Pgsql/DeleteTest.php
+++ b/tests/Pgsql/DeleteTest.php
@@ -7,6 +7,17 @@ class DeleteTest extends Common\DeleteTest
 {
     protected $db_type = 'pgsql';
 
+    /**
+     * Postgres has no DELETE-level IGNORE; asking for it has to say so rather than
+     * fatal on an undefined method.
+     */
+    public function testIgnoreNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support IGNORE flag");
+        $this->query->ignore();
+    }
+
     public function testReturning()
     {
         $this->query->from('t1')

--- a/tests/Pgsql/InsertTest.php
+++ b/tests/Pgsql/InsertTest.php
@@ -7,6 +7,17 @@ class InsertTest extends Common\InsertTest
 {
     protected $db_type = 'pgsql';
 
+    /**
+     * Postgres has no REPLACE; asking for it has to say so rather than
+     * fatal on an undefined method.
+     */
+    public function testOrReplaceNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support OR REPLACE flag");
+        $this->query->orReplace();
+    }
+
     public function testReturning()
     {
         $this->query->into('t1')
@@ -89,5 +100,130 @@ class InsertTest extends Common\InsertTest
         ";
 
         $this->assertSameSql($expect, $actual);
+    }
+
+    public function testOnConflictDoNothing()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('c1')
+                    ->ignore();
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>
+            ) VALUES (
+                :c1,
+                :c2
+            )
+            ON CONFLICT (<<c1>>) DO NOTHING
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testOnConflictDoUpdate()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2', 'c3'))
+                    ->onConflict(array('c1', 'c2'))
+                    ->doUpdateCols(array('c2'))
+                    ->doUpdate('c3', 'excluded.c3');
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>,
+                <<c3>>
+            ) VALUES (
+                :c1,
+                :c2,
+                :c3
+            )
+            ON CONFLICT (<<c1>>, <<c2>>) DO UPDATE SET
+                <<c2>> = excluded.<<c2>>,
+                <<c3>> = <<excluded>>.<<c3>>
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testOnConflictDoUpdateWhere()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('c1')
+                    ->doUpdateCol('c2', 'c2-updated')
+                    ->doUpdateWhere('t1.c2 != :c2_old', array('c2_old' => 'foo'))
+                    ->doUpdateWhere('t1.c3 = :c3_old', array('c3_old' => 'bar'));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>
+            ) VALUES (
+                :c1,
+                :c2
+            )
+            ON CONFLICT (<<c1>>) DO UPDATE SET
+                <<c2>> = :c2__on_conflict
+            WHERE
+                <<t1>>.<<c2>> != :c2_old
+                AND <<t1>>.<<c3>> = :c3_old
+        ";
+        $this->assertSameSql($expect, $actual);
+
+        $binds = $this->query->getBindValues();
+        $this->assertSame('c2-updated', $binds['c2__on_conflict']);
+        $this->assertSame('foo', $binds['c2_old']);
+        $this->assertSame('bar', $binds['c3_old']);
+    }
+
+    public function testOnConflictThrowsExceptionWhenNoTarget()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->doUpdateCols(array('c2'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('Database requires a conflict target for DO UPDATE.');
+        $this->query->__toString();
+    }
+
+    public function testOnConflictDoUpdateAmbiguousColumn()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'hits'))
+                    ->onConflict('c1')
+                    ->doUpdate('hits', 't1.hits + 1');
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<hits>>
+            ) VALUES (
+                :c1,
+                :hits
+            )
+            ON CONFLICT (<<c1>>) DO UPDATE SET
+                <<hits>> = <<t1>>.<<hits>> + 1
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testOnConflictThrowsExceptionWhenIgnoreAndUpdate()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('c1')
+                    ->ignore()
+                    ->doUpdateCols(array('c2'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('Cannot combine IGNORE / DO NOTHING with DO UPDATE SET.');
+        $this->query->__toString();
     }
 }

--- a/tests/Pgsql/InsertTest.php
+++ b/tests/Pgsql/InsertTest.php
@@ -181,6 +181,31 @@ class InsertTest extends Common\InsertTest
         $this->assertSame('bar', $binds['c3_old']);
     }
 
+    /**
+     * The constraint-name conflict target is Postgres-only.
+     */
+    public function testOnConflictConstraintTarget()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('ON CONSTRAINT t1_c1_key')
+                    ->doUpdateCols(array('c2'));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>
+            ) VALUES (
+                :c1,
+                :c2
+            )
+            ON CONFLICT ON CONSTRAINT <<t1_c1_key>> DO UPDATE SET
+                <<c2>> = excluded.<<c2>>
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testOnConflictThrowsExceptionWhenNoTarget()
     {
         $this->query->into('t1')

--- a/tests/Pgsql/InsertTest.php
+++ b/tests/Pgsql/InsertTest.php
@@ -2,6 +2,7 @@
 namespace Aura\SqlQuery\Pgsql;
 
 use Aura\SqlQuery\Common;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class InsertTest extends Common\InsertTest
 {
@@ -204,6 +205,34 @@ class InsertTest extends Common\InsertTest
                 <<c2>> = excluded.<<c2>>
         ";
         $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     * An empty target is the same mistake as no target, but it used to slip
+     * past the no-target check and build `ON CONFLICT ()`, which the server
+     * rejects as a syntax error.
+     *
+     * @param string|array $target
+     */
+    #[DataProvider('provideEmptyConflictTarget')]
+    public function testOnConflictThrowsExceptionWhenTargetEmpty($target)
+    {
+        $this->expectException('Aura\SqlQuery\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('onConflict() requires a column name or constraint.');
+        $this->query->onConflict($target);
+    }
+
+    public static function provideEmptyConflictTarget()
+    {
+        return array(
+            'empty array' => array(array()),
+            'empty string' => array(''),
+            'blank string' => array('   '),
+            'array of blanks' => array(array('')),
+            'array with a blank' => array(array('c1', '')),
+            'constraint keyword alone' => array('ON CONSTRAINT'),
+            'constraint with no name' => array('ON CONSTRAINT   '),
+        );
     }
 
     public function testOnConflictThrowsExceptionWhenNoTarget()

--- a/tests/Pgsql/UpdateTest.php
+++ b/tests/Pgsql/UpdateTest.php
@@ -7,6 +7,24 @@ class UpdateTest extends Common\UpdateTest
 {
     protected $db_type = 'pgsql';
 
+    /**
+     * Postgres has no UPDATE-level IGNORE, and no REPLACE at all; asking for
+     * either has to say so rather than fatal on an undefined method.
+     */
+    public function testIgnoreNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support IGNORE flag");
+        $this->query->ignore();
+    }
+
+    public function testOrReplaceNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support OR REPLACE flag");
+        $this->query->orReplace();
+    }
+
     public function testReturning()
     {
         $this->query->table('t1')

--- a/tests/Sqlite/DeleteTest.php
+++ b/tests/Sqlite/DeleteTest.php
@@ -7,6 +7,17 @@ class DeleteTest extends Common\DeleteTest
 {
     protected $db_type = 'sqlite';
 
+    /**
+     * SQLite's DELETE grammar has no OR clause; asking for it has to say so rather than
+     * fatal on an undefined method.
+     */
+    public function testIgnoreNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support IGNORE flag");
+        $this->query->ignore();
+    }
+
     public function testOrderLimit()
     {
         $this->query->from('t1')

--- a/tests/Sqlite/InsertTest.php
+++ b/tests/Sqlite/InsertTest.php
@@ -294,4 +294,15 @@ class InsertTest extends Common\InsertTest
         $this->expectExceptionMessage('Cannot combine IGNORE / DO NOTHING with DO UPDATE SET.');
         $this->query->__toString();
     }
+
+    /**
+     * SQLite takes only a column list as the conflict target; the
+     * constraint-name form is Postgres-only and is a syntax error here.
+     */
+    public function testOnConflictConstraintTargetNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support a constraint-name conflict target");
+        $this->query->onConflict('ON CONSTRAINT t1_c1_key');
+    }
 }

--- a/tests/Sqlite/InsertTest.php
+++ b/tests/Sqlite/InsertTest.php
@@ -237,6 +237,32 @@ class InsertTest extends Common\InsertTest
         $this->assertSame('foo', $binds['c2_old']);
     }
 
+    /**
+     * An empty target is the same mistake as no target, but it used to slip
+     * past the no-target check and build `ON CONFLICT ()`.
+     *
+     * @param string|array $target
+     */
+    #[DataProvider('provideEmptyConflictTarget')]
+    public function testOnConflictThrowsExceptionWhenTargetEmpty($target)
+    {
+        $this->expectException('Aura\SqlQuery\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('onConflict() requires a column name or constraint.');
+        $this->query->onConflict($target);
+    }
+
+    public static function provideEmptyConflictTarget()
+    {
+        return array(
+            'empty array' => array(array()),
+            'empty string' => array(''),
+            'blank string' => array('   '),
+            'array of blanks' => array(array('')),
+            'constraint keyword alone' => array('ON CONSTRAINT'),
+            'constraint with no name' => array('ON CONSTRAINT   '),
+        );
+    }
+
     public function testOnConflictThrowsExceptionWhenNoTarget()
     {
         $this->query->into('t1')

--- a/tests/Sqlite/InsertTest.php
+++ b/tests/Sqlite/InsertTest.php
@@ -160,4 +160,138 @@ class InsertTest extends Common\InsertTest
             $this->query->__toString()
         );
     }
+
+    public function testOnConflictDoNothing()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('c1')
+                    ->ignore();
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>
+            ) VALUES (
+                :c1,
+                :c2
+            )
+            ON CONFLICT (<<c1>>) DO NOTHING
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testOnConflictDoUpdate()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2', 'c3'))
+                    ->onConflict(array('c1', 'c2'))
+                    ->doUpdateCols(array('c2'))
+                    ->doUpdate('c3', 'excluded.c3');
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>,
+                <<c3>>
+            ) VALUES (
+                :c1,
+                :c2,
+                :c3
+            )
+            ON CONFLICT (<<c1>>, <<c2>>) DO UPDATE SET
+                <<c2>> = excluded.<<c2>>,
+                <<c3>> = <<excluded>>.<<c3>>
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testOnConflictDoUpdateWhere()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('c1')
+                    ->doUpdateCol('c2', 'c2-updated')
+                    ->doUpdateWhere('t1.c2 != :c2_old', array('c2_old' => 'foo'));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>
+            ) VALUES (
+                :c1,
+                :c2
+            )
+            ON CONFLICT (<<c1>>) DO UPDATE SET
+                <<c2>> = :c2__on_conflict
+            WHERE
+                <<t1>>.<<c2>> != :c2_old
+        ";
+        $this->assertSameSql($expect, $actual);
+
+        $binds = $this->query->getBindValues();
+        $this->assertSame('c2-updated', $binds['c2__on_conflict']);
+        $this->assertSame('foo', $binds['c2_old']);
+    }
+
+    public function testOnConflictThrowsExceptionWhenNoTarget()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->doUpdateCols(array('c2'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('Database requires a conflict target for DO UPDATE.');
+        $this->query->__toString();
+    }
+
+    public function testCannotCombineWithOrFlags()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('c1')
+                    ->orReplace();
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('Cannot combine ON CONFLICT clause with SQLite OR conflict flags: OR REPLACE.');
+        $this->query->__toString();
+    }
+
+    public function testOnConflictDoUpdateAmbiguousColumn()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'hits'))
+                    ->onConflict('c1')
+                    ->doUpdate('hits', 't1.hits + 1');
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<hits>>
+            ) VALUES (
+                :c1,
+                :hits
+            )
+            ON CONFLICT (<<c1>>) DO UPDATE SET
+                <<hits>> = <<t1>>.<<hits>> + 1
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testOnConflictThrowsExceptionWhenIgnoreAndUpdate()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('c1')
+                    ->ignore()
+                    ->doUpdateCols(array('c2'));
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('Cannot combine IGNORE / DO NOTHING with DO UPDATE SET.');
+        $this->query->__toString();
+    }
 }

--- a/tests/Sqlite/InsertTest.php
+++ b/tests/Sqlite/InsertTest.php
@@ -260,6 +260,41 @@ class InsertTest extends Common\InsertTest
         $this->query->__toString();
     }
 
+    public function testOnConflictFlagStateNotCorruptedOnException()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1', 'c2'))
+                    ->onConflict('c1')
+                    ->ignore()
+                    ->orReplace();
+
+        try {
+            $this->query->__toString();
+            $this->fail('Expected LogicException was not thrown.');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            $this->assertStringContainsString('Cannot combine ON CONFLICT clause with SQLite OR conflict flags: OR REPLACE.', $e->getMessage());
+        }
+
+        // The caller fixes the offending flag and reuses the object. The
+        // ignore() set earlier has to survive: build() clears OR IGNORE
+        // while rendering, so a throw between the clear and the restore
+        // used to strip it for good, turning DO NOTHING into a plain
+        // INSERT with nothing to report it.
+        $this->query->orReplace(false);
+
+        $expect = "
+            INSERT INTO <<t1>> (
+                <<c1>>,
+                <<c2>>
+            ) VALUES (
+                :c1,
+                :c2
+            )
+            ON CONFLICT (<<c1>>) DO NOTHING
+        ";
+        $this->assertSameSql($expect, $this->query->__toString());
+    }
+
     public function testOnConflictDoUpdateAmbiguousColumn()
     {
         $this->query->into('t1')

--- a/tests/Sqlsrv/DeleteTest.php
+++ b/tests/Sqlsrv/DeleteTest.php
@@ -6,4 +6,15 @@ use Aura\SqlQuery\Common;
 class DeleteTest extends Common\DeleteTest
 {
     protected $db_type = 'sqlsrv';
+
+    /**
+     * SQL Server has no IGNORE; asking for it has to say so rather than
+     * fatal on an undefined method.
+     */
+    public function testIgnoreNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support IGNORE flag");
+        $this->query->ignore();
+    }
 }

--- a/tests/Sqlsrv/InsertTest.php
+++ b/tests/Sqlsrv/InsertTest.php
@@ -7,6 +7,17 @@ class InsertTest extends Common\InsertTest
 {
     protected $db_type = 'sqlsrv';
 
+    /**
+     * SQL Server has no REPLACE; asking for it has to say so rather than
+     * fatal on an undefined method.
+     */
+    public function testOrReplaceNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support OR REPLACE flag");
+        $this->query->orReplace();
+    }
+
     public function testIgnore()
     {
         // T-SQL has no INSERT IGNORE equivalent, so the base behavior
@@ -14,5 +25,12 @@ class InsertTest extends Common\InsertTest
         $this->expectException(\Aura\SqlQuery\Exception\BadMethodCallException::class);
         $this->expectExceptionMessage("doesn't support IGNORE");
         $this->query->ignore();
+    }
+
+    public function testOnConflictNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support ON CONFLICT clause");
+        $this->query->onConflict('id');
     }
 }

--- a/tests/Sqlsrv/UpdateTest.php
+++ b/tests/Sqlsrv/UpdateTest.php
@@ -6,4 +6,26 @@ use Aura\SqlQuery\Common;
 class UpdateTest extends Common\UpdateTest
 {
     protected $db_type = 'sqlsrv';
+
+    /**
+     * SQL Server has no IGNORE; asking for it has to say so rather than
+     * fatal on an undefined method.
+     */
+    public function testIgnoreNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support IGNORE flag");
+        $this->query->ignore();
+    }
+
+    /**
+     * SQL Server has no REPLACE; asking for it has to say so rather than
+     * fatal on an undefined method.
+     */
+    public function testOrReplaceNotSupported()
+    {
+        $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');
+        $this->expectExceptionMessage("doesn't support OR REPLACE flag");
+        $this->query->orReplace();
+    }
 }

--- a/tests/doc-examples.php
+++ b/tests/doc-examples.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ *
+ * Tells the shared doc-example checker how to run this package's examples.
+ *
+ *     php /Volumes/S/auraphp/scripts/verify-doc-examples.php .
+ *
+ * Each dialect page is checked against a QueryFactory for that dialect, so the
+ * SQL printed under a `php` block has to be the SQL the builder really emits.
+ * See CONTRIBUTING.md.
+ *
+ */
+
+use Aura\SqlQuery\QueryFactory;
+
+return [
+    'bootstrap' => __DIR__ . '/../autoload.php',
+
+    'docs' => __DIR__ . '/../docs',
+
+    /**
+     * The examples open with `$queryFactory->newSelect()` and friends, so the
+     * factory has to exist before one is evaluated. The dialect comes from the
+     * page name; docs/other.md and the like fall back to 'common'.
+     */
+    'context' => function (string $file): array {
+        $page = basename($file, '.md');
+        $db_types = ['mysql', 'pgsql', 'sqlite', 'sqlsrv'];
+
+        return [
+            'queryFactory' => new QueryFactory(
+                in_array($page, $db_types, true) ? $page : 'common'
+            ),
+        ];
+    },
+
+    /**
+     * An example builds a query into $select, $insert, $update or $delete;
+     * anything else is prose-only and has no SQL to compare.
+     */
+    'render' => function (array $vars): ?string {
+        foreach (['select', 'insert', 'update', 'delete'] as $name) {
+            if (isset($vars[$name]) && $vars[$name] instanceof Aura\SqlQuery\QueryInterface) {
+                return $vars[$name]->getStatement();
+            }
+        }
+        return null;
+    },
+];

--- a/tests/doc-examples.php
+++ b/tests/doc-examples.php
@@ -3,7 +3,7 @@
  *
  * Tells the shared doc-example checker how to run this package's examples.
  *
- *     php /Volumes/S/auraphp/scripts/verify-doc-examples.php .
+ *     php ../scripts/verify-doc-examples.php .
  *
  * Each dialect page is checked against a QueryFactory for that dialect, so the
  * SQL printed under a `php` block has to be the SQL the builder really emits.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL and SQLite `INSERT ... ON CONFLICT` upsert support, including `DO NOTHING`, `DO UPDATE SET`, conflict targets (columns or named constraints where supported), and `DO UPDATE ... WHERE`.
  * Added fluent helpers for building `DO UPDATE SET` assignments.
* **Bug Fixes**
  * Unsupported `ignore()`, `orReplace()`, and upsert operations now consistently throw clear exceptions.
  * Added validation for illegal combinations and invalid/empty conflict targets (including SQLite `OR ...` flag restrictions).
* **Documentation**
  * Expanded PostgreSQL, SQLite, and MySQL docs; improved contributing guide and doc-example verification.
* **Tests**
  * Added PostgreSQL/SQLite integration coverage plus cross-dialect negative tests and doc-example checker config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->