### PR TITLE
Throw when two parts of a query claim one placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,11 @@
   resetHaving() and resetTables() release the names their clause claimed, so
   the placeholder may be reused after a reset; the bound values themselves
   survive a reset as they always have, which is what lets union() bind the
-  half it has already rendered. Fixes #238.
+  half it has already rendered. Both halves of a union may filter on one
+  placeholder as long as they ask for the same value -- the same tenant id
+  either side of the union is not a collision -- but only one clause per
+  branch may do so, and resetUnions() then leaves the name with that clause
+  rather than freeing it. Fixes #238.
 
 - [BRK] Bumped the minimum version to PHP 8.4; the CI matrix now covers
   PHP 8.4 and 8.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 6.0.0 (unreleased)
 
+- [BRK] Two different parts of one query binding different values to the same
+  placeholder name now throws Aura\SqlQuery\Exception\LogicException instead of
+  silently discarding one of the values. The common case is a condition that
+  tests a column the query also sets:
+
+      $update->table('orders')
+          ->cols(['status' => 'shipped'])
+          ->where('status = :status', ['status' => 'pending']);
+
+  which previously rendered `SET "status" = :status WHERE status = :status`
+  with a single bound value, so the UPDATE quietly set the column to the value
+  meant only to select rows. Bind the condition under its own name
+  (`:old_status`) to fix it. Binding by hand with bindValue()/bindValues() is
+  unaffected and may still overwrite any value; one part of the query revising
+  its own placeholder is not a collision either. The same check covers
+  doUpdateCol() and onDuplicateKeyUpdateCol(), whose placeholders are derived
+  by suffix and so only collide when a column is literally named
+  `<col>__on_conflict` or `<col>__on_duplicate_key`. Fixes #238.
+
 - [BRK] Bumped the minimum version to PHP 8.4; the CI matrix now covers
   PHP 8.4 and 8.5.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,20 @@
   (`:old_status`) to fix it. This applies even when the two values happen to
   agree, since either part may revise its value afterwards and nothing
   re-checks the pair. Binding by hand with bindValue()/bindValues() is
-  unaffected and may still overwrite any value; one part of the query revising
-  its own placeholder is not a collision either. The same check covers
+  unaffected and may still overwrite any value; cols() and the upsert methods
+  may still revise a placeholder they already own. The same check covers
   doUpdateCol() and onDuplicateKeyUpdateCol(), whose placeholders are derived
   by suffix and so only collide when a column is literally named
-  `<col>__on_conflict` or `<col>__on_duplicate_key`. Fixes #238.
+  `<col>__on_conflict` or `<col>__on_duplicate_key`.
+
+  Conditions count separately per clause, so two WHERE conditions, or a WHERE
+  and a HAVING, binding different values to one name is caught as well; a
+  sub-select's own bound values and those passed alongside a closure condition
+  are tracked too, where before they were merged in unchecked. resetWhere(),
+  resetHaving() and resetTables() release the names their clause claimed, so
+  the placeholder may be reused after a reset; the bound values themselves
+  survive a reset as they always have, which is what lets union() bind the
+  half it has already rendered. Fixes #238.
 
 - [BRK] Bumped the minimum version to PHP 8.4; the CI matrix now covers
   PHP 8.4 and 8.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,18 @@
   placeholder as long as they ask for the same value -- the same tenant id
   either side of the union is not a collision -- but only one clause per
   branch may do so, and resetUnions() then leaves the name with that clause
-  rather than freeing it. Fixes #238.
+  rather than freeing it.
+
+  Two consequences worth calling out. A sub-select's bound values are claimed
+  by the clause it is rendered into -- fromSubSelect() and joinSubSelect()
+  hold theirs until resetTables() -- rather than by whichever of the
+  sub-select's own clauses bound them, so resetWhere() on the outer query no
+  longer frees a name the sub-select is still binding. And two `?`
+  placeholders bound by separate where() calls now throw, because both are
+  numbered from the start of their own values array and so ask for the same
+  name; this never worked, since the two conditions rendered against a single
+  bound value and PDO rejected the statement at execute time. Several `?` in
+  one call are unaffected. Fixes #238.
 
 - [BRK] Bumped the minimum version to PHP 8.4; the CI matrix now covers
   PHP 8.4 and 8.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 6.0.0 (unreleased)
 
-- [BRK] Two different parts of one query binding different values to the same
-  placeholder name now throws Aura\SqlQuery\Exception\LogicException instead of
-  silently discarding one of the values. The common case is a condition that
-  tests a column the query also sets:
+- [BRK] Two different parts of one query claiming the same placeholder name
+  now throws Aura\SqlQuery\Exception\LogicException instead of silently
+  discarding one of the values. The common case is a condition that tests a
+  column the query also sets:
 
       $update->table('orders')
           ->cols(['status' => 'shipped'])
@@ -14,7 +14,9 @@
   which previously rendered `SET "status" = :status WHERE status = :status`
   with a single bound value, so the UPDATE quietly set the column to the value
   meant only to select rows. Bind the condition under its own name
-  (`:old_status`) to fix it. Binding by hand with bindValue()/bindValues() is
+  (`:old_status`) to fix it. This applies even when the two values happen to
+  agree, since either part may revise its value afterwards and nothing
+  re-checks the pair. Binding by hand with bindValue()/bindValues() is
   unaffected and may still overwrite any value; one part of the query revising
   its own placeholder is not a collision either. The same check covers
   doUpdateCol() and onDuplicateKeyUpdateCol(), whose placeholders are derived

--- a/docs/other.md
+++ b/docs/other.md
@@ -34,3 +34,63 @@ turns out to be not as great as it seems in theory. This assessment is the
 result of the hard trials of experience. For those of you who want modifiable
 table prefixes, we suggest using constants with your table names prefixed as
 desired; as the prefixes change, you can then change your constants.
+
+## Placeholder Names
+
+Bound values live in one flat array keyed by placeholder name, so two values
+under one name means one of them is lost. When two *different* parts of a query
+do that, it throws `Aura\SqlQuery\Exception\LogicException` — see
+[UPDATE](./update.md) for the case that trips people up, a condition testing a
+column the query also sets.
+
+Two *conditions* sharing a name is not caught, because both come from the same
+part of the query. Watch for it:
+
+```php
+$select = $queryFactory->newSelect();
+
+$select
+    ->cols(['*'])
+    ->from('orders')
+    ->where('status = :val', ['val' => 'pending'])
+    ->orWhere('channel = :val', ['val' => 'web']);
+```
+
+```sql
+SELECT
+    *
+FROM
+    "orders"
+WHERE
+    status = :val
+    OR channel = :val
+```
+
+Only `'web'` stays bound, so this asks for `status = 'web' OR channel = 'web'`.
+Give each condition its own name:
+
+```php
+$select = $queryFactory->newSelect();
+
+$select
+    ->cols(['*'])
+    ->from('orders')
+    ->where('status = :status', ['status' => 'pending'])
+    ->orWhere('channel = :channel', ['channel' => 'web']);
+```
+
+```sql
+SELECT
+    *
+FROM
+    "orders"
+WHERE
+    status = :status
+    OR channel = :channel
+```
+
+The upsert methods need no such care: `doUpdateCol()` and
+`onDuplicateKeyUpdateCol()` derive their placeholder by suffixing the column
+name, so `cols(['name' => 'Alice'])` binds `:name` while
+`onDuplicateKeyUpdateCol('name', 'updated')` binds `:name__on_duplicate_key`,
+and both values survive.

--- a/docs/other.md
+++ b/docs/other.md
@@ -39,34 +39,27 @@ desired; as the prefixes change, you can then change your constants.
 
 Bound values live in one flat array keyed by placeholder name, so two values
 under one name means one of them is lost. When two *different* parts of a query
-do that, it throws `Aura\SqlQuery\Exception\LogicException` — see
-[UPDATE](./update.md) for the case that trips people up, a condition testing a
-column the query also sets.
+do that, or when two conditions bind different values to the same name, it throws
+`Aura\SqlQuery\Exception\LogicException` — see [UPDATE](./update.md) for the case
+that trips people up, a condition testing a column the query also sets.
 
-Two *conditions* sharing a name is not caught, because both come from the same
-part of the query. Watch for it:
+For example, this throws a `LogicException` because `:val` is bound to two
+different values:
 
 ```php
-$select = $queryFactory->newSelect();
+$query = $queryFactory->newSelect();
 
-$select
-    ->cols(['*'])
-    ->from('orders')
-    ->where('status = :val', ['val' => 'pending'])
-    ->orWhere('channel = :val', ['val' => 'web']);
+try {
+    $query
+        ->cols(['*'])
+        ->from('orders')
+        ->where('status = :val', ['val' => 'pending'])
+        ->orWhere('channel = :val', ['val' => 'web']);
+} catch (\Aura\SqlQuery\Exception\LogicException $e) {
+    // throws: The placeholder ':val' is already in use by a WHERE condition...
+}
 ```
 
-```sql
-SELECT
-    *
-FROM
-    "orders"
-WHERE
-    status = :val
-    OR channel = :val
-```
-
-Only `'web'` stays bound, so this asks for `status = 'web' OR channel = 'web'`.
 Give each condition its own name:
 
 ```php

--- a/docs/other.md
+++ b/docs/other.md
@@ -146,3 +146,10 @@ WHERE
 A rendered branch holds its names against `resetWhere()` and the other clause
 resets too, since those clauses have been built into SQL already.
 `resetUnions()` discards that SQL and releases the names with it.
+
+This covers hand-bound values as well. A branch can be written around
+`bindValue()` -- `where('id = :id')` with the value supplied separately -- and
+the retained SQL binds `:id` no differently, so a later clause cannot rebind it
+to another value. The branch is held to every name bound when it was rendered,
+whether or not its SQL mentions them; `bindValue()` still overwrites any of
+them, as it does everywhere else.

--- a/docs/other.md
+++ b/docs/other.md
@@ -145,7 +145,9 @@ WHERE
 
 A rendered branch holds its names against `resetWhere()` and the other clause
 resets too, since those clauses have been built into SQL already.
-`resetUnions()` discards that SQL and releases the names with it.
+`resetUnions()` discards that SQL and releases the names with it -- except
+those a clause of the current branch is sharing, which pass to that clause
+rather than going free, since it is still binding them.
 
 This covers hand-bound values as well. A branch can be written around
 `bindValue()` -- `where('id = :id')` with the value supplied separately -- and

--- a/docs/other.md
+++ b/docs/other.md
@@ -93,3 +93,56 @@ reserved, so do not bind them yourself. A column literally named
 `name__on_duplicate_key` in `cols()` collides with
 `onDuplicateKeyUpdateCol('name', ...)`, and `name__on_conflict` collides with
 `doUpdateCol('name', ...)`. Both throw the same `LogicException`.
+
+### UNION Branches
+
+`union()` and `unionAll()` build the branch so far into SQL and keep it, so
+that SQL goes on binding the placeholders it was written with. A later branch
+may not rebind one of those names to a *different* value -- the rendered branch
+would silently start running with the new one -- so this throws:
+
+```php
+$select = $queryFactory->newSelect();
+
+try {
+    $select
+        ->cols(['*'])->from('a')->where('id = :id', ['id' => 1])
+        ->union()
+        ->cols(['*'])->from('b')->where('id = :id', ['id' => 2]);
+} catch (\Aura\SqlQuery\Exception\LogicException $e) {
+    // throws: The placeholder ':id' is already in use by a rendered UNION
+    // branch...
+}
+```
+
+Binding the *same* value is fine, since there is nothing to lose -- one filter
+applied to both halves needs only one placeholder:
+
+```php
+$select = $queryFactory->newSelect();
+
+$select
+    ->cols(['*'])->from('a')->where('tenant = :tenant', ['tenant' => 5])
+    ->union()
+    ->cols(['*'])->from('b')->where('tenant = :tenant', ['tenant' => 5]);
+```
+
+```sql
+SELECT
+    *
+FROM
+    "a"
+WHERE
+    tenant = :tenant
+UNION
+SELECT
+    *
+FROM
+    "b"
+WHERE
+    tenant = :tenant
+```
+
+A rendered branch holds its names against `resetWhere()` and the other clause
+resets too, since those clauses have been built into SQL already.
+`resetUnions()` discards that SQL and releases the names with it.

--- a/docs/other.md
+++ b/docs/other.md
@@ -150,6 +150,15 @@ resets too, since those clauses have been built into SQL already.
 This covers hand-bound values as well. A branch can be written around
 `bindValue()` -- `where('id = :id')` with the value supplied separately -- and
 the retained SQL binds `:id` no differently, so a later clause cannot rebind it
-to another value. The branch is held to every name bound when it was rendered,
-whether or not its SQL mentions them; `bindValue()` still overwrites any of
-them, as it does everywhere else.
+to another value.
+
+A branch is held to every name bound when it was rendered, not to the ones its
+SQL spells out as `:name`. The wider net is deliberate: a placeholder can be
+bound by SQL that never names it, and a positional one is exactly that --
+`where('id = ?')` keeps the `?` token and binds its value by number, so there
+is no name in the statement to find. Holding only the visible names would free
+that value for a later branch to overwrite, and the first branch would then run
+on the second branch's data with nothing reported. Holding them all can instead
+refuse a name a branch had bound but never used, which says so and is answered
+by choosing another name -- or by `bindValue()`, which overwrites any of them,
+as it does everywhere else.

--- a/docs/other.md
+++ b/docs/other.md
@@ -82,8 +82,14 @@ WHERE
     OR channel = :channel
 ```
 
