### PR TITLE
Add the bookdown config

### DIFF
--- a/docs/_bookdown.json
+++ b/docs/_bookdown.json
@@ -1,0 +1,15 @@
+{
+    "title": "Aura.SqlQuery 6.x",
+    "content": [
+        "instantiation.md",
+        "select.md",
+        "insert.md",
+        "update.md",
+        "delete.md",
+        "mysql.md",
+        "pgsql.md",
+        "sqlite.md",
+        "sqlsrv.md",
+        "other.md"
+    ]
+}


### PR DESCRIPTION
Adds `docs/_bookdown.json`, which this package never had. Every other Aura
package carries one alongside `docs/index.md` — Aura.Auth, Aura.Filter,
Aura.Router, Aura.Di and the rest — so the docs here cannot be built as a
book the way the others are.

The page list and its order match `docs/index.md` exactly. Following the
convention in the sibling packages, `index.md` itself is not listed.

Docs only; no source or test changes.
