### PR TITLE
Fix #139: stop shadowing the shared bindValues test

### DIFF
--- a/tests/AbstractQueryTest.php
+++ b/tests/AbstractQueryTest.php
@@ -75,4 +75,23 @@ abstract class AbstractQueryTest extends TestCase
         $this->query->resetBindValues();
         $this->assertEmpty($this->query->getBindValues());
     }
+
+    public function testBindValue()
+    {
+        $this->query->bindValue('foo', 'bar');
+        $this->assertSame(array('foo' => 'bar'), $this->query->getBindValues());
+
+        $this->query->bindValue('baz', 'dib');
+        $expect = array('foo' => 'bar', 'baz' => 'dib');
+        $this->assertSame($expect, $this->query->getBindValues());
+
+        $this->query->resetBindValues();
+        $this->assertEmpty($this->query->getBindValues());
+    }
+
+    public function testBindValuesReturnsTheQueryForChaining()
+    {
+        $this->assertSame($this->query, $this->query->bindValues(array('foo' => 'bar')));
+        $this->assertSame($this->query, $this->query->bindValue('baz', 'dib'));
+    }
 }

--- a/tests/Common/InsertTest.php
+++ b/tests/Common/InsertTest.php
@@ -77,16 +77,6 @@ class InsertTest extends AbstractQueryTest
         $this->assertSame($expect, $actual);
     }
 
-    public function testBindValues()
-    {
-        $this->assertInstanceOf('\Aura\SqlQuery\AbstractQuery', $this->query->bindValues(array('bar', 'bar value')));
-    }
-
-    public function testBindValue()
-    {
-        $this->assertInstanceOf('\Aura\SqlQuery\AbstractQuery', $this->query->bindValue('bar', 'bar value'));
-    }
-
     public function testBulkAddRow()
     {
         $this->query->into('t1');


### PR DESCRIPTION
Fixes #139.

`Aura\SqlQuery\Common\InsertTest` defined its own `testBindValues()`, which
**overrode** the thorough one it inherits from `AbstractQueryTest`:

```php
public function testBindValues()
{
    $this->assertInstanceOf('\Aura\SqlQuery\AbstractQuery', $this->query->bindValues(array('bar', 'bar value')));
}
```

Because `Mysql`, `Pgsql`, `Sqlite` and `Sqlsrv` `InsertTest` all extend
`Common\InsertTest`, five test classes were quietly running that one-line
assertion instead of the base-class test that checks values are actually
stored, accumulate across calls, and reset. So this was not only an
undocumented use case, as the issue reports — it was a silent loss of
coverage on every Insert dialect.

`testBindValue()` next to it had the same shape, and both exercise
`AbstractQuery` methods from an Insert-specific class.

**Changes**

- Remove both methods from `Common\InsertTest`. The Insert classes now
  inherit the real `testBindValues()` again.
- Add `testBindValue()` to `AbstractQueryTest`, asserting the value lands
  and accumulates rather than only that an object is returned. It now runs
  for Select, Insert, Update and Delete across every dialect, not just Insert.
- Add `testBindValuesReturnsTheQueryForChaining()`, which keeps the one
  thing the deleted tests did assert: the fluent return.

**On the original suggestion** — @djmattyg007 asked that the non-associative
array become associative and that both tests move to a query-level class.
This does the move, but drops the `bindValues()` test rather than rewriting
it: `AbstractQueryTest` already covers that method properly with associative
arrays, so a second copy here would just shadow it again.

**Result** — tests only, no `src/` change, no CHANGELOG entry.

```
before:  Tests: 678, Assertions: 1324
after:   Tests: 713, Assertions: 1434
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for query parameter binding, including accumulating and resetting bound values.
  * Verified that binding methods support fluent chaining.
  * Consolidated binding behavior tests into the shared query test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->