### PR TITLE
Track the placeholder names a bulk insert banks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,19 @@
   `DB_MYSQL_DSN` / `DB_PGSQL_DSN` / `DB_SQLSRV_DSN` are set; see
   CONTRIBUTING.md.
 
+- [BRK] The placeholder names a bulk insert generates are now tracked like
+  any others. Each row's placeholders are renamed `<name>_<row>`, and those
+  banked names were invisible to the collision check while still winning the
+  merge in getBindValues() -- so after
+  `cols(['status' => ...])->addRow([...])`, a condition binding `:status_0`
+  had its value silently replaced by row 0's, and the statement ran against
+  the wrong one. Either order now throws
+  Aura\SqlQuery\Exception\LogicException; bind the condition under a name no
+  row can generate. Columns of the row being built are exempt, since a column
+  named `a_1` alongside `a` is renamed out of the way before the merge.
+  Binding by hand with bindValue() is unaffected and now correctly overwrites
+  a row's value, where before the banked value won regardless. Fixes #241.
+
 - [FIX] A bulk insert combined with an upsert no longer loses the upsert's
   bound values. Finishing a row cleared every bound value, not just that
   row's, and building the statement finishes the last row -- so

--- a/docs/other.md
+++ b/docs/other.md
@@ -94,6 +94,34 @@ reserved, so do not bind them yourself. A column literally named
 `onDuplicateKeyUpdateCol('name', ...)`, and `name__on_conflict` collides with
 `doUpdateCol('name', ...)`. Both throw the same `LogicException`.
 
+### Bulk Insert Rows
+
+A bulk insert renames each row's placeholders, appending the row number: two
+rows of `cols(['status' => ...])` bind `:status_0` and `:status_1`. Those
+generated names are reserved in the same way, so binding one from another part
+of the query throws:
+
+```php
+$insert = $queryFactory->newInsert();
+
+try {
+    $insert
+        ->into('t')
+        ->cols(['status' => 'row0'])
+        ->addRow(['status' => 'row1'])
+        ->onConflict('id')
+        ->doUpdateCol('status')
+        ->doUpdateWhere('t.note = :status_0', ['status_0' => 'checked']);
+} catch (\Aura\SqlQuery\Exception\LogicException $e) {
+    // throws: The placeholder ':status_0' is already in use by a
+    // bulk-insert row...
+}
+```
+
+Name the condition's placeholder something a row cannot generate -- `:note` --
+and both values survive. As everywhere else, `bindValue()` may still overwrite
+a row's value by its generated name.
+
 ### UNION Branches
 
 `union()` and `unionAll()` build the branch so far into SQL and keep it, so