-The upsert methods need no such care: `doUpdateCol()` and
+The upsert methods stay clear of `cols()` on their own: `doUpdateCol()` and
 `onDuplicateKeyUpdateCol()` derive their placeholder by suffixing the column
 name, so `cols(['name' => 'Alice'])` binds `:name` while
 `onDuplicateKeyUpdateCol('name', 'updated')` binds `:name__on_duplicate_key`,
 and both values survive.
+
+The suffix only settles the ordinary case, though; the derived names are
+reserved, so do not bind them yourself. A column literally named
+`name__on_duplicate_key` in `cols()` collides with
+`onDuplicateKeyUpdateCol('name', ...)`, and `name__on_conflict` collides with
+`doUpdateCol('name', ...)`. Both throw the same `LogicException`.

--- a/docs/update.md
+++ b/docs/update.md
@@ -43,7 +43,8 @@ $update->table('foo')           // update this table
 `cols()` names its placeholder after the column, and so does a bind value
 passed to `where()`. When a condition tests a column the query also sets, both
 want the same placeholder, and only one value can survive — so this throws
-`Aura\SqlQuery\Exception\LogicException`:
+`Aura\SqlQuery\Exception\LogicException`. It throws even if the two values
+happen to match, since either one may be revised afterwards:
 
 ```php
 $update = $queryFactory->newUpdate();

--- a/docs/update.md
+++ b/docs/update.md
@@ -73,24 +73,22 @@ WHERE
     status = :old_status
 ```
 
