### PR TITLE
Keep the upsert binds through a bulk insert row

### DIFF
--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -389,6 +389,13 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * Finishes off the current row in a bulk insert, collecting the bulk
      * values and resetting for the next row.
      *
+     * Only the names this row banked are cleared. Clearing the whole of
+     * bind_values would take the rest of the query's placeholders with it --
+     * the upsert values and their WHERE conditions, which belong to the
+     * statement as a whole rather than to any one row. build() finishes the
+     * last row, so those names would go missing from a statement that still
+     * spells them, and execute() would fail on the unbound placeholder.
+     *
      * @return null
      *
      */
@@ -399,12 +406,13 @@ class Insert extends AbstractDmlQuery implements InsertInterface
         }
 
         foreach ($this->col_order as $col) {
-            $this->finishCol($col);
+            $name = $this->finishCol($col);
+            if ($name !== null) {
+                unset($this->bind_values[$name], $this->bind_sources[$name]);
+            }
         }
 
         $this->col_values = array();
-        $this->bind_values = array();
-        $this->bind_sources = array();
     }
 
     /**
@@ -413,7 +421,8 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * @param string $col The column to finish off.
      *
-     * @return null
+     * @return string|null The placeholder name this row banked, which the
+     * caller clears; null for a raw value, which never had one.
      *
      * @throws InvalidArgumentException on named column missing from row.
      *
@@ -431,7 +440,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
         if (substr($value, 0, 1) != ':') {
             // copy the value as-is
             $this->col_values_bulk[$this->row][$col] = $value;
-            return;
+            return null;
         }
 
         // retain col_values in bulk with the row number appended
@@ -444,5 +453,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
         if (array_key_exists($name, $this->bind_values)) {
             $this->bind_values_bulk["{$name}_{$this->row}"] = $this->bind_values[$name];
         }
+
+        return $name;
     }
 }

--- a/tests/Integration/MysqlIntegrationTest.php
+++ b/tests/Integration/MysqlIntegrationTest.php
@@ -329,6 +329,35 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
         $this->assertSame('Updated', $sth->fetchColumn());
     }
 
+    /**
+     *
+     * A bulk insert whose rows collide with existing keys: the upsert value
+     * is bound once for the whole statement, not per row. Building the
+     * statement finishes the last row, and clearing that row used to take the
+     * upsert bind with it, leaving :name__on_duplicate_key unbound -- so this
+     * failed at execute() with HY093 rather than returning wrong data.
+     *
+     */
+    public function testBulkInsertOnDuplicateKeyUpdate()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Ignored One'])
+            ->addRow(['id' => 2, 'name' => 'Ignored Two'])
+            ->onDuplicateKeyUpdateCol('name', 'Bulk Updated');
+
+        $this->assertStatementContains('ON DUPLICATE KEY UPDATE', $insert);
+        $this->assertArrayHasKey('name__on_duplicate_key', $insert->getBindValues());
+
+        $this->exec($insert);
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept ORDER BY id');
+        $this->assertSame(
+            ['Bulk Updated', 'Bulk Updated'],
+            $sth->fetchAll(PDO::FETCH_COLUMN)
+        );
+    }
+
     public function testInsertOrReplace()
     {
         $insert = $this->query_factory->newInsert()

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -250,6 +250,39 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
     }
 
     /**
+     *
+     * A bulk insert whose rows collide with existing keys: the DO UPDATE
+     * value and its WHERE condition are bound once for the whole statement,
+     * not per row. Building the statement finishes the last row, and clearing
+     * that row used to take both binds with it, leaving :name__on_conflict
+     * and :min unbound -- so this failed at execute() with HY093 rather than
+     * returning wrong data.
+     *
+     */
+    public function testBulkInsertOnConflictDoUpdate()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'Ignored One'])
+            ->addRow(['id' => 2, 'name' => 'Ignored Two'])
+            ->onConflict('id')
+            ->doUpdateCol('name', 'Bulk Updated')
+            ->doUpdateWhere('test_dept.id < :max', ['max' => 100]);
+
+        $binds = $insert->getBindValues();
+        $this->assertArrayHasKey('name__on_conflict', $binds);
+        $this->assertArrayHasKey('max', $binds);
+
+        $this->assertSame(2, $this->exec($insert));
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept ORDER BY id');
+        $this->assertSame(
+            ['Bulk Updated', 'Bulk Updated'],
+            $sth->fetchAll(PDO::FETCH_COLUMN)
+        );
+    }
+
+    /**
      * The conflict target may name a constraint instead of its columns.
      */
     public function testInsertOnConflictConstraintTarget()

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -314,6 +314,41 @@ class InsertTest extends Common\InsertTest
         $this->assertSame($expect, $actual);
     }
 