--- a/docs/other.md
+++ b/docs/other.md
@@ -102,7 +102,10 @@ generated names are reserved in the same way, so binding one from another part
 of the query throws:
 
 ```php
-$insert = $queryFactory->newInsert();
+// onConflict() is PostgreSQL and SQLite only, so this example needs one of
+// those factories rather than the shared one used elsewhere on this page
+$pgsqlFactory = new \Aura\SqlQuery\QueryFactory('pgsql');
+$insert = $pgsqlFactory->newInsert();
 
 try {
     $insert

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -69,6 +69,7 @@ abstract class AbstractQuery
         'union' => 'a rendered UNION branch',
         'conflict' => 'doUpdateCol()',
         'duplicate_key' => 'onDuplicateKeyUpdateCol()',
+        'bulk_col' => 'a bulk-insert row',
     );
 
     /**

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -80,6 +80,18 @@ class Insert extends AbstractDmlQuery implements InsertInterface
 
     /**
      *
+     * Which banked bulk names are taken, as `<name>_<row>` => 'bulk_col'.
+     * The banked values live outside `$bind_values` until getBindValues()
+     * merges them, so `$bind_sources` cannot record them and this stands in
+     * for it.
+     *
+     * @var array
+     *
+     */
+    protected $bind_sources_bulk = array();
+
+    /**
+     *
      * The order in which columns will be bulk-inserted; this is taken from the
      * very first inserted row.
      *
@@ -219,7 +231,23 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      */
     public function getBindValues()
     {
-        return array_merge(parent::getBindValues(), $this->bind_values_bulk);
+        $values = parent::getBindValues();
+
+        foreach ($this->bind_values_bulk as $name => $value) {
+            // a hand bind overwrites the value wherever it lands, as it does
+            // everywhere else, so it keeps the name against the banked value.
+            // Nothing else can be holding one: a sourced bind under a banked
+            // name throws, so an unclaimed name here was bound by hand.
+            if (
+                array_key_exists($name, $values)
+                && ! isset($this->bind_sources[$name])
+            ) {
+                continue;
+            }
+            $values[$name] = $value;
+        }
+
+        return $values;
     }
 
     /**
@@ -451,9 +479,55 @@ class Insert extends AbstractDmlQuery implements InsertInterface
 
         // retain bind_value in bulk with new placeholder
         if (array_key_exists($name, $this->bind_values)) {
-            $this->bind_values_bulk["{$name}_{$this->row}"] = $this->bind_values[$name];
+            $banked = "{$name}_{$this->row}";
+
+            // the generated name is a claim on the flat bind array like any
+            // other. If a clause got there first, banking over it would
+            // discard that clause's value in the getBindValues() merge.
+            //
+            // A column of this same row is the exception: `a` in row 1 banks
+            // `a_1`, which a sibling column literally named `a_1` is holding
+            // at that moment. Both are row placeholders, and finishRow()
+            // clears them -- the sibling banks itself as `a_1_1` -- so they
+            // never meet in the merge.
+            $prior = isset($this->bind_sources[$banked])
+                ? $this->bind_sources[$banked]
+                : null;
+
+            if ($prior !== null && $prior !== 'col') {
+                $this->throwCollision($banked, $prior, 'bulk_col');
+            }
+
+            $this->bind_values_bulk[$banked] = $this->bind_values[$name];
+            $this->bind_sources_bulk[$banked] = 'bulk_col';
         }
 
         return $name;
+    }
+
+    /**
+     *
+     * Adds the banked bulk names to the collision check. They are not in
+     * `$bind_values`, so the inherited check cannot see them, yet they win
+     * the merge in getBindValues() and would silently discard whatever a
+     * clause bound under the same name.
+     *
+     * {@inheritdoc}
+     *
+     */
+    protected function bindValueFrom($name, $value, $source)
+    {
+        // 'col' is exempt for the same reason it is in finishCol(): a later
+        // row's column may be named `a_1` while `a` in row 1 has banked that
+        // name, and both are cleared before the merge.
+        if (
+            $source !== null
+            && $source !== 'col'
+            && isset($this->bind_sources_bulk[$name])
+        ) {
+            $this->throwCollision($name, $this->bind_sources_bulk[$name], $source);
+        }
+
+        return parent::bindValueFrom($name, $value, $source);
     }
 }

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -507,6 +507,27 @@ class Insert extends AbstractDmlQuery implements InsertInterface
 
     /**
      *
+     * Clears the banked bulk values along with the rest, so the names they
+     * held are free to claim again. Leaving the banked sources behind would
+     * refuse a name nothing is bound to any more.
+     *
+     * The rows themselves stay. `$col_values_bulk` is structure rather than
+     * bound values -- the non-bulk path keeps `$col_values` the same way --
+     * so the statement goes on spelling every placeholder with nothing bound
+     * to it, which is what this method means everywhere else.
+     *
+     * @return $this
+     *
+     */
+    public function resetBindValues()
+    {
+        $this->bind_values_bulk = array();
+        $this->bind_sources_bulk = array();
+        return parent::resetBindValues();
+    }
+
+    /**
+     *
      * Adds the banked bulk names to the collision check. They are not in
      * `$bind_values`, so the inherited check cannot see them, yet they win
      * the merge in getBindValues() and would silently discard whatever a

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -1001,4 +1001,130 @@ class CollisionTest extends TestCase
             $bind_values
         );
     }
+
+    /**
+     *
+     * A bulk insert renames each row's placeholders to `<name>_<row>` and
+     * banks them. Those generated names are as much a claim on the flat bind
+     * array as any other, so a clause binding one of them by hand afterwards
+     * would lose its value to the banked one: the merge in getBindValues()
+     * comes last. This is the reproduction filed as #241.
+     *
+     */
+    public function testABankedBulkNameCollidesWithALaterCondition()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert->into('t')
+               ->cols(array('status' => 'row0'))
+               ->addRow(array('status' => 'row1'));
+
+        $this->expectException(Exception\LogicException::class);
+        $this->expectExceptionMessage("':status_0' is already in use by a bulk-insert row");
+        $insert->onConflict('id')
+               ->doUpdateCol('status')
+               ->doUpdateWhere('t.note = :status_0', array('status_0' => 'from the condition'));
+    }
+
+    /**
+     *
+     * And the other way round: the clause claimed the name first, so the row
+     * that would bank over it is the second claimant.
+     *
+     */
+    public function testARowCannotBankOverANameAClauseAlreadyClaimed()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert->into('t')
+               ->cols(array('status' => 'row0'))
+               ->onConflict('id')
+               ->doUpdateCol('status')
+               ->doUpdateWhere('t.note = :status_0', array('status_0' => 'from the condition'));
+
+        $this->expectException(Exception\LogicException::class);
+        $this->expectExceptionMessage("':status_0' is already in use by a condition");
+        $insert->addRow(array('status' => 'row1'));
+    }
+
+    /**
+     *
+     * A hand bind overwrites the value wherever it lands, as it does
+     * everywhere else -- rebinding before execution is legitimate. On the
+     * bulk path the banked value used to win regardless, so the hand-bound
+     * one vanished without a word.
+     *
+     */
+    public function testAHandBindOverwritesABankedBulkValue()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert->into('t')
+               ->cols(array('status' => 'row0'))
+               ->addRow(array('status' => 'row1'));
+
+        $insert->getStatement();
+        $insert->bindValue('status_0', 'by hand');
+
+        $this->assertSame(
+            array('status_0' => 'by hand', 'status_1' => 'row1'),
+            $insert->getBindValues()
+        );
+    }
+
+    /**
+     *
+     * A row still being built holds its own column names, and one of them may
+     * be spelled the same as a name an earlier row banked -- column `a_1`
+     * against the `a_1` that column `a` banked in row 1. Asking for the bind
+     * values before the statement is built catches that overlap in the open.
+     *
+     * The banked value wins, because it is the one the finished statement
+     * binds: the live column has not been renamed yet and will bank itself as
+     * `a_1_2`.
+     *
+     */
+    public function testABankedNameBeatsALiveColumnSpelledTheSame()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert->into('t')
+               ->cols(array('a' => 'r0', 'a_1' => 'x0'))
+               ->addRow(array('a' => 'r1', 'a_1' => 'x1'))
+               ->addRow(array('a' => 'r2', 'a_1' => 'x2'));
+
+        // deliberately before getStatement(), while row 2 is still live
+        $values = $insert->getBindValues();
+        $this->assertSame('r1', $values['a_1']);
+
+        // and once built, the live row banks itself out of the way
+        $insert->getStatement();
+        $values = $insert->getBindValues();
+        $this->assertSame('r1', $values['a_1']);
+        $this->assertSame('x2', $values['a_1_2']);
+    }
+
+    /**
+     *
+     * The generated names cannot collide with each other: the row number is
+     * appended, so a column named `a` in row 1 banks `a_1` while a column
+     * named `a_1` in row 0 banks `a_1_0`. Pinned so that a future change to
+     * the naming scheme has to think about it.
+     *
+     */
+    public function testTwoBulkColumnsWhoseNamesOverlapDoNotCollide()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert->into('t')
+               ->cols(array('a' => 'a-row0', 'a_1' => 'a1-row0'))
+               ->addRow(array('a' => 'a-row1', 'a_1' => 'a1-row1'));
+
+        $insert->getStatement();
+
+        $this->assertSame(
+            array(
+                'a_0' => 'a-row0',
+                'a_1_0' => 'a1-row0',
+                'a_1' => 'a-row1',
+                'a_1_1' => 'a1-row1',
+            ),
+            $insert->getBindValues()
+        );
+    }
 }

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -1071,6 +1071,57 @@ class CollisionTest extends TestCase
 
     /**
      *
+     * resetBindValues() clears the values a query has bound, banked bulk ones
+     * included, so the names they held are free again. Leaving the banked
+     * sources behind would refuse a name nothing is bound to any more.
+     *
+     */
+    public function testResetBindValuesFreesTheBankedBulkNames()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert->into('t')
+               ->cols(array('status' => 'row0'))
+               ->addRow(array('status' => 'row1'));
+        $insert->getStatement();
+
+        $insert->resetBindValues();
+
+        // no collision, because nothing is holding :status_0 now
+        $insert->onConflict('id')
+               ->doUpdateCol('status')
+               ->doUpdateWhere('t.note = :status_0', array('status_0' => 'fresh'));
+
+        $values = $insert->getBindValues();
+        $this->assertSame('fresh', $values['status_0']);
+        $this->assertArrayNotHasKey('status_1', $values);
+    }
+
+    /**
+     *
+     * The reset takes the values and leaves the rows. Columns are structure,
+     * not bound values -- the non-bulk path keeps col_values the same way, so
+     * the statement still spells every placeholder and simply has nothing
+     * bound to them, which is what resetBindValues() means everywhere else.
+     *
+     */
+    public function testResetBindValuesKeepsTheBulkRows()
+    {
+        $insert = $this->newFactory('pgsql')->newInsert();
+        $insert->into('t')
+               ->cols(array('status' => 'row0'))
+               ->addRow(array('status' => 'row1'));
+        $insert->getStatement();
+
+        $insert->resetBindValues();
+
+        $this->assertSame(array(), $insert->getBindValues());
+        $statement = $insert->getStatement();
+        $this->assertStringContainsString(':status_0', $statement);
+        $this->assertStringContainsString(':status_1', $statement);
+    }
+
+    /**
+     *
      * A row still being built holds its own column names, and one of them may
      * be spelled the same as a name an earlier row banked -- column `a_1`
      * against the `a_1` that column `a` banked in row 1. Asking for the bind

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -251,24 +251,52 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
 
     /**
      *
-     * A bulk insert renames its placeholders to `<name>_<row>`. A condition
-     * binding one of those generated names used to be discarded silently, and
-     * the statement ran against the row value instead -- well-formed SQL
-     * asking the wrong question, which is why it needs a real server to show
-     * it would have run at all. It is refused now.
+     * A bulk insert renames its placeholders to `<name>_<row>`, and a
+     * condition binding one of those generated names used to lose its value
+     * to the row's -- well-formed SQL asking the wrong question. The builder
+     * now rejects it, and the documented fix, naming the condition's
+     * placeholder something no row can generate, has to do the right thing
+     * against a real server. See #241.
      *
      */
-    public function testBulkInsertRefusesAConditionOnABankedName()
+    public function testBulkInsertConditionOnABankedName()
     {
+        $collides = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'row0'])
+            ->addRow(['id' => 2, 'name' => 'row1'])
+            ->onConflict('id')
+            ->doUpdateCol('name', 'Updated');
+
+        try {
+            $collides->doUpdateWhere('test_dept.name != :name_0', ['name_0' => 'Sales']);
+            $this->fail('Expected a collision on the :name_0 placeholder.');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            $this->assertStringContainsString(':name_0', $e->getMessage());
+        }
+
         $insert = $this->query_factory->newInsert()
             ->into('test_dept')
             ->cols(['id' => 1, 'name' => 'row0'])
-            ->addRow(['id' => 2, 'name' => 'row1']);
+            ->addRow(['id' => 2, 'name' => 'row1'])
+            ->onConflict('id')
+            ->doUpdateCol('name', 'Updated')
+            ->doUpdateWhere('test_dept.name != :keep', ['keep' => 'Sales']);
 
-        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
-        $insert->onConflict('id')
-            ->doUpdateCol('name')
-            ->doUpdateWhere('test_dept.name != :name_0', ['name_0' => 'from the condition']);
+        // the condition really is testing 'Sales' and not row 0's name, so
+        // exactly the one row that is not Sales gets updated
+        $this->assertSame(1, $this->exec($insert));
+
+        // read after execution: building the statement is what banks the
+        // last row, so before that the row is still live under its own name
+        $this->assertSame(
+            ['name__on_conflict' => 'Updated', 'keep' => 'Sales',
+             'id_0' => 1, 'name_0' => 'row0', 'id_1' => 2, 'name_1' => 'row1'],
+            $insert->getBindValues()
+        );
+
+        $sth = $this->pdo->query('SELECT name FROM test_dept ORDER BY id');
+        $this->assertSame(['Updated', 'Sales'], $sth->fetchAll(PDO::FETCH_COLUMN));
     }
 
     /**

--- a/tests/Integration/PgsqlIntegrationTest.php
+++ b/tests/Integration/PgsqlIntegrationTest.php
@@ -251,6 +251,28 @@ class PgsqlIntegrationTest extends AbstractIntegrationTest
 
     /**
      *
+     * A bulk insert renames its placeholders to `<name>_<row>`. A condition
+     * binding one of those generated names used to be discarded silently, and
+     * the statement ran against the row value instead -- well-formed SQL
+     * asking the wrong question, which is why it needs a real server to show
+     * it would have run at all. It is refused now.
+     *
+     */
+    public function testBulkInsertRefusesAConditionOnABankedName()
+    {
+        $insert = $this->query_factory->newInsert()
+            ->into('test_dept')
+            ->cols(['id' => 1, 'name' => 'row0'])
+            ->addRow(['id' => 2, 'name' => 'row1']);
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $insert->onConflict('id')
+            ->doUpdateCol('name')
+            ->doUpdateWhere('test_dept.name != :name_0', ['name_0' => 'from the condition']);
+    }
+
+    /**
+     *
      * A bulk insert whose rows collide with existing keys: the DO UPDATE
      * value and its WHERE condition are bound once for the whole statement,
      * not per row. Building the statement finishes the last row, and clearing


### PR DESCRIPTION
Fixes #241 — the half left open by #242.

A bulk insert renames each row's placeholders to `<name>_<row>` and banks them outside `bind_values`, so the collision check never saw them, and the merge in `getBindValues()` came last and won:

```php
$insert->into('t')->cols(['status' => 'row0'])->addRow(['status' => 'row1'])
       ->onConflict('id')->doUpdateCol('status')
       ->doUpdateWhere('t.note = :status_0', ['status_0' => 'from the condition']);