-Binding by hand is never blocked, so a value you set yourself may always
-replace an earlier one:
+Only UPDATE can run into this: INSERT has no `where()`, DELETE has no `cols()`,
+and a SELECT `cols()` binds nothing. Two conditions sharing one placeholder
+name is a separate case that is *not* caught — see
+[Placeholder Names](./other.md#placeholder-names).
+
+Binding a value yourself is never blocked, whatever set it first:
 
 ```php
 $update = $queryFactory->newUpdate();
 
 $update->table('orders')->cols(['status' => 'shipped']);
-$update->bindValue('status', 'delivered');   // fine: :status is now 'delivered'
+$update->bindValue('status', 'delivered');   // :status is now 'delivered'
 ```
 
-> **Note:** the same rule covers the upsert methods, which build their
-> placeholder by appending a suffix to the column name —
-> `doUpdateCol('status', ...)` binds `:status__on_conflict` on PostgreSQL and
-> SQLite, and `onDuplicateKeyUpdateCol('status', ...)` binds
-> `:status__on_duplicate_key` on MySQL. Because the name is derived, it does
-> not clash with the `:status` bound by `cols()`; the ordinary upsert needs no
-> special handling. It throws only if a column is itself named
-> `status__on_conflict` or `status__on_duplicate_key`.
+It does not take ownership of the name, though: the placeholder still belongs
+to `cols()`, so a condition claiming `:status` afterwards still throws.
 
 Once you have built the query, pass it to the database connection of your
 choice as a string, and send the bound values along with it.

--- a/docs/update.md
+++ b/docs/update.md
@@ -38,6 +38,60 @@ $update->table('foo')           // update this table
     ]);
 ```
 
+## Placeholder names
+
+`cols()` names its placeholder after the column, and so does a bind value
+passed to `where()`. When a condition tests a column the query also sets, both
+want the same placeholder, and only one value can survive — so this throws
+`Aura\SqlQuery\Exception\LogicException`:
+
+```php
+$update = $queryFactory->newUpdate();
+
+$update
+    ->table('orders')
+    ->cols(['status' => 'shipped'])                     // binds :status
+    ->where('status = :status', ['status' => 'pending']);   // wants :status too
+```
+
+Bind the condition under a name of its own:
+
+```php
+$update = $queryFactory->newUpdate();
+
+$update
+    ->table('orders')
+    ->cols(['status' => 'shipped'])
+    ->where('status = :old_status', ['old_status' => 'pending']);
+```
+
+```sql
+UPDATE "orders"
+SET
+    "status" = :status
+WHERE
+    status = :old_status
+```
+
+Binding by hand is never blocked, so a value you set yourself may always
+replace an earlier one:
+
+```php
+$update = $queryFactory->newUpdate();
+
+$update->table('orders')->cols(['status' => 'shipped']);
+$update->bindValue('status', 'delivered');   // fine: :status is now 'delivered'
+```
+
+> **Note:** the same rule covers the upsert methods, which build their
+> placeholder by appending a suffix to the column name —
+> `doUpdateCol('status', ...)` binds `:status__on_conflict` on PostgreSQL and
+> SQLite, and `onDuplicateKeyUpdateCol('status', ...)` binds
+> `:status__on_duplicate_key` on MySQL. Because the name is derived, it does
+> not clash with the `:status` bound by `cols()`; the ordinary upsert needs no
+> special handling. It throws only if a column is itself named
+> `status__on_conflict` or `status__on_duplicate_key`.
+
 Once you have built the query, pass it to the database connection of your
 choice as a string, and send the bound values along with it.
 

--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -56,7 +56,7 @@ abstract class AbstractDmlQuery extends AbstractQuery
         $key = $this->quoter->quoteName($col);
         $this->col_values[$key] = ":$col";
         if (count($value) > 0) {
-            $this->bindValue($col, $value[0]);
+            $this->bindValueFrom($col, $value[0], 'col');
         }
         return $this;
     }

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -53,6 +53,7 @@ abstract class AbstractQuery
         'where' => 'a WHERE condition',
         'having' => 'a HAVING condition',
         'join' => 'a JOIN condition',
+        'union' => 'a rendered UNION branch',
         'conflict' => 'doUpdateCol()',
         'duplicate_key' => 'onDuplicateKeyUpdateCol()',
     );
@@ -234,7 +235,8 @@ abstract class AbstractQuery
      * @param mixed $value The value to bind to the placeholder.
      *
      * @param string $source The part of the query binding the value: 'col',
-     * 'cond', 'conflict', 'duplicate_key', or null when bound by hand.
+     * 'cond', 'conflict', 'duplicate_key', 'union', or null when bound by
+     * hand.
      *
      * @return $this
      *
@@ -247,6 +249,20 @@ abstract class AbstractQuery
         $prior = isset($this->bind_sources[$name])
             ? $this->bind_sources[$name]
             : null;
+
+        // A rendered UNION branch owns its placeholders, but a later branch
+        // filtering on the same value -- one tenant id across both halves --
+        // asks for exactly what is already bound, and nothing is lost by
+        // letting it through. Returning here also leaves the name with the
+        // union: were ownership to pass to the new clause, a later
+        // resetWhere() would free a name the rendered SQL still binds.
+        if (
+            $prior === 'union'
+            && array_key_exists($name, $this->bind_values)
+            && $this->bind_values[$name] === $value
+        ) {
+            return $this;
+        }
 
         if (
             $source !== null

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -65,6 +65,7 @@ abstract class AbstractQuery
         'where' => 'a WHERE condition',
         'having' => 'a HAVING condition',
         'join' => 'a JOIN condition',
+        'table' => 'a sub-select in the FROM clause',
         'union' => 'a rendered UNION branch',
         'conflict' => 'doUpdateCol()',
         'duplicate_key' => 'onDuplicateKeyUpdateCol()',
@@ -320,26 +321,28 @@ abstract class AbstractQuery
 
     /**
      *
-     * Takes over the values a sub-select has bound, keeping the part of that
-     * sub-select which claimed each one so the collision check reads the same
-     * as it would there.
+     * Takes over the values a sub-select has bound, claiming them for the
+     * clause the sub-select was rendered into.
+     *
+     * The sub-select's own clause labels are deliberately not carried over.
+     * They describe parts of a different query: recording them here would
+     * have the outer query hold a name against a WHERE it may not even have,
+     * which no reset of the outer query can reach -- resetTables() releases
+     * the clause the sub-select actually sits in, and would leave the name
+     * claimed forever. The message would name that absent clause too, and
+     * send the reader looking for it.
      *
      * @param SelectInterface $select The sub-select to take the values from.
      *
-     * @param string $default_source The source to record for a value the
-     * sub-select bound by hand, which has no claimant to carry over.
+     * @param string $source The part of THIS query the sub-select was
+     * rendered into.
      *
      * @return $this
      *
      */
-    protected function bindValuesFromSelect(SelectInterface $select, $default_source)
+    protected function bindValuesFromSelect(SelectInterface $select, $source)
     {
-        $bind_sources = ($select instanceof AbstractQuery) ? $select->bind_sources : [];
-
         foreach ($select->getBindValues() as $name => $value) {
-            $source = isset($bind_sources[$name])
-                ? $bind_sources[$name]
-                : $default_source;
             $this->bindValueFrom($name, $value, $source);
         }
 
@@ -380,14 +383,25 @@ abstract class AbstractQuery
         // a positional placeholder is bound by number and keeps its `?` in
         // the statement, so quoting it as ':1' would name a token the query
         // does not contain and send the reader looking for it.
-        $which = ctype_digit((string) $name)
+        // a positional placeholder is numbered by its offset in the values
+        // array, which starts again at zero on every call, so "use a
+        // different one" is advice the caller cannot act on: naming them is
+        // the only way to keep the two apart.
+        $positional = ctype_digit((string) $name);
+
+        $which = $positional
             ? "The positional placeholder {$name}"
             : "The placeholder ':{$name}'";
+
+        $remedy = $positional
+            ? "Give the placeholders names instead of '?', so that each one "
+            . "carries its own value."
+            : "Use a different placeholder for one of them.";
 
         throw new Exception\LogicException(
             "{$which} is already in use by {$was}, so "
             . "{$now} cannot bind it as well: one value would overwrite "
-            . "the other. Use a different placeholder for one of them."
+            . "the other. {$remedy}"
         );
     }
 

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -32,6 +32,30 @@ abstract class AbstractQuery
 
     /**
      *
+     * Which part of the query bound each placeholder name; null means it was
+     * bound by hand. Keys match $bind_values.
+     *
+     * @var array
+     *
+     */
+    protected $bind_sources = array();
+
+    /**
+     *
+     * Human-readable names for the $bind_sources values, for error messages.
+     *
+     * @var array
+     *
+     */
+    protected $bind_source_labels = array(
+        'col' => 'cols()',
+        'cond' => 'a condition',
+        'conflict' => 'doUpdateCol()',
+        'duplicate_key' => 'onDuplicateKeyUpdateCol()',
+    );
+
+    /**
+     *
      * The list of WHERE conditions.
      *
      * @var array
@@ -184,7 +208,73 @@ abstract class AbstractQuery
      */
     public function bindValue($name, $value)
     {
+        return $this->bindValueFrom($name, $value, null);
+    }
+
+    /**
+     *
+     * Binds a single value, recording which part of the query asked for it.
+     *
+     * Two different parts of a query claiming the same placeholder name is a
+     * mistake: only one value can survive in the flat bind array, so the
+     * other is silently discarded and the statement runs with the wrong data.
+     * Throw instead of losing it.
+     *
+     * A null source means the caller bound the value by hand, which may
+     * always overwrite: rebinding before execution, and reusing a query
+     * object with fresh values, are both legitimate.
+     *
+     * @param string $name The placeholder name or number.
+     *
+     * @param mixed $value The value to bind to the placeholder.
+     *
+     * @param string $source The part of the query binding the value: 'col',
+     * 'cond', 'conflict', 'duplicate_key', or null when bound by hand.
+     *
+     * @return $this
+     *
+     * @throws Exception\LogicException when two different parts of the query
+     * bind different values to one placeholder name.
+     *
+     */
+    protected function bindValueFrom($name, $value, $source)
+    {
+        $prior = isset($this->bind_sources[$name])
+            ? $this->bind_sources[$name]
+            : null;
+
+        if (
+            $source !== null
+            && $prior !== null
+            && $prior !== $source
+            && array_key_exists($name, $this->bind_values)
+            && $this->bind_values[$name] !== $value
+        ) {
+            $was = isset($this->bind_source_labels[$prior])
+                ? $this->bind_source_labels[$prior]
+                : $prior;
+            $now = isset($this->bind_source_labels[$source])
+                ? $this->bind_source_labels[$source]
+                : $source;
+
+            throw new Exception\LogicException(
+                "Cannot bind two different values to the placeholder "
+                . "':{$name}'; it is already in use by {$was}, and {$now} "
+                . "would discard that value. Use a different placeholder "
+                . "name for one of them."
+            );
+        }
+
         $this->bind_values[$name] = $value;
+
+        // a hand-bound value overwrites the value but does not take ownership
+        // of the name: otherwise binding by hand between two parts of the
+        // query would erase the record of who claimed it first, and the
+        // collision they would have had goes undetected.
+        if ($source !== null) {
+            $this->bind_sources[$name] = $source;
+        }
+
         return $this;
     }
 
@@ -210,6 +300,7 @@ abstract class AbstractQuery
     public function resetBindValues()
     {
         $this->bind_values = array();
+        $this->bind_sources = array();
         return $this;
     }
 
@@ -372,7 +463,7 @@ abstract class AbstractQuery
             } elseif (is_array($val)) {
                 $cond = $this->getCond($key, $cond, $val, $index);
             } else {
-                $this->bindValue($key, $val);
+                $this->bindValueFrom($key, $val, 'cond');
             }
             $index++;
         }
@@ -395,7 +486,7 @@ abstract class AbstractQuery
         foreach ($array as $val) {
             $this->inlineCount++;
             $key = "__{$this->inlineCount}__";
-            $this->bindValue($key, $val);
+            $this->bindValueFrom($key, $val, 'cond');
             $keys[] = ":{$key}";
         }
         return implode(', ', $keys);

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -246,9 +246,10 @@ abstract class AbstractQuery
      *
      * @param mixed $value The value to bind to the placeholder.
      *
-     * @param string $source The part of the query binding the value: 'col',
-     * 'cond', 'conflict', 'duplicate_key', 'union', or null when bound by
-     * hand.
+     * @param string|null $source The part of the query binding the value:
+     * 'col', 'where', 'having', 'join', 'cond' for a condition with no
+     * clause of its own, 'conflict', 'duplicate_key', 'union', or null when
+     * bound by hand.
      *
      * @return $this
      *
@@ -319,6 +320,34 @@ abstract class AbstractQuery
 
     /**
      *
+     * Takes over the values a sub-select has bound, keeping the part of that
+     * sub-select which claimed each one so the collision check reads the same
+     * as it would there.
+     *
+     * @param SelectInterface $select The sub-select to take the values from.
+     *
+     * @param string $default_source The source to record for a value the
+     * sub-select bound by hand, which has no claimant to carry over.
+     *
+     * @return $this
+     *
+     */
+    protected function bindValuesFromSelect(SelectInterface $select, $default_source)
+    {
+        $bind_sources = ($select instanceof AbstractQuery) ? $select->bind_sources : [];
+
+        foreach ($select->getBindValues() as $name => $value) {
+            $source = isset($bind_sources[$name])
+                ? $bind_sources[$name]
+                : $default_source;
+            $this->bindValueFrom($name, $value, $source);
+        }
+
+        return $this;
+    }
+
+    /**
+     *
      * Reports two parts of the query claiming one placeholder name.
      *
      * @param string $name The placeholder name.
@@ -348,11 +377,17 @@ abstract class AbstractQuery
             $now = 'another ' . preg_replace('/^an? /', '', $now);
         }
 
+        // a positional placeholder is bound by number and keeps its `?` in
+        // the statement, so quoting it as ':1' would name a token the query
+        // does not contain and send the reader looking for it.
+        $which = ctype_digit((string) $name)
+            ? "The positional placeholder {$name}"
+            : "The placeholder ':{$name}'";
+
         throw new Exception\LogicException(
-            "The placeholder ':{$name}' is already in use by {$was}, so "
+            "{$which} is already in use by {$was}, so "
             . "{$now} cannot bind it as well: one value would overwrite "
-            . "the other. Use a different placeholder name for one of "
-            . "them."
+            . "the other. Use a different placeholder for one of them."
         );
     }
 
@@ -385,7 +420,12 @@ abstract class AbstractQuery
 
     /**
      *
-     * Removes all bound values and sources for a given query source.
+     * Releases the placeholder names a query source claimed, so they may be
+     * claimed again. The bound values themselves are kept: the clause resets
+     * have never removed them, and union() depends on that.
+     *
+     * A name another clause is sharing passes to that clause rather than
+     * being released, since it is still in use.
      *
      * @param string $source The source to remove (e.g. 'where', 'having').
      *
@@ -592,11 +632,7 @@ abstract class AbstractQuery
 
         foreach ($selects as $key => $select) {
             $selects[$key] = $select->getStatement();
-            $bind_sources = ($select instanceof AbstractQuery) ? $select->bind_sources : [];
-            foreach ($select->getBindValues() as $subName => $subVal) {
-                $subSource = isset($bind_sources[$subName]) ? $bind_sources[$subName] : $clause;
-                $this->bindValueFrom($subName, $subVal, $subSource);
-            }
+            $this->bindValuesFromSelect($select, $clause);
         }
 
         $cond = strtr($cond, $selects);

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -50,6 +50,9 @@ abstract class AbstractQuery
     protected $bind_source_labels = array(
         'col' => 'cols()',
         'cond' => 'a condition',
+        'where' => 'a WHERE condition',
+        'having' => 'a HAVING condition',
+        'join' => 'a JOIN condition',
         'conflict' => 'doUpdateCol()',
         'duplicate_key' => 'onDuplicateKeyUpdateCol()',
     );
@@ -248,8 +251,14 @@ abstract class AbstractQuery
         if (
             $source !== null
             && $prior !== null
-            && $prior !== $source
             && array_key_exists($name, $this->bind_values)
+            && (
+                $prior !== $source
+                || (
+                    $this->bind_values[$name] !== $value
+                    && !in_array($source, ['col', 'conflict', 'duplicate_key'], true)
+                )
+            )
         ) {
             $was = isset($this->bind_source_labels[$prior])
                 ? $this->bind_source_labels[$prior]
@@ -257,6 +266,13 @@ abstract class AbstractQuery
             $now = isset($this->bind_source_labels[$source])
                 ? $this->bind_source_labels[$source]
                 : $source;
+
+            // "a WHERE condition ... a WHERE condition" reads like a bug when
+            // both halves are the same clause; say "another" instead, taking
+            // the article off the label first.
+            if ($prior === $source) {
+                $now = 'another ' . preg_replace('/^an? /', '', $now);
+            }
 
             throw new Exception\LogicException(
                 "The placeholder ':{$name}' is already in use by {$was}, so "
@@ -304,6 +320,30 @@ abstract class AbstractQuery
     {
         $this->bind_values = array();
         $this->bind_sources = array();
+        return $this;
+    }
+
+    /**
+     *
+     * Removes all bound values and sources for a given query source.
+     *
+     * @param string $source The source to remove (e.g. 'where', 'having').
+     *
+     * @return $this
+     *
+     */
+    protected function removeBindSources($source)
+    {
+        // drop the record of who claimed the name, but keep the value: the
+        // clause resets never removed bound values, and union() depends on
+        // that -- it renders the current half to SQL, placeholders and all,
+        // then resets, so deleting the values leaves that SQL with tokens
+        // nothing can bind.
+        foreach ($this->bind_sources as $name => $src) {
+            if ($src === $source) {
+                unset($this->bind_sources[$name]);
+            }
+        }
         return $this;
     }
 
@@ -375,12 +415,14 @@ abstract class AbstractQuery
     {
         if ($cond instanceof Closure) {
             $this->addClauseCondClosure($clause, $andor, $cond);
-            $this->bindValues($bind);
+            foreach ($bind as $key => $val) {
+                $this->bindValueFrom($key, $val, $clause);
+            }
             return;
         }
 
         $cond = $this->quoter->quoteNamesIn($cond);
-        $cond = $this->rebuildCondAndBindValues($cond, $bind);
+        $cond = $this->rebuildCondAndBindValues($cond, $bind, $clause);
 
         $clause =& $this->$clause;
         if ($clause) {
@@ -452,10 +494,12 @@ abstract class AbstractQuery
      * @param array $bind_values The values to bind to the sequential
      * placeholders under their named versions.
      *
+     * @param string $clause The source clause name.
+     *
      * @return string The rebuilt condition string.
      *
      */
-    protected function rebuildCondAndBindValues($cond, array $bind_values)
+    protected function rebuildCondAndBindValues($cond, array $bind_values, $clause = 'cond')
     {
         $index = 0;
         $selects = [];
@@ -466,17 +510,18 @@ abstract class AbstractQuery
             } elseif (is_array($val)) {
                 $cond = $this->getCond($key, $cond, $val, $index);
             } else {
-                $this->bindValueFrom($key, $val, 'cond');
+                $this->bindValueFrom($key, $val, $clause);
             }
             $index++;
         }
 
         foreach ($selects as $key => $select) {
             $selects[$key] = $select->getStatement();
-            $this->bind_values = array_merge(
-                $this->bind_values,
-                $select->getBindValues()
-            );
+            $bind_sources = ($select instanceof AbstractQuery) ? $select->bind_sources : [];
+            foreach ($select->getBindValues() as $subName => $subVal) {
+                $subSource = isset($bind_sources[$subName]) ? $bind_sources[$subName] : $clause;
+                $this->bindValueFrom($subName, $subVal, $subSource);
+            }
         }
 
         $cond = strtr($cond, $selects);

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -267,11 +267,13 @@ abstract class AbstractQuery
 
         $this->bind_values[$name] = $value;
 
-        // a hand-bound value overwrites the value but does not take ownership
-        // of the name: otherwise binding by hand between two parts of the
-        // query would erase the record of who claimed it first, and the
-        // collision they would have had goes undetected.
-        if ($source !== null) {
+        // Ownership stays with whoever claimed the name first. A hand-bound
+        // value overwrites the value without claiming the name, and so does a
+        // second part of the query that happens to bind the same value: the
+        // check above lets that through, but if it took ownership, the
+        // original claimant revising its own placeholder later would look
+        // like a collision with the part that only ever agreed with it.
+        if ($source !== null && ($prior === null || $prior === $source)) {
             $this->bind_sources[$name] = $source;
         }
 

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -218,7 +218,9 @@ abstract class AbstractQuery
      * Two different parts of a query claiming the same placeholder name is a
      * mistake: only one value can survive in the flat bind array, so the
      * other is silently discarded and the statement runs with the wrong data.
-     * Throw instead of losing it.
+     * Throw instead of losing it -- even when the two values happen to agree
+     * today, since either part may revise its value afterwards and there is
+     * nothing to re-check it against.
      *
      * A null source means the caller bound the value by hand, which may
      * always overwrite: rebinding before execution, and reusing a query
@@ -234,7 +236,7 @@ abstract class AbstractQuery
      * @return $this
      *
      * @throws Exception\LogicException when two different parts of the query
-     * bind different values to one placeholder name.
+     * claim one placeholder name.
      *
      */
     protected function bindValueFrom($name, $value, $source)
@@ -248,7 +250,6 @@ abstract class AbstractQuery
             && $prior !== null
             && $prior !== $source
             && array_key_exists($name, $this->bind_values)
-            && $this->bind_values[$name] !== $value
         ) {
             $was = isset($this->bind_source_labels[$prior])
                 ? $this->bind_source_labels[$prior]
@@ -258,22 +259,22 @@ abstract class AbstractQuery
                 : $source;
 
             throw new Exception\LogicException(
-                "Cannot bind two different values to the placeholder "
-                . "':{$name}'; it is already in use by {$was}, and {$now} "
-                . "would discard that value. Use a different placeholder "
-                . "name for one of them."
+                "The placeholder ':{$name}' is already in use by {$was}, so "
+                . "{$now} cannot bind it as well: one value would overwrite "
+                . "the other. Use a different placeholder name for one of "
+                . "them."
             );
         }
 
         $this->bind_values[$name] = $value;
 
-        // Ownership stays with whoever claimed the name first. A hand-bound
-        // value overwrites the value without claiming the name, and so does a
-        // second part of the query that happens to bind the same value: the
-        // check above lets that through, but if it took ownership, the
-        // original claimant revising its own placeholder later would look
-        // like a collision with the part that only ever agreed with it.
-        if ($source !== null && ($prior === null || $prior === $source)) {
+        // A hand-bound value overwrites the value but does not claim the
+        // name: otherwise binding by hand between two parts of the query
+        // would erase the record of who claimed it first, and the collision
+        // they would have had goes undetected. Any other source reaching
+        // here either claimed the name already or found it free, since a
+        // second claimant throws above.
+        if ($source !== null) {
             $this->bind_sources[$name] = $source;
         }
 

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -42,6 +42,18 @@ abstract class AbstractQuery
 
     /**
      *
+     * A second claimant on a name a rendered UNION branch owns, for the case
+     * where the active branch asks for the value already bound. Ownership
+     * stays with the union, but the name is not free while this clause is
+     * still using it. Keys match $bind_sources.
+     *
+     * @var array
+     *
+     */
+    protected $bind_shared = array();
+
+    /**
+     *
      * Human-readable names for the $bind_sources values, for error messages.
      *
      * @var array
@@ -253,14 +265,25 @@ abstract class AbstractQuery
         // A rendered UNION branch owns its placeholders, but a later branch
         // filtering on the same value -- one tenant id across both halves --
         // asks for exactly what is already bound, and nothing is lost by
-        // letting it through. Returning here also leaves the name with the
-        // union: were ownership to pass to the new clause, a later
-        // resetWhere() would free a name the rendered SQL still binds.
+        // letting it through. Ownership stays with the union: were it to pass
+        // to the new clause, a later resetWhere() would free a name the
+        // rendered SQL still binds. Record the clause as a second claimant
+        // all the same, so that resetUnions() hands the name over to it
+        // instead of freeing a name this clause is still using.
         if (
             $prior === 'union'
             && array_key_exists($name, $this->bind_values)
             && $this->bind_values[$name] === $value
         ) {
+            if ($source !== null && $source !== 'union') {
+                $shared = isset($this->bind_shared[$name])
+                    ? $this->bind_shared[$name]
+                    : null;
+                if ($shared !== null && $shared !== $source) {
+                    $this->throwCollision($name, $shared, $source);
+                }
+                $this->bind_shared[$name] = $source;
+            }
             return $this;
         }
 
@@ -276,26 +299,7 @@ abstract class AbstractQuery
                 )
             )
         ) {
-            $was = isset($this->bind_source_labels[$prior])
-                ? $this->bind_source_labels[$prior]
-                : $prior;
-            $now = isset($this->bind_source_labels[$source])
-                ? $this->bind_source_labels[$source]
-                : $source;
-
-            // "a WHERE condition ... a WHERE condition" reads like a bug when
-            // both halves are the same clause; say "another" instead, taking
-            // the article off the label first.
-            if ($prior === $source) {
-                $now = 'another ' . preg_replace('/^an? /', '', $now);
-            }
-
-            throw new Exception\LogicException(
-                "The placeholder ':{$name}' is already in use by {$was}, so "
-                . "{$now} cannot bind it as well: one value would overwrite "
-                . "the other. Use a different placeholder name for one of "
-                . "them."
-            );
+            $this->throwCollision($name, $prior, $source);
         }
 
         $this->bind_values[$name] = $value;
@@ -311,6 +315,45 @@ abstract class AbstractQuery
         }
 
         return $this;
+    }
+
+    /**
+     *
+     * Reports two parts of the query claiming one placeholder name.
+     *
+     * @param string $name The placeholder name.
+     *
+     * @param string $prior The part of the query holding the name.
+     *
+     * @param string $source The part of the query asking for it as well.
+     *
+     * @return void
+     *
+     * @throws Exception\LogicException always.
+     *
+     */
+    protected function throwCollision($name, $prior, $source)
+    {
+        $was = isset($this->bind_source_labels[$prior])
+            ? $this->bind_source_labels[$prior]
+            : $prior;
+        $now = isset($this->bind_source_labels[$source])
+            ? $this->bind_source_labels[$source]
+            : $source;
+
+        // "a WHERE condition ... a WHERE condition" reads like a bug when
+        // both halves are the same clause; say "another" instead, taking
+        // the article off the label first.
+        if ($prior === $source) {
+            $now = 'another ' . preg_replace('/^an? /', '', $now);
+        }
+
+        throw new Exception\LogicException(
+            "The placeholder ':{$name}' is already in use by {$was}, so "
+            . "{$now} cannot bind it as well: one value would overwrite "
+            . "the other. Use a different placeholder name for one of "
+            . "them."
+        );
     }
 
     /**
@@ -336,6 +379,7 @@ abstract class AbstractQuery
     {
         $this->bind_values = array();
         $this->bind_sources = array();
+        $this->bind_shared = array();
         return $this;
     }
 
@@ -355,10 +399,25 @@ abstract class AbstractQuery
         // that -- it renders the current half to SQL, placeholders and all,
         // then resets, so deleting the values leaves that SQL with tokens
         // nothing can bind.
-        foreach ($this->bind_sources as $name => $src) {
+        foreach ($this->bind_shared as $name => $src) {
             if ($src === $source) {
-                unset($this->bind_sources[$name]);
+                unset($this->bind_shared[$name]);
             }
+        }
+
+        foreach ($this->bind_sources as $name => $src) {
+            if ($src !== $source) {
+                continue;
+            }
+            // a name another clause is still using is not free: hand it over
+            // rather than releasing it, or that clause's placeholder could be
+            // rebound to a different value with nothing to report the clash.
+            if (isset($this->bind_shared[$name])) {
+                $this->bind_sources[$name] = $this->bind_shared[$name];
+                unset($this->bind_shared[$name]);
+                continue;
+            }
+            unset($this->bind_sources[$name]);
         }
         return $this;
     }

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -404,6 +404,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
 
         $this->col_values = array();
         $this->bind_values = array();
+        $this->bind_sources = array();
     }
 
     /**

--- a/src/Common/LateralJoinTrait.php
+++ b/src/Common/LateralJoinTrait.php
@@ -56,7 +56,7 @@ trait LateralJoinTrait
 
         $this->addTableRef("$join (SELECT ...)", $name);
 
-        $spec = $this->subSelect($spec, '            ');
+        $spec = $this->subSelect($spec, '            ', 'join');
         $name = $this->quoter->quoteName($name);
         $cond = $this->fixJoinCondition($cond, $bind);
 

--- a/src/Common/OnConflictUpdateTrait.php
+++ b/src/Common/OnConflictUpdateTrait.php
@@ -155,7 +155,7 @@ trait OnConflictUpdateTrait
         if (count($value) > 0) {
             $bind = $col . '__on_conflict';
             $this->conflict_update_values[$key] = ":$bind";
-            $this->bindValue($bind, $value[0]);
+            $this->bindValueFrom($bind, $value[0], 'conflict');
         } else {
             $this->conflict_update_values[$key] = 'excluded.' . $key;
         }

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -521,7 +521,11 @@ class Select extends AbstractQuery implements SelectInterface
     protected function subSelect($spec, $indent)
     {
         if ($spec instanceof SelectInterface) {
-            $this->bindValues($spec->getBindValues());
+            $bind_sources = ($spec instanceof AbstractQuery) ? $spec->bind_sources : [];
+            foreach ($spec->getBindValues() as $subName => $subVal) {
+                $subSource = isset($bind_sources[$subName]) ? $bind_sources[$subName] : 'cond';
+                $this->bindValueFrom($subName, $subVal, $subSource);
+            }
         }
 
         return PHP_EOL . $indent
@@ -575,7 +579,7 @@ class Select extends AbstractQuery implements SelectInterface
         }
 
         $cond = $this->quoter->quoteNamesIn($cond);
-        $cond = $this->rebuildCondAndBindValues($cond, $bind);
+        $cond = $this->rebuildCondAndBindValues($cond, $bind, 'join');
 
         if (strtoupper(substr(ltrim($cond), 0, 3)) == 'ON ') {
             return $cond;
@@ -856,6 +860,7 @@ class Select extends AbstractQuery implements SelectInterface
         $this->from_key = -1;
         $this->join = array();
         $this->table_refs = array();
+        $this->removeBindSources('join');
         return $this;
     }
 
@@ -869,6 +874,7 @@ class Select extends AbstractQuery implements SelectInterface
     public function resetWhere()
     {
         $this->where = array();
+        $this->removeBindSources('where');
         return $this;
     }
 
@@ -895,6 +901,7 @@ class Select extends AbstractQuery implements SelectInterface
     public function resetHaving()
     {
         $this->having = array();
+        $this->removeBindSources('having');
         return $this;
     }
 

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -515,13 +515,16 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string $indent Indent each line with this string.
      *
+     * @param string $source The part of this query the sub-select is being
+     * rendered into, which claims the names it binds.
+     *
      * @return string The sub-SELECT string.
      *
      */
-    protected function subSelect($spec, $indent)
+    protected function subSelect($spec, $indent, $source = 'table')
     {
         if ($spec instanceof SelectInterface) {
-            $this->bindValuesFromSelect($spec, 'cond');
+            $this->bindValuesFromSelect($spec, $source);
         }
 
         return PHP_EOL . $indent
@@ -654,7 +657,7 @@ class Select extends AbstractQuery implements SelectInterface
         $join = strtoupper(ltrim("$join JOIN"));
         $this->addTableRef("$join (SELECT ...) AS", $name);
 
-        $spec = $this->subSelect($spec, '            ');
+        $spec = $this->subSelect($spec, '            ', 'join');
         $name = $this->quoter->quoteName($name);
         $cond = $this->fixJoinCondition($cond, $bind);
 
@@ -894,6 +897,7 @@ class Select extends AbstractQuery implements SelectInterface
         $this->join = array();
         $this->table_refs = array();
         $this->removeBindSources('join');
+        $this->removeBindSources('table');
         return $this;
     }
 

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -792,7 +792,7 @@ class Select extends AbstractQuery implements SelectInterface
     public function union()
     {
         $this->union[] = $this->build() . PHP_EOL . 'UNION';
-        $this->reset();
+        $this->resetAfterRendering();
         return $this;
     }
 
@@ -807,8 +807,32 @@ class Select extends AbstractQuery implements SelectInterface
     public function unionAll()
     {
         $this->union[] = $this->build() . PHP_EOL . 'UNION ALL';
-        $this->reset();
+        $this->resetAfterRendering();
         return $this;
+    }
+
+    /**
+     *
+     * Clears the current select properties after its SQL has been rendered
+     * and retained, keeping the placeholder names that SQL still binds.
+     *
+     * A clause reset frees the names it claimed, which is right while the
+     * query is still being built. It is wrong here: union() has already
+     * turned the current branch into SQL, placeholders and all, and that SQL
+     * keeps binding those names. Left free, the next branch could claim :id
+     * for a different value and overwrite the one the rendered branch needs,
+     * with nothing to report the clash. The names pass to the union itself
+     * rather than staying with their clause, so that a resetWhere() in the
+     * next branch cannot free them either.
+     *
+     * @return null
+     *
+     */
+    protected function resetAfterRendering()
+    {
+        $bind_sources = $this->bind_sources;
+        $this->reset();
+        $this->bind_sources = array_fill_keys(array_keys($bind_sources), 'union');
     }
 
     /**
@@ -928,6 +952,10 @@ class Select extends AbstractQuery implements SelectInterface
     public function resetUnions()
     {
         $this->union = array();
+
+        // the rendered branches are gone, so nothing binds their placeholders
+        // any more: release the names they were holding.
+        $this->removeBindSources('union');
         return $this;
     }
 

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -824,11 +824,23 @@ class Select extends AbstractQuery implements SelectInterface
      * rather than staying with their clause, so that a resetWhere() in the
      * next branch cannot free them either.
      *
-     * Every bound name passes to the union, not only the ones a query part
-     * claimed. A hand-bound value has no claimant -- that is what lets it
-     * overwrite -- but the rendered SQL can just as well be written around it,
-     * as `where('id = :id')` with the value supplied by bindValue(), and a
-     * later clause binding :id would overwrite what that SQL needs.
+     * The names come from the rendered SQL rather than from the query parts
+     * that bound them. A hand-bound value has no claimant -- that is what lets
+     * it overwrite -- but the rendered SQL can just as well be written around
+     * it, as `where('id = :id')` with the value supplied by bindValue(), and a
+     * later clause binding :id would overwrite what that SQL needs. Scanning
+     * the SQL catches that name along with every other one it spells.
+     *
+     * It also stops short of the names that SQL does *not* spell. A clause
+     * reset frees a name but keeps its value, so a placeholder dropped before
+     * the union is still bound while appearing nowhere in the branch: nothing
+     * there can bind it, the union has no claim to stake, and the next branch
+     * is free to use the name for a value of its own.
+     *
+     * A positional placeholder is the one name the scan cannot find, since it
+     * keeps its `?` in the statement and is bound by number. Those are held on
+     * the strength of being bound at all -- the alternative is to release a
+     * name the rendered SQL is certainly using.
      *
      * @return null
      *
@@ -836,10 +848,20 @@ class Select extends AbstractQuery implements SelectInterface
     protected function resetAfterRendering()
     {
         $this->reset();
-        $this->bind_sources = array_fill_keys(
-            array_keys($this->bind_values),
-            'union'
-        );
+
+        // a name inside a string literal is data, not a placeholder, so this
+        // can claim a name the branch does not really bind. That costs a
+        // needless collision report, where missing a name the branch *does*
+        // bind would let a later branch overwrite it silently.
+        preg_match_all('/(?<!:):(\w+)/', end($this->union), $matches);
+        $spelled = array_flip($matches[1]);
+
+        $this->bind_sources = array();
+        foreach (array_keys($this->bind_values) as $name) {
+            if (isset($spelled[$name]) || ctype_digit((string) $name)) {
+                $this->bind_sources[$name] = 'union';
+            }
+        }
 
         // every name now belongs to the union, including any a clause of the
         // branch just rendered was sharing: that clause is SQL now, so there

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -521,11 +521,7 @@ class Select extends AbstractQuery implements SelectInterface
     protected function subSelect($spec, $indent)
     {
         if ($spec instanceof SelectInterface) {
-            $bind_sources = ($spec instanceof AbstractQuery) ? $spec->bind_sources : [];
-            foreach ($spec->getBindValues() as $subName => $subVal) {
-                $subSource = isset($bind_sources[$subName]) ? $bind_sources[$subName] : 'cond';
-                $this->bindValueFrom($subName, $subVal, $subSource);
-            }
+            $this->bindValuesFromSelect($spec, 'cond');
         }
 
         return PHP_EOL . $indent

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -833,6 +833,11 @@ class Select extends AbstractQuery implements SelectInterface
         $bind_sources = $this->bind_sources;
         $this->reset();
         $this->bind_sources = array_fill_keys(array_keys($bind_sources), 'union');
+
+        // every name now belongs to the union, including any a clause of the
+        // branch just rendered was sharing: that clause is SQL now, so there
+        // is no live claimant left to hand a name back to.
+        $this->bind_shared = array();
     }
 
     /**

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -825,14 +825,22 @@ class Select extends AbstractQuery implements SelectInterface
      * rather than staying with their clause, so that a resetWhere() in the
      * next branch cannot free them either.
      *
+     * Every bound name passes to the union, not only the ones a query part
+     * claimed. A hand-bound value has no claimant -- that is what lets it
+     * overwrite -- but the rendered SQL can just as well be written around it,
+     * as `where('id = :id')` with the value supplied by bindValue(), and a
+     * later clause binding :id would overwrite what that SQL needs.
+     *
      * @return null
      *
      */
     protected function resetAfterRendering()
     {
-        $bind_sources = $this->bind_sources;
         $this->reset();
-        $this->bind_sources = array_fill_keys(array_keys($bind_sources), 'union');
+        $this->bind_sources = array_fill_keys(
+            array_keys($this->bind_values),
+            'union'
+        );
 
         // every name now belongs to the union, including any a clause of the
         // branch just rendered was sharing: that clause is SQL now, so there

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -134,7 +134,7 @@ class Insert extends Common\Insert
         $bind = $col . '__on_duplicate_key';
         $this->col_on_update_values[$key] = ":$bind";
         if (count($value) > 0) {
-            $this->bindValue($bind, $value[0]);
+            $this->bindValueFrom($bind, $value[0], 'duplicate_key');
         }
         return $this;
     }

--- a/tests/AbstractQueryTest.php
+++ b/tests/AbstractQueryTest.php
@@ -89,6 +89,19 @@ abstract class AbstractQueryTest extends TestCase
         $this->assertEmpty($this->query->getBindValues());
     }
 
+    public function testBindValueOverwritesByHand()
+    {
+        // binding by hand may always overwrite, whatever set the value
+        // first; collision detection applies only between two parts of the
+        // query building it themselves. See #238.
+        $this->query->bindValue('foo', 'first');
+        $this->query->bindValue('foo', 'second');
+        $this->assertSame(array('foo' => 'second'), $this->query->getBindValues());
+
+        $this->query->bindValues(array('foo' => 'third'));
+        $this->assertSame(array('foo' => 'third'), $this->query->getBindValues());
+    }
+
     public function testBindValuesReturnsTheQueryForChaining()
     {
         $this->assertSame($this->query, $this->query->bindValues(array('foo' => 'bar')));

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -365,6 +365,88 @@ class CollisionTest extends TestCase
         $select->where('status = :status', array('status' => 'pending'));
     }
 
+    /**
+     *
+     * A sub-select's names are claimed by the clause it was rendered into,
+     * not by whichever of its own clauses bound them: the outer query has no
+     * WHERE of its own here, and the sub-select's WHERE is not a part of the
+     * outer query that any reset could reach. resetTables() discards the
+     * sub-select's SQL, so its names go with it.
+     *
+     */
+    public function testJoinSubSelectNamesAreReleasedByResetTables()
+    {
+        $subSelect = $this->query_factory->newSelect();
+        $subSelect->cols(array('id'))->from('u')->where('s = :s', array('s' => 'a'));
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('t')
+               ->joinSubSelect('INNER', $subSelect, 'sub', 'sub.id = t.id');
+        $select->resetTables();
+
+        $select->from('t')->join('INNER', 'u', 'u.s = :s', array('s' => 'b'));
+        $this->assertSame(array('s' => 'b'), $select->getBindValues());
+    }
+
+    public function testFromSubSelectNamesAreReleasedByResetTables()
+    {
+        $subSelect = $this->query_factory->newSelect();
+        $subSelect->cols(array('id'))->from('u')->where('s = :s', array('s' => 'a'));
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->fromSubSelect($subSelect, 'sub');
+        $select->resetTables();
+
+        $select->from('t')->where('s = :s', array('s' => 'b'));
+        $this->assertSame(array('s' => 'b'), $select->getBindValues());
+    }
+
+    /**
+     *
+     * The other half of claiming for the rendered-into clause: resetWhere()
+     * must not free a name a FROM sub-select is binding. It used to, because
+     * the name was inherited as the sub-select's own 'where', which left the
+     * rendered sub-select running on a later clause's value.
+     *
+     */
+    public function testResetWhereCannotFreeAFromSubSelectsPlaceholder()
+    {
+        $subSelect = $this->query_factory->newSelect();
+        $subSelect->cols(array('id'))->from('u')->where('status = :status', array('status' => 'active'));
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->fromSubSelect($subSelect, 'sub');
+        $select->resetWhere();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('x = :status', array('status' => 'CLOBBERED'));
+    }
+
+    /**
+     *
+     * The message has to name a part of the query the reader can find. A
+     * sub-select's internal WHERE is not one: the outer query never had a
+     * WHERE clause to look at.
+     *
+     */
+    public function testSubSelectCollisionNamesTheOuterClause()
+    {
+        $subSelect = $this->query_factory->newSelect();
+        $subSelect->cols(array('id'))->from('u')->where('s = :s', array('s' => 'a'));
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->fromSubSelect($subSelect, 'sub');
+
+        try {
+            $select->where('s = :s', array('s' => 'b'));
+            $this->fail('Expected a collision on the :s placeholder.');
+        } catch (Exception\LogicException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('sub-select', $message);
+            $this->assertStringNotContainsString('already in use by a WHERE condition', $message);
+        }
+    }
+
     public function testSameSourceDifferentValueCollides()
     {
         $select = $this->query_factory->newSelect();
@@ -635,6 +717,10 @@ class CollisionTest extends TestCase
             $message = $e->getMessage();
             $this->assertStringContainsString('positional placeholder 1', $message);
             $this->assertStringNotContainsString("':1'", $message);
+
+            // "use a different placeholder" is not something the caller can
+            // do with `?`, whose number is its offset in the values array
+            $this->assertStringContainsString('names instead', $message);
         }
     }
 

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -614,6 +614,30 @@ class CollisionTest extends TestCase
         $select->where('id = ?', array(1 => 6));
     }
 
+    /**
+     *
+     * The message has to describe the query the reader is looking at. A
+     * positional placeholder keeps its `?` in the statement, so quoting it as
+     * ':1' would name a token that is not there.
+     *
+     */
+    public function testCollisionMessageDoesNotNameAPositionalPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = ?');
+        $select->bindValue(1, 5);
+        $select->union()->cols(array('*'))->from('b');
+
+        try {
+            $select->where('id = ?', array(1 => 6));
+            $this->fail('Expected a collision on the positional placeholder.');
+        } catch (Exception\LogicException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('positional placeholder 1', $message);
+            $this->assertStringNotContainsString("':1'", $message);
+        }
+    }
+
     public function testHandBoundPlaceholderOfARenderedBranchMayBeSharedOnTheSameValue()
     {
         $select = $this->query_factory->newSelect();

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -418,6 +418,182 @@ class CollisionTest extends TestCase
      * has nothing to bind.
      *
      */
+    /**
+     *
+     * union() renders the current branch to SQL and retains it, placeholders
+     * and all, so that SQL goes on binding the names it was rendered with. A
+     * later branch reusing one of them for a different value overwrites the
+     * value the rendered branch needs, and the first half of the union then
+     * runs with the second half's data. The names stay claimed across the
+     * reset precisely so this is caught.
+     *
+     */
+    public function testUnionBranchesCannotShareAPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id', array('id' => 1))
+               ->union()
+               ->cols(array('*'))->from('b');
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = :id', array('id' => 2));
+    }
+
+    public function testUnionAllBranchesCannotShareAPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id', array('id' => 1))
+               ->unionAll()
+               ->cols(array('*'))->from('b');
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = :id', array('id' => 2));
+    }
+
+    /**
+     *
+     * The message must name the union rather than the clause the placeholder
+     * was bound in: the clause has been reset and rebuilt, and pointing at it
+     * would send the reader looking at the branch they are writing now.
+     *
+     */
+    public function testUnionCollisionMessageNamesTheRenderedBranch()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id', array('id' => 1))
+               ->union()
+               ->cols(array('*'))->from('b');
+
+        try {
+            $select->where('id = :id', array('id' => 2));
+            $this->fail('Expected the shared placeholder to be rejected.');
+        } catch (Exception\LogicException $e) {
+            $this->assertStringContainsString("':id'", $e->getMessage());
+            $this->assertStringContainsString('UNION branch', $e->getMessage());
+        }
+    }
+
+    /**
+     *
+     * A clause reset frees the names that clause claimed, so the ownership a
+     * rendered branch keeps has to sit with the union instead: left with the
+     * clause, a resetWhere() in the next branch would hand back a name the
+     * retained SQL still binds, and the overwrite goes undetected again.
+     *
+     */
+    public function testResetWhereCannotFreeARenderedBranchesPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id', array('id' => 1))
+               ->union()
+               ->cols(array('*'))->from('b')
+               ->resetWhere();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = :id', array('id' => 2));
+    }
+
+    public function testResetHavingCannotFreeARenderedBranchesPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->having('id = :id', array('id' => 1))
+               ->union()
+               ->cols(array('*'))->from('b')
+               ->resetHaving();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->having('id = :id', array('id' => 2));
+    }
+
+    public function testResetTablesCannotFreeARenderedBranchesPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')
+               ->join('LEFT', 'j', 'j.id = a.id AND j.status = :id', array('id' => 1))
+               ->union()
+               ->cols(array('*'))->from('b')
+               ->resetTables();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->from('c')->join('LEFT', 'k', 'k.status = :id', array('id' => 2));
+    }
+
+    /**
+     *
+     * Both branches filtering on one value -- the same tenant either side of
+     * the union -- ask for exactly what is already bound. Nothing is lost, so
+     * nothing is wrong: rejecting it would break working queries.
+     *
+     */
+    public function testUnionBranchesMayShareAPlaceholderOnTheSameValue()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->from('b')->where('tenant = :t', array('t' => 5));
+
+        $statement = $select->getStatement();
+        $this->assertSame(2, substr_count($statement, ':t'));
+        $this->assertSame(array('t' => 5), $select->getBindValues());
+    }
+
+    /**
+     *
+     * Sharing the name on an equal value must not move ownership to the new
+     * clause: if it did, resetting that clause would free a name the rendered
+     * branch still binds.
+     *
+     */
+    public function testSharingOnTheSameValueLeavesOwnershipWithTheUnion()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->from('b')->where('tenant = :t', array('t' => 5))
+               ->resetWhere();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('tenant = :t', array('t' => 6));
+    }
+
+    /**
+     *
+     * resetUnions() throws away the rendered SQL, and with it the only reason
+     * those placeholders were held: nothing binds them any more, so the names
+     * are free again.
+     *
+     */
+    public function testResetUnionsReleasesTheRenderedPlaceholders()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id', array('id' => 1))
+               ->union()
+               ->cols(array('*'))->from('b');
+
+        $select->resetUnions();
+
+        $select->where('id = :id', array('id' => 2));
+        $this->assertSame(array('id' => 2), $select->getBindValues());
+    }
+
+    /**
+     *
+     * Binding by hand stays the escape hatch it is everywhere else: a null
+     * source overwrites the value without the union's claim standing in the
+     * way.
+     *
+     */
+    public function testHandBindStillOverwritesARenderedBranchesValue()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id', array('id' => 1))
+               ->union()
+               ->cols(array('*'))->from('b');
+
+        $select->bindValue('id', 9);
+        $this->assertSame(array('id' => 9), $select->getBindValues());
+    }
+
     public function testUnionKeepsTheValuesOfEveryHalf()
     {
         $select = $this->query_factory->newSelect();

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -411,15 +411,6 @@ class CollisionTest extends TestCase
 
     /**
      *
-     * union() builds the current half into SQL and then resets, so every
-     * value bound so far must still be there to bind against the retained
-     * statement. Clearing bind values on reset breaks this, and only the
-     * integration suite catches it -- the statement is well-formed, PDO just
-     * has nothing to bind.
-     *
-     */
-    /**
-     *
      * union() renders the current branch to SQL and retains it, placeholders
      * and all, so that SQL goes on binding the names it was rendered with. A
      * later branch reusing one of them for a different value overwrites the
@@ -578,6 +569,36 @@ class CollisionTest extends TestCase
 
     /**
      *
+     * A hand-bound value has no claimant, which is what lets it overwrite --
+     * but the rendered branch can be written around it all the same, with the
+     * condition naming :id and bindValue() supplying the value. The retained
+     * SQL binds that name as surely as any other, so the union takes it over
+     * too and a later clause cannot rebind it to something else.
+     *
+     */
+    public function testHandBoundPlaceholderOfARenderedBranchIsHeld()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id');
+        $select->bindValue('id', 1);
+        $select->union()->cols(array('*'))->from('b');
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = :id', array('id' => 2));
+    }
+
+    public function testHandBoundPlaceholderOfARenderedBranchMayBeSharedOnTheSameValue()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t');
+        $select->bindValue('t', 5);
+        $select->union()->cols(array('*'))->from('b')->where('tenant = :t', array('t' => 5));
+
+        $this->assertSame(array('t' => 5), $select->getBindValues());
+    }
+
+    /**
+     *
      * Binding by hand stays the escape hatch it is everywhere else: a null
      * source overwrites the value without the union's claim standing in the
      * way.
@@ -716,6 +737,15 @@ class CollisionTest extends TestCase
         $this->assertSame(array('t' => 6), $select->getBindValues());
     }
 
+    /**
+     *
+     * union() builds the current half into SQL and then resets, so every
+     * value bound so far must still be there to bind against the retained
+     * statement. Clearing bind values on reset breaks this, and only the
+     * integration suite catches it -- the statement is well-formed, PDO just
+     * has nothing to bind.
+     *
+     */
     public function testUnionKeepsTheValuesOfEveryHalf()
     {
         $select = $this->query_factory->newSelect();

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -424,6 +424,30 @@ class CollisionTest extends TestCase
 
     /**
      *
+     * A LATERAL JOIN sub-select is joined, not selected from, so it must say
+     * so: resetTables() releases either way, but the message is the only
+     * thing telling the reader which part of the query to go and look at.
+     *
+     */
+    public function testLateralJoinSubSelectIsNamedAsAJoin()
+    {
+        $subSelect = $this->newFactory('pgsql')->newSelect();
+        $subSelect->cols(array('id'))->from('u')->where('s = :s', array('s' => 'a'));
+
+        $select = $this->newFactory('pgsql')->newSelect();
+        $select->cols(array('*'))->from('t')
+               ->lateralJoinSubSelect('INNER', $subSelect, 'sub', 'sub.id = t.id');
+
+        try {
+            $select->where('s = :s', array('s' => 'b'));
+            $this->fail('Expected a collision on the :s placeholder.');
+        } catch (Exception\LogicException $e) {
+            $this->assertStringContainsString('JOIN', $e->getMessage());
+        }
+    }
+
+    /**
+     *
      * The message has to name a part of the query the reader can find. A
      * sub-select's internal WHERE is not one: the outer query never had a
      * WHERE clause to look at.

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -587,6 +587,33 @@ class CollisionTest extends TestCase
         $select->where('id = :id', array('id' => 2));
     }
 
+    /**
+     *
+     * The union holds every name bound when the branch was rendered, not the
+     * subset its SQL spells out as ':name'. A positional placeholder is the
+     * case that shows why: the retained SQL keeps the '?' token and the value
+     * is keyed by number, so reading the SQL back cannot recover the name.
+     *
+     * Narrowing the claim to the names a branch visibly mentions looks like a
+     * tidy-up and passes every other test in this file. It frees this one,
+     * and the first branch then runs on the second branch's value with
+     * nothing raised. That is what this test is here to stop.
+     *
+     */
+    public function testPositionalPlaceholderOfARenderedBranchIsHeld()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = ?');
+        $select->bindValue(1, 5);
+        $select->union()->cols(array('*'))->from('b');
+
+        // the retained branch spells no name to scan for
+        $this->assertStringContainsString('id = ?', $select->getStatement());
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = ?', array(1 => 6));
+    }
+
     public function testHandBoundPlaceholderOfARenderedBranchMayBeSharedOnTheSameValue()
     {
         $select = $this->query_factory->newSelect();

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -146,6 +146,39 @@ class CollisionTest extends TestCase
         $this->assertSame(array('status' => 'second'), $update->getBindValues());
     }
 
+    /**
+     *
+     * A second part of the query binding the *same* value is allowed through,
+     * but it must not take ownership of the name. If it did, the original
+     * claimant revising its own placeholder afterwards would look like a
+     * collision with the part that only ever agreed with it.
+     *
+     */
+    public function testAgreeingOnAValueDoesNotTransferOwnership()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('orders')->cols(array('status' => 'first'));
+
+        // same value from a different part: no collision, and cols() keeps
+        // the name
+        $update->where('status = :status', array('status' => 'first'));
+
+        // so cols() may still revise its own placeholder
+        $update->cols(array('status' => 'second'));
+        $this->assertSame(array('status' => 'second'), $update->getBindValues());
+    }
+
+    public function testAgreeingOnAValueStillGuardsTheOriginalOwner()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('orders')->cols(array('status' => 'first'));
+        $update->where('status = :status', array('status' => 'first'));
+
+        // the condition disagreeing later is still a real collision
+        $this->expectException(Exception\LogicException::class);
+        $update->where('status = :status', array('status' => 'third'));
+    }
+
     public function testBulkInsertDoesNotCollideWithItself()
     {
         $insert = $this->query_factory->newInsert();

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -68,15 +68,20 @@ class CollisionTest extends TestCase
         $update->where('id = :id', array('id' => 2));
     }
 
-    public function testSameValueFromTwoSourcesDoesNotCollide()
+    /**
+     *
+     * Agreeing on the value today is not a reason to share the name: either
+     * part may revise its value afterwards, and nothing re-checks the pair.
+     * Sharing is rejected when it appears, not when it starts to hurt.
+     *
+     */
+    public function testSameValueFromTwoSourcesStillCollides()
     {
         $update = $this->query_factory->newUpdate();
-        $update
-            ->table('t1')
-            ->cols(array('id' => 1))
-            ->where('id = :id', array('id' => 1));
+        $update->table('t1')->cols(array('id' => 1));
 
-        $this->assertSame(array('id' => 1), $update->getBindValues());
+        $this->expectException(Exception\LogicException::class);
+        $update->where('id = :id', array('id' => 1));
     }
 
     public function testRebindingByHandIsAllowed()
@@ -148,35 +153,29 @@ class CollisionTest extends TestCase
 
     /**
      *
-     * A second part of the query binding the *same* value is allowed through,
-     * but it must not take ownership of the name. If it did, the original
-     * claimant revising its own placeholder afterwards would look like a
-     * collision with the part that only ever agreed with it.
+     * The sequence that made sharing on an equal value unsafe: the two parts
+     * agree, then one of them revises its value, and the pair silently
+     * disagrees with nothing left to catch it. Rejecting the share up front
+     * removes the sequence entirely.
      *
      */
-    public function testAgreeingOnAValueDoesNotTransferOwnership()
+    public function testAgreeThenDivergeCannotHappen()
     {
         $update = $this->query_factory->newUpdate();
         $update->table('orders')->cols(array('status' => 'first'));
 
-        // same value from a different part: no collision, and cols() keeps
-        // the name
-        $update->where('status = :status', array('status' => 'first'));
-
-        // so cols() may still revise its own placeholder
-        $update->cols(array('status' => 'second'));
-        $this->assertSame(array('status' => 'second'), $update->getBindValues());
-    }
-
-    public function testAgreeingOnAValueStillGuardsTheOriginalOwner()
-    {
-        $update = $this->query_factory->newUpdate();
-        $update->table('orders')->cols(array('status' => 'first'));
-        $update->where('status = :status', array('status' => 'first'));
-
-        // the condition disagreeing later is still a real collision
-        $this->expectException(Exception\LogicException::class);
-        $update->where('status = :status', array('status' => 'third'));
+        try {
+            $update->where('status = :status', array('status' => 'first'));
+            $this->fail('Expected the shared placeholder to be rejected.');
+        } catch (Exception\LogicException $e) {
+            // the condition never took the name, so cols() still owns it and
+            // may revise its own value
+            $update->cols(array('status' => 'second'));
+            $this->assertSame(
+                array('status' => 'second'),
+                $update->getBindValues()
+            );
+        }
     }
 
     public function testBulkInsertDoesNotCollideWithItself()

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -1,0 +1,221 @@
+<?php
+namespace Aura\SqlQuery;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ *
+ * Two different parts of one query must never claim the same placeholder
+ * name: only one value survives the flat bind array, so the other is
+ * silently discarded and the statement runs with the wrong data. See #238.
+ *
+ */
+class CollisionTest extends TestCase
+{
+    protected $query_factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->query_factory = new QueryFactory('common');
+    }
+
+    protected function newFactory($db_type)
+    {
+        return new QueryFactory($db_type);
+    }
+
+    public function testColsAndWhereCollide()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('t1')->cols(array('id' => 1));
+
+        $this->expectException(Exception\LogicException::class);
+        $update->where('id = :id', array('id' => 2));
+    }
+
+    public function testDoUpdateColCollidesWithCols()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert
+            ->into('t1')
+            ->cols(array('status__on_conflict' => 'from cols'))
+            ->onConflict('id');
+
+        $this->expectException(Exception\LogicException::class);
+        $insert->doUpdateCol('status', 'from do update');
+    }
+
+    public function testOnDuplicateKeyUpdateColCollidesWithCols()
+    {
+        $insert = $this->newFactory('mysql')->newInsert();
+        $insert
+            ->into('t1')
+            ->cols(array('status__on_duplicate_key' => 'from cols'));
+
+        $this->expectException(Exception\LogicException::class);
+        $insert->onDuplicateKeyUpdateCol('status', 'from on duplicate key');
+    }
+
+    public function testCollisionMessageNamesBothSources()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('t1')->cols(array('id' => 1));
+
+        $this->expectException(Exception\LogicException::class);
+        $this->expectExceptionMessage("':id'");
+        $this->expectExceptionMessage('cols()');
+        $update->where('id = :id', array('id' => 2));
+    }
+
+    public function testSameValueFromTwoSourcesDoesNotCollide()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update
+            ->table('t1')
+            ->cols(array('id' => 1))
+            ->where('id = :id', array('id' => 1));
+
+        $this->assertSame(array('id' => 1), $update->getBindValues());
+    }
+
+    public function testRebindingByHandIsAllowed()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('t1')->where('id = :id', array('id' => 1));
+
+        // changing the value before execution is legitimate
+        $select->bindValue('id', 2);
+        $this->assertSame(array('id' => 2), $select->getBindValues());
+
+        // and so is reusing the query object with a fresh set of values
+        $select->bindValues(array('id' => 3));
+        $this->assertSame(array('id' => 3), $select->getBindValues());
+    }
+
+    /**
+     *
+     * Binding by hand overwrites the value but must not take ownership of the
+     * name. If it did, a hand bind sitting between cols() and where() would
+     * erase the record of which part claimed the placeholder first, and the
+     * collision would go undetected again.
+     *
+     */
+    public function testHandBindDoesNotLaunderTheSource()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('orders')->cols(array('status' => 'shipped'));
+        $update->bindValue('status', 'delivered');
+
+        $this->expectException(Exception\LogicException::class);
+        $update->where('status = :status', array('status' => 'pending'));
+    }
+
+    public function testHandBindStillOverwritesTheValue()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('orders')->cols(array('status' => 'shipped'));
+        $update->bindValue('status', 'delivered');
+
+        $this->assertSame(array('status' => 'delivered'), $update->getBindValues());
+    }
+
+    public function testHandBoundValueMayBeClaimedByCols()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('t1')->bindValue('id', 1);
+
+        // a null source never blocks a later bind
+        $update->cols(array('id' => 2));
+        $this->assertSame(array('id' => 2), $update->getBindValues());
+    }
+
+    /**
+     *
+     * The docs promise the builder methods "may be called multiple times", so
+     * one part of the query revising its own placeholder is not a collision.
+     * Only two *different* parts claiming one name is.
+     *
+     */
+    public function testOnePartMayRebindItsOwnPlaceholder()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('orders')->cols(array('status' => 'first'));
+        $update->cols(array('status' => 'second'));
+
+        $this->assertSame(array('status' => 'second'), $update->getBindValues());
+    }
+
+    public function testBulkInsertDoesNotCollideWithItself()
+    {
+        $insert = $this->query_factory->newInsert();
+        $insert
+            ->into('t1')
+            ->cols(array('c1' => 'v1-0'))
+            ->addRow(array('c1' => 'v1-1'))
+            ->addRow(array('c1' => 'v1-2'));
+
+        $expect = array('c1_0' => 'v1-0', 'c1_1' => 'v1-1', 'c1_2' => 'v1-2');
+        $insert->getStatement();
+        $this->assertSame($expect, $insert->getBindValues());
+    }
+
+    /**
+     *
+     * finishRow() empties $bind_values once a row is banked. If the source
+     * map is not emptied with it, the stale entry makes a later bind of the
+     * same name look like a collision when the value it would have clobbered
+     * is already safely stored under its row-numbered name.
+     *
+     */
+    public function testFinishedRowDoesNotLeaveAStaleSource()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert
+            ->into('t1')
+            ->cols(array('status__on_conflict' => 'banked into the row'))
+            ->addRow();
+
+        // the name is free again, so this is not a collision
+        $insert->onConflict('id')->doUpdateCol('status', 'from do update');
+
+        $bind_values = $insert->getBindValues();
+        $this->assertSame('banked into the row', $bind_values['status__on_conflict_0']);
+        $this->assertSame('from do update', $bind_values['status__on_conflict']);
+    }
+
+    /**
+     *
+     * Belt and braces for the check itself: a source recorded for a name that
+     * has no value cannot be a collision, because there is no value left to
+     * discard. finishRow() and resetBindValues() both keep the two arrays in
+     * step, so this state should never arise -- but if it ever did, reading
+     * the missing value would raise an undefined-key warning and then throw a
+     * collision that is not real.
+     *
+     */
+    public function testSourceWithoutAValueIsNotACollision()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('t1')->cols(array('id' => 1));
+
+        // force the desync the guard exists for
+        $property = new \ReflectionProperty($update, 'bind_values');
+        $property->setAccessible(true);
+        $property->setValue($update, array());
+
+        $update->where('id = :id', array('id' => 2));
+        $this->assertSame(array('id' => 2), $update->getBindValues());
+    }
+
+    public function testResetBindValuesClearsTheSources()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('t1')->cols(array('id' => 1));
+        $update->resetBindValues();
+
+        // with the source forgotten there is nothing left to collide with
+        $update->where('id = :id', array('id' => 2));
+        $this->assertSame(array('id' => 2), $update->getBindValues());
+    }
+}

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -57,15 +57,29 @@ class CollisionTest extends TestCase
         $insert->onDuplicateKeyUpdateCol('status', 'from on duplicate key');
     }
 
+    /**
+     *
+     * The message has to name the placeholder and both parts fighting over
+     * it, or it does not say enough to act on. Asserted through a catch
+     * rather than expectExceptionMessage(), which replaces its expectation
+     * on each call instead of accumulating -- so consecutive calls would
+     * check only the last string and quietly drop the rest.
+     *
+     */
     public function testCollisionMessageNamesBothSources()
     {
         $update = $this->query_factory->newUpdate();
         $update->table('t1')->cols(array('id' => 1));
 
-        $this->expectException(Exception\LogicException::class);
-        $this->expectExceptionMessage("':id'");
-        $this->expectExceptionMessage('cols()');
-        $update->where('id = :id', array('id' => 2));
+        try {
+            $update->where('id = :id', array('id' => 2));
+            $this->fail('Expected a collision on the :id placeholder.');
+        } catch (Exception\LogicException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString("':id'", $message);
+            $this->assertStringContainsString('cols()', $message);
+            $this->assertStringContainsString('WHERE condition', $message);
+        }
     }
 
     /**
@@ -82,6 +96,32 @@ class CollisionTest extends TestCase
 
         $this->expectException(Exception\LogicException::class);
         $update->where('id = :id', array('id' => 1));
+    }
+
+    /**
+     *
+     * Two separate where() calls are two separate parts of the query, even
+     * though they land in the same clause: neither is revising the other's
+     * value, so sharing a name loses one of them. Conditions carry the
+     * clause as their source precisely so this is caught.
+     *
+     */
+    public function testTwoConditionsCannotShareAPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('t1')->where('a = :id', array('id' => 1));
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('b = :id', array('id' => 2));
+    }
+
+    public function testWhereAndHavingCannotShareAPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('a'))->from('t1')->where('a = :x', array('x' => 1));
+
+        $this->expectException(Exception\LogicException::class);
+        $select->having('b = :x', array('x' => 2));
     }
 
     public function testRebindingByHandIsAllowed()
@@ -249,5 +289,113 @@ class CollisionTest extends TestCase
         // with the source forgotten there is nothing left to collide with
         $update->where('id = :id', array('id' => 2));
         $this->assertSame(array('id' => 2), $update->getBindValues());
+    }
+
+    public function testClosureBindsDoNotBypassCollision()
+    {
+        $update = $this->query_factory->newUpdate();
+        $update->table('orders')->cols(array('status' => 'shipped'));
+
+        $this->expectException(Exception\LogicException::class);
+        $update->where(function($query) {}, array('status' => 'pending'));
+    }
+
+    public function testSubselectBindsDoNotBypassCollision()
+    {
+        $subSelect = $this->query_factory->newSelect();
+        $subSelect->cols(array('id'))->from('users')->where('status = :status', array('status' => 'active'));
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('orders')
+               ->where('status = :status', array('status' => 'pending'));
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('user_id IN (:sub)', array('sub' => $subSelect));
+    }
+
+    public function testFromSubSelectBindsDoNotBypassCollision()
+    {
+        $subSelect = $this->query_factory->newSelect();
+        $subSelect->cols(array('id'))->from('users')->where('status = :status', array('status' => 'active'));
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))
+               ->fromSubSelect($subSelect, 'sub');
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('status = :status', array('status' => 'pending'));
+    }
+
+    public function testSameSourceDifferentValueCollides()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('orders')
+               ->where('status = :status', array('status' => 'pending'));
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('status = :status', array('status' => 'active'));
+    }
+
+    /**
+     *
+     * Resetting a clause frees the names it claimed, so the same placeholder
+     * may be used again afterwards. The *values* deliberately survive the
+     * reset, as they always have: union() renders the current half to SQL --
+     * placeholders and all -- and then resets, so dropping them would leave
+     * that SQL with tokens nothing can bind.
+     *
+     */
+    public function testResetWhereFreesItsPlaceholderNames()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('orders')
+               ->where('status = :status', array('status' => 'pending'));
+
+        $select->resetWhere();
+
+        // no collision, because the WHERE clause no longer claims the name
+        $select->where('status = :status', array('status' => 'active'));
+        $this->assertSame(array('status' => 'active'), $select->getBindValues());
+    }
+
+    public function testResetHavingFreesItsPlaceholderNames()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('orders')
+               ->having('status = :status', array('status' => 'pending'));
+
+        $select->resetHaving();
+
+        $select->having('status = :status', array('status' => 'active'));
+        $this->assertSame(array('status' => 'active'), $select->getBindValues());
+    }
+
+    /**
+     *
+     * union() builds the current half into SQL and then resets, so every
+     * value bound so far must still be there to bind against the retained
+     * statement. Clearing bind values on reset breaks this, and only the
+     * integration suite catches it -- the statement is well-formed, PDO just
+     * has nothing to bind.
+     *
+     */
+    public function testUnionKeepsTheValuesOfEveryHalf()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('orders')
+               ->where('status = :first', array('first' => 'pending'))
+               ->union()
+               ->cols(array('*'))->from('orders')
+               ->where('status = :second', array('second' => 'shipped'));
+
+        $statement = $select->getStatement();
+        $bind_values = $select->getBindValues();
+
+        $this->assertStringContainsString(':first', $statement);
+        $this->assertStringContainsString(':second', $statement);
+        $this->assertSame(
+            array('first' => 'pending', 'second' => 'shipped'),
+            $bind_values
+        );
     }
 }

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -124,6 +124,45 @@ class CollisionTest extends TestCase
         $select->having('b = :x', array('x' => 2));
     }
 
+    public function testJoinAndWhereCannotShareAPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select
+            ->cols(array('a'))
+            ->from('t1')
+            ->join('LEFT', 't2', 't2.id = t1.id AND t2.status = :x', array('x' => 1));
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('b = :x', array('x' => 2));
+    }
+
+    public function testTwoJoinConditionsCannotShareAPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select
+            ->cols(array('a'))
+            ->from('t1')
+            ->join('LEFT', 't2', 't2.status = :x', array('x' => 1));
+
+        $this->expectException(Exception\LogicException::class);
+        $select->join('LEFT', 't3', 't3.status = :x', array('x' => 2));
+    }
+
+    public function testJoinSubSelectConditionCannotShareAPlaceholder()
+    {
+        $subSelect = $this->query_factory->newSelect();
+        $subSelect->cols(array('id'))->from('users');
+
+        $select = $this->query_factory->newSelect();
+        $select
+            ->cols(array('a'))
+            ->from('t1')
+            ->where('b = :x', array('x' => 1));
+
+        $this->expectException(Exception\LogicException::class);
+        $select->joinSubSelect('LEFT', $subSelect, 'sub', 'sub.status = :x', array('x' => 2));
+    }
+
     public function testRebindingByHandIsAllowed()
     {
         $select = $this->query_factory->newSelect();

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -599,6 +599,49 @@ class CollisionTest extends TestCase
 
     /**
      *
+     * A name that starts with no claimant can acquire one. Hand-bound, then
+     * taken over by the union at render time, then shared by the next
+     * branch's WHERE: resetUnions() hands it to that WHERE, which is still in
+     * the query and still binding it, so a second clause rebinding it is the
+     * ordinary clash. Being hand-bound to begin with does not exempt it --
+     * only bindValue() itself keeps that privilege.
+     *
+     */
+    public function testAHandBoundNameSharedByALiveClauseBecomesItsToHold()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id');
+        $select->bindValue('id', 1);
+        $select->union()->cols(array('*'))->from('b')->where('id = :id', array('id' => 1));
+        $select->resetUnions();
+
+        // the sharing WHERE outlives the union it was sharing with
+        $this->assertStringContainsString('id = :id', $select->getStatement());
+
+        $this->expectException(Exception\LogicException::class);
+        $select->having('x = :id', array('id' => 2));
+    }
+
+    /**
+     *
+     * The same name with no live claimant is free after resetUnions(), so the
+     * handover cannot be blaming the union for a hold nothing needs.
+     *
+     */
+    public function testAHandBoundNameNoClauseSharesIsFreeAfterResetUnions()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('id = :id');
+        $select->bindValue('id', 1);
+        $select->union()->cols(array('*'))->from('b');
+        $select->resetUnions();
+
+        $select->having('x = :id', array('id' => 2));
+        $this->assertSame(array('id' => 2), $select->getBindValues());
+    }
+
+    /**
+     *
      * Binding by hand stays the escape hatch it is everywhere else: a null
      * source overwrites the value without the union's claim standing in the
      * way.

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -517,6 +517,38 @@ class CollisionTest extends TestCase
 
     /**
      *
+     * A clause reset frees the name but keeps the value, so a name reset
+     * before the union is bound without appearing anywhere in the rendered
+     * branch. Nothing in that SQL can bind it, so the union has no claim to
+     * stake, and the next branch must be free to use the name for its own
+     * value.
+     *
+     */
+    public function testANameResetBeforeTheUnionIsFreeInTheNextBranch()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')
+               ->where('id = :id', array('id' => 1));
+
+        $select->resetWhere();
+        $select->where('status = :status', array('status' => 'pending'));
+        $select->union()->cols(array('*'))->from('b');
+
+        // the rendered branch spells :status, but never :id
+        $statement = $select->getStatement();
+        $this->assertStringContainsString('status = :status', $statement);
+        $this->assertStringNotContainsString(':id', $statement);
+
+        // so the next branch may claim :id for a value of its own
+        $select->where('id = :id', array('id' => 2));
+        $this->assertSame(
+            array('id' => 2, 'status' => 'pending'),
+            $select->getBindValues()
+        );
+    }
+
+    /**
+     *
      * union() renders the current branch to SQL and retains it, placeholders
      * and all, so that SQL goes on binding the names it was rendered with. A
      * later branch reusing one of them for a different value overwrites the

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -594,6 +594,128 @@ class CollisionTest extends TestCase
         $this->assertSame(array('id' => 9), $select->getBindValues());
     }
 
+    /**
+     *
+     * Sharing on an equal value leaves the name with the union, so the active
+     * branch's own condition is never recorded as a claimant. resetUnions()
+     * then frees the name while that condition is still in the query.
+     *
+     */
+    public function testResetUnionsCannotFreeANameTheActiveBranchStillUses()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->from('b')->where('tenant = :t', array('t' => 5))
+               ->resetUnions();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('other = :t', array('t' => 6));
+    }
+
+    /**
+     *
+     * Sharing a union's name is one clause's privilege: two different clauses
+     * of the active branch asking for it are the ordinary cross-clause clash,
+     * since either may revise its value afterwards.
+     *
+     */
+    public function testTwoClausesCannotBothShareARenderedBranchesPlaceholder()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->from('b')->where('tenant = :t', array('t' => 5));
+
+        $this->expectException(Exception\LogicException::class);
+        $select->having('tenant = :t', array('t' => 5));
+    }
+
+    /**
+     *
+     * Once resetUnions() has handed the name to the clause that was sharing
+     * it, resetting that clause frees it for real: nothing binds it any more.
+     *
+     */
+    public function testResetUnionsThenResettingTheSharingClauseFreesTheName()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->from('b')->where('tenant = :t', array('t' => 5))
+               ->resetUnions()
+               ->resetWhere();
+
+        $select->where('other = :t', array('t' => 6));
+        $this->assertSame(array('t' => 6), $select->getBindValues());
+    }
+
+    /**
+     *
+     * A clause that has been reset is no longer using the name it shared, so
+     * a later resetUnions() must not hand the name back to it -- that would
+     * refuse a placeholder nothing in the query binds.
+     *
+     */
+    public function testResettingTheSharingClauseFirstStillFreesTheName()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->from('b')->where('tenant = :t', array('t' => 5))
+               ->resetWhere()
+               ->resetUnions();
+
+        $select->where('other = :t', array('t' => 6));
+        $this->assertSame(array('t' => 6), $select->getBindValues());
+    }
+
+    /**
+     *
+     * A sharing clause that has itself been rendered into a union branch is
+     * no longer a live claimant: resetUnions() throws away that SQL too, so
+     * the name is free rather than owed back to the clause.
+     *
+     */
+    public function testASharingClauseRenderedIntoItsOwnBranchDoesNotHoldTheName()
+    {
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->from('b')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->from('c')
+               ->resetUnions();
+
+        $select->where('other = :t', array('t' => 6));
+        $this->assertSame(array('t' => 6), $select->getBindValues());
+    }
+
+    /**
+     *
+     * Same again for a sub-select's names, which no clause reset releases:
+     * once the branch holding the sub-select is rendered, resetUnions() must
+     * still free them.
+     *
+     */
+    public function testASharedSubSelectNameIsFreedAfterItsBranchIsRendered()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(array('*'))->from('s');
+        $sub->bindValue('t', 5);
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(array('*'))->from('a')->where('tenant = :t', array('t' => 5))
+               ->union()
+               ->cols(array('*'))->fromSubSelect($sub, 'x')
+               ->union()
+               ->cols(array('*'))->from('c')
+               ->resetUnions();
+
+        $select->where('other = :t', array('t' => 6));
+        $this->assertSame(array('t' => 6), $select->getBindValues());
+    }
+
     public function testUnionKeepsTheValuesOfEveryHalf()
     {
         $select = $this->query_factory->newSelect();

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -556,6 +556,47 @@ abstract class AbstractIntegrationTest extends TestCase
         $this->assertSame('anon', $sth->fetchColumn());
     }
 
+    /**
+     *
+     * "Set a column to a new value where it currently holds an old one" is the
+     * shape that used to collide: cols() and where() both wanted :name, one
+     * value was discarded, and the statement became a no-op that reported
+     * success. The builder now rejects it, and the documented fix -- binding
+     * the condition under its own name -- has to do the right thing against a
+     * real server. See #238.
+     *
+     */
+    public function testUpdateSetAndMatchTheSameColumn()
+    {
+        $collides = $this->query_factory->newUpdate()
+            ->table('test_employee')
+            ->cols(['name' => 'Annabel']);
+
+        try {
+            $collides->where('name = :name', ['name' => 'Anna']);
+            $this->fail('Expected a collision on the :name placeholder.');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            $this->assertStringContainsString(':name', $e->getMessage());
+        }
+
+        $update = $this->query_factory->newUpdate()
+            ->table('test_employee')
+            ->cols(['name' => 'Annabel'])
+            ->where('name = :old_name', ['old_name' => 'Anna']);
+
+        $this->assertSame(
+            ['name' => 'Annabel', 'old_name' => 'Anna'],
+            $update->getBindValues()
+        );
+
+        // exactly the one row matches, and it really is renamed
+        $this->assertSame(1, $this->exec($update));
+        $this->assertSame(
+            ['Annabel', 'Betty', 'Clara', 'Donna'],
+            $this->fetchNames()
+        );
+    }
+
     public function testUpdate()
     {
         $update = $this->query_factory->newUpdate()


### PR DESCRIPTION
Fixes #238.

Bound values live in one flat array keyed by placeholder name, so when two
parts of a query claim the same name, one value is silently discarded and the
statement executes with the wrong data. The case people actually hit is an
UPDATE whose condition tests a column the query also sets:

```php
$update->table('orders')
    ->cols(['status' => 'shipped'])
    ->where('status = :status', ['status' => 'pending']);