+    /**
+     *
+     * A bulk insert renames each row's placeholders and banks them, then
+     * clears the working values ready for the next row. The ON DUPLICATE KEY
+     * UPDATE value is not one of those row values, and the statement goes on
+     * spelling its placeholder, so it has to survive that clearing: an
+     * unbound placeholder makes execute() fail with HY093.
+     *
+     */
+    public function testBulkInsertKeepsTheOnDuplicateKeyUpdateBind()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1' => 'v1-0'))
+                    ->addRow(array('c1' => 'v1-1'))
+                    ->onDuplicateKeyUpdateCol('c1', 'c1-updated');
+
+        $actual = $this->query->__toString();
+        $expect = '
+            INSERT INTO <<t1>>
+                (<<c1>>)
+            VALUES
+                (:c1_0),
+                (:c1_1) ON DUPLICATE KEY UPDATE
+                <<c1>> = :c1__on_duplicate_key
+        ';
+        $this->assertSameSql($expect, $actual);
+
+        $expect = array(
+            'c1__on_duplicate_key' => 'c1-updated',
+            'c1_0' => 'v1-0',
+            'c1_1' => 'v1-1',
+        );
+        $this->assertSame($expect, $this->query->getBindValues());
+    }
+
     public function testOnConflictNotSupported()
     {
         $this->expectException('Aura\SqlQuery\Exception\BadMethodCallException');

--- a/tests/Pgsql/InsertTest.php
+++ b/tests/Pgsql/InsertTest.php
@@ -183,6 +183,47 @@ class InsertTest extends Common\InsertTest
     }
 
     /**
+     *
+     * A bulk insert renames each row's placeholders and banks them, then
+     * clears the working values ready for the next row. Neither the DO UPDATE
+     * value nor its WHERE condition is a row value, and the statement goes on
+     * spelling both placeholders, so they have to survive that clearing: an
+     * unbound placeholder makes execute() fail with HY093.
+     *
+     */
+    public function testBulkInsertKeepsTheDoUpdateBinds()
+    {
+        $this->query->into('t1')
+                    ->cols(array('c1' => 'v1-0'))
+                    ->addRow(array('c1' => 'v1-1'))
+                    ->onConflict('c1')
+                    ->doUpdateCol('c2', 'c2-updated')
+                    ->doUpdateWhere('t1.c3 = :c3_old', array('c3_old' => 'bar'));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            INSERT INTO <<t1>>
+                (<<c1>>)
+            VALUES
+                (:c1_0),
+                (:c1_1)
+            ON CONFLICT (<<c1>>) DO UPDATE SET
+                <<c2>> = :c2__on_conflict
+            WHERE
+                <<t1>>.<<c3>> = :c3_old
+        ";
+        $this->assertSameSql($expect, $actual);
+
+        $expect = array(
+            'c2__on_conflict' => 'c2-updated',
+            'c3_old' => 'bar',
+            'c1_0' => 'v1-0',
+            'c1_1' => 'v1-1',
+        );
+        $this->assertSame($expect, $this->query->getBindValues());
+    }
+
+    /**
      * The constraint-name conflict target is Postgres-only.
      */
     public function testOnConflictConstraintTarget()


### PR DESCRIPTION
Part of #241 — the second symptom only, so please don't close #241 on merge.

`finishRow()` cleared `bind_values` wholesale, and `build()` calls it for the
last row, so a bulk insert dropped the upsert's own binds:

```php
$insert->into('t')->cols(['a' => 1])->addRow(['a' => 2])
       ->onDuplicateKeyUpdateCol('a', 3);
```

rendered `:a__on_duplicate_key` but bound only `a_0`/`a_1`, so `execute()`
failed with `HY093: Invalid parameter number`. Same for Pgsql
`doUpdateCol()` and `doUpdateWhere()` — bulk insert plus any upsert was broken.
Loud failure, not wrong data.

Fix: `finishCol()` returns the name it banked and `finishRow()` clears only
those, instead of emptying the array.

Unit tests for both dialects, plus integration tests running a colliding
two-row bulk upsert against live MySQL and PostgreSQL. Mutation-tested:
restoring the wholesale clear fails 2 unit tests and both integration tests;
never clearing the banked name fails 23. 742 unit, 107 integration, 17 doc
examples, PHPStan clean.

Still open in #241: the original report, bulk placeholders bypassing collision
tracking, which needs a parallel `$bind_sources_bulk`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed bulk insert statements so conflict-update values remain correctly bound across all inserted rows.
  - Improved handling of placeholder values during bulk inserts, preventing valid update parameters from being cleared.

- **Tests**
  - Added coverage for MySQL duplicate-key updates and PostgreSQL conflict updates.
  - Verified generated statements, retained parameters, conditional updates, and final database results for multi-row inserts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->