// bind values: {"status_0":"row0","status_1":"row1"} — the condition's value gone,
// the WHERE silently testing row 0's data instead
```

Fix: a parallel `$bind_sources_bulk`, checked in both directions — a clause binding a banked name, and a row banking over a name a clause holds. Columns of the row being built are exempt: `a_1` alongside `a` is renamed out of the way before the merge, so it never collides. Hand binds now correctly overwrite a banked value, which they previously could not.

Four guards, each mutation-tested to failure. One of them survived the first pass, which turned out to be a missing test rather than dead code — a live column spelled the same as an earlier row's banked name, reachable by calling `getBindValues()` before the statement is built — now pinned.

Integration test on Postgres, plus docs and a changelog entry. 747 unit, 108 integration, 17 doc examples, PHPStan clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bulk-insert generated placeholder names are now included in collision detection.
  - Conflicts involving banked bulk-insert placeholders now raise a `LogicException` with a clearer collision source.
  - Bulk placeholder name handling is corrected for ordering, resets, and `bindValue()` interactions.
- **Documentation**
  - Added a “Bulk Insert Rows” section explaining per-row placeholder renaming, reservation behavior, and workarounds for collisions.
- **Tests**
  - Added collision and PostgreSQL integration coverage for bulk-insert placeholder conflicts and `ON CONFLICT ... DO UPDATE` conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->