```

Before this change that rendered

```sql
UPDATE "orders" SET "status" = :status WHERE status = :status
```

with `getBindValues() === ['status' => 'pending']` — one placeholder, one
value. The UPDATE set the column to the value meant only to select rows: a
no-op that reported success. It now throws
`Aura\SqlQuery\Exception\LogicException` naming both sources.

This is the only query type that can hit it. INSERT has no `where()`, DELETE
has no `cols()`, and a SELECT `cols()` binds nothing.

## Approach

`bindValueFrom($name, $value, $source)` is `protected`, and the public
`bindValue()` / `bindValues()` signatures are **unchanged** — both are declared
in `QueryInterface`, so adding a parameter there would break every third-party
implementer. Sources are `'col'`, the clause a condition belongs to
(`'where'`, `'having'`, `'join'`, `'table'`, `'union'`), `'cond'` for a
condition with no clause of its own, `'conflict'`, `'duplicate_key'`, and
`null` for a hand bind. It throws when two *different non-null* sources claim
one name, whatever the values.

That keeps the legitimate patterns working: rebinding before execution,
reusing a query object with fresh values, and one part of the query revising
its own placeholder (the docs promise the builder methods "may be called
multiple times").

The same check covers `doUpdateCol()` and `onDuplicateKeyUpdateCol()`, whose
placeholders are derived by suffix. Those only collide when a column is
literally named `<col>__on_conflict` or `<col>__on_duplicate_key`, so the
ordinary upsert is unaffected — `cols(['name' => …])` binds `:name` while
`onDuplicateKeyUpdateCol('name', …)` binds `:name__on_duplicate_key`.

## Four further bugs found while building this

Each has a regression test:

1. **Ownership laundered by a hand bind.** A `bindValue()` between `cols()`
   and `where()` overwrote the source with `null`, so the later `where()` saw
   no prior owner and the original bug returned silently. A hand bind now
   overwrites the *value* without claiming the *name*.
2. **Sharing a name on an equal value.** A second source binding the *same*
   value used to be allowed through. @coderabbitai caught that it also took
   ownership on the way past, locking the original claimant out of its own
   placeholder; testing one step further showed the permission itself was
   unsound, since the two parts can diverge afterwards with nothing to
   re-check them — `cols('first')` → `where('first')` → `cols('second')`
   rebuilt the very no-op this PR exists to prevent. Two different parts may
   now never claim one name, whatever the values. That is a no-op query in
   any case: `SET status='pending' WHERE status='pending'`.
3. **Undefined-key read.** A source recorded for a name with no value raised a
   PHP warning and then threw a collision that was not real.
4. **Same-source rebinding.** `cols()` twice on one column would have thrown,
   contradicting the documented promise above.

Every guard is mutation-tested: removing any one of them makes a test fail
(throw disabled → 5 failures; hand-bind laundering → 1; equal-value
permission → 2; same-source → 1; existence guard → 1).

## Coverage

`tests/CollisionTest.php` covers all three collision cases plus the legitimate
patterns. The integration suite runs the realistic shape — set a column where
it currently holds an old value — against live MySQL, PostgreSQL and SQLite,
asserting the colliding form throws and the documented fix updates exactly one
row.

740 unit tests, 105 integration tests, 17 doc examples verified, PHPStan clean.

## Gaps closed since this description was written

Two *conditions* sharing a placeholder name, and a sub-select's own bind
values, were both listed here as untracked. Both are now covered: conditions
carry their clause as the source, and a sub-select's names are claimed by the
clause it is rendered into. The one path still open is bulk-insert
placeholders, filed as #241.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added placeholder-name collision detection across query parts, now throwing a `LogicException` instead of silently losing a value (breaking).
  * Manual `bindValue()`/`bindValues()` can overwrite values, but ownership/collision checks still apply for non-manual placeholder bindings.
  * Improved placeholder tracking through clause resets and UNION rendering, ensuring held names are released appropriately.
* **Documentation**
  * Documented placeholder-name collision rules, `UPDATE`/upsert reserved placeholders, and UNION branch placeholder locking.
* **Tests**
  * Added comprehensive collision test coverage (including UNION, closures, subselects, JOINs, and resets) and a new integration update collision regression test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

