### PR TITLE
Read a comma-separated table list as a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,21 @@
   conditions. Part of #241; the remaining half of that issue, bulk
   placeholders bypassing collision tracking, is still open.
 
+- [FIX] Naming several tables in one string no longer produces an identifier
+  no database has. `from('t1, t2')` was read as a name and its alias and
+  quoted whole, giving `"t1," "t2"`; a Select now builds the list, quoting
+  and reference-checking each table, so it is the same as calling `from()`
+  once per table. An identifier you quoted yourself is left as you wrote it,
+  as it already was inside expressions, so a comma within it stays part of
+  the name.
+
+  Update::table() and Delete::from() take a single table and now throw
+  Aura\SqlQuery\Exception\LogicException for a list, naming the sub-select
+  alternative. There is no portable statement to build: MySQL writes a
+  multi-table update as `UPDATE a, b SET ...`, PostgreSQL and SQLite as
+  `UPDATE a SET ... FROM b`, and SQL Server as `UPDATE a SET ... FROM a JOIN
+  b`, while `DELETE FROM a, b` is valid nowhere. Fixes #160.
+
 - [FIX] An Insert with no columns no longer throws a TypeError; it now
   renders `INSERT INTO t DEFAULT VALUES` (or `INSERT INTO t () VALUES ()`
   on MySQL, which does not support DEFAULT VALUES), letting the database

--- a/docs/select.md
+++ b/docs/select.md
@@ -43,8 +43,30 @@ $select
     ->from('bar AS b');     // alias the table as desired
 ```
 
+Several tables may be named in one call, comma-separated, which builds the
+same list:
+
+```php
+$select = $queryFactory->newSelect();
+
+$select->cols(['*'])->from('foo, bar AS b');
+```
+
+```sql
+SELECT
+    *
+FROM
+    "foo",
+    "bar" AS "b"
+```
+
 The table names will automatically be quoted for you. If you don't want
-quoting applied, use the `fromRaw()` method instead.
+quoting applied, use the `fromRaw()` method instead. A name you have quoted
+yourself is left as you wrote it, so a comma inside it stays part of the name
+rather than separating the list.
+
+Note that UPDATE and DELETE take a single table and reject a list; see
+[the UPDATE page](update.md) for why, and what to write instead.
 
 If you want to SELECT FROM a subselect, do so by calling `fromSubSelect()`.
 Pass both the subselect query string, and an alias for the subselect:

--- a/docs/update.md
+++ b/docs/update.md
@@ -38,6 +38,49 @@ $update->table('foo')           // update this table
     ]);
 ```
 
+## One table at a time
+
+`table()` takes a single table. Naming several, comma-separated, throws
+`Aura\SqlQuery\Exception\LogicException`:
+
+```php
+$update = $queryFactory->newUpdate();
+
+try {
+    $update->table('themes, entities');
+} catch (\Aura\SqlQuery\Exception\LogicException $e) {
+    // throws: An UPDATE takes one table, and 'themes, entities' names
+    // several...
+}
+```
+
+There is no portable statement to build. MySQL writes a multi-table update as
+`UPDATE a, b SET ...`, PostgreSQL and SQLite as `UPDATE a SET ... FROM b`, and
+SQL Server as `UPDATE a SET ... FROM a JOIN b` — four grammars, not one. Match
+the other table with a sub-select in the `WHERE` clause instead:
+
+```php
+$update = $queryFactory->newUpdate();
+
+$update->table('themes')
+    ->cols(['name' => 'new name'])
+    ->where(
+        'id IN (SELECT theme_id FROM entities WHERE uuid = :uuid)',
+        ['uuid' => 'abc-123']
+    );
+```
+
+```sql
+UPDATE "themes"
+SET
+    "name" = :name
+WHERE
+    id IN (SELECT theme_id FROM entities WHERE uuid = :uuid)
+```
+
+`DELETE` is the same: `from()` takes one table. SELECT is unaffected — several
+tables in a `FROM` is an ordinary join, so `from('a, b')` builds the list.
+
 ## Placeholder names
 
 `cols()` names its placeholder after the column, and so does a bind value

--- a/src/Common/Delete.php
+++ b/src/Common/Delete.php
@@ -10,6 +10,7 @@ namespace Aura\SqlQuery\Common;
 
 use Aura\SqlQuery\AbstractDmlQuery;
 use Aura\SqlQuery\Exception\BadMethodCallException;
+use Aura\SqlQuery\Exception\LogicException;
 
 /**
  *
@@ -21,6 +22,7 @@ use Aura\SqlQuery\Exception\BadMethodCallException;
 class Delete extends AbstractDmlQuery implements DeleteInterface
 {
     use WhereTrait;
+    use TableListTrait;
 
     /**
      *
@@ -39,9 +41,22 @@ class Delete extends AbstractDmlQuery implements DeleteInterface
      *
      * @return $this
      *
+     * @throws LogicException when the spec names more than one table.
+     *
      */
     public function from($from)
     {
+        $names = $this->splitNamesList($from);
+        if (count($names) > 1) {
+            throw new LogicException(
+                "A DELETE takes one table, and '{$from}' names several. "
+                . '`DELETE FROM a, b` is not valid on any of the supported '
+                . "databases -- MySQL's multi-table delete is a different "
+                . 'shape again, `DELETE a, b FROM a JOIN b`. Match the other '
+                . 'table with a sub-select in the WHERE clause instead.'
+            );
+        }
+
         $this->from = $this->quoter->quoteName($from);
         return $this;
     }

--- a/src/Common/Quoter.php
+++ b/src/Common/Quoter.php
@@ -85,6 +85,15 @@ class Quoter implements QuoterInterface
     public function quoteName($spec)
     {
         $spec = trim($spec);
+
+        // issue #183: leave an identifier the caller already quoted as they
+        // wrote it, the way quoteNamesIn() does for expressions. The test is
+        // against this dialect's own quotes, so `"odd,name"` is a finished
+        // identifier on PostgreSQL and still a name to wrap on MySQL.
+        if ($this->isQuotedName($spec)) {
+            return $spec;
+        }
+
         $seps = array(' AS ', ' ', '.');
         foreach ($seps as $sep) {
             $pos = strripos($spec, $sep);

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -21,6 +21,7 @@ use Aura\SqlQuery\Exception\LogicException;
 class Select extends AbstractQuery implements SelectInterface
 {
     use WhereTrait;
+    use TableListTrait;
     use LimitOffsetTrait { limit as setLimit; offset as setOffset; }
 
     /**
@@ -443,15 +444,32 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Adds a FROM element to the query; quotes the table name automatically.
      *
-     * @param string $spec The table specification; "foo" or "foo AS bar".
+     * Several tables may be named at once, comma-separated, which is the
+     * same list as calling this once per table -- each is quoted and
+     * reference-checked on its own. Passing the list as one string used to
+     * quote it whole, giving `"foo," "bar"`; see #160.
+     *
+     * @param string $spec The table specification; "foo", "foo AS bar", or
+     * a comma-separated list of either.
      *
      * @return $this
      *
      */
     public function from($spec)
     {
-        $this->addTableRef('FROM', $spec);
-        return $this->addFrom($this->quoter->quoteName($spec));
+        $names = $this->splitNamesList($spec);
+
+        // an empty spec is nobody's list; leave it to quoteName() as before
+        if (empty($names)) {
+            $names = array($spec);
+        }
+
+        foreach ($names as $name) {
+            $this->addTableRef('FROM', $name);
+            $this->addFrom($this->quoter->quoteName($name));
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Common/TableListTrait.php
+++ b/src/Common/TableListTrait.php
@@ -50,9 +50,22 @@ trait TableListTrait
 
             if ($closer !== null) {
                 $name .= $char;
-                if ($char === $closer) {
-                    $closer = null;
+                if ($char !== $closer) {
+                    continue;
                 }
+
+                // a doubled closer is an escaped one, part of the name: the
+                // SQL Server identifier [odd]],name] is `odd],name`, comma
+                // and all. Symmetric quotes survive without this, since
+                // closing and reopening on the doubled character lands back
+                // inside the name, but `[` and `]` cannot do that.
+                if (isset($spec[$i + 1]) && $spec[$i + 1] === $closer) {
+                    $i ++;
+                    $name .= $spec[$i];
+                    continue;
+                }
+
+                $closer = null;
                 continue;
             }
 

--- a/src/Common/TableListTrait.php
+++ b/src/Common/TableListTrait.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+/**
+ *
+ * Reads a comma-separated list of table names, for the queries that take a
+ * table: SELECT, UPDATE and DELETE.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait TableListTrait
+{
+    /**
+     *
+     * Splits a comma-separated list of table names into its parts.
+     *
+     * quoteName() reads a space as the boundary between a name and its alias
+     * and has no idea what to do with a list, so 't1, t2' came out as
+     * `"t1," "t2"` -- an identifier no database has. Splitting first leaves
+     * each caller to decide whether a list means anything where it stands: a
+     * SELECT takes several tables, an UPDATE or a DELETE takes one.
+     *
+     * A comma inside quotes belongs to the name, so the scan steps over
+     * quoted stretches. It tracks the ordinary identifier quotes rather than
+     * asking the quoter for this dialect's, since a caller may hand-quote in
+     * any of them and the answer is the same either way: not a separator.
+     *
+     * @param string $spec One or more table names, comma-separated.
+     *
+     * @return array The individual names, trimmed, with empty parts dropped.
+     *
+     */
+    protected function splitNamesList($spec)
+    {
+        $names = array();
+        $name = '';
+        $closer = null;
+        $len = strlen($spec);
+
+        for ($i = 0; $i < $len; $i ++) {
+            $char = $spec[$i];
+
+            if ($closer !== null) {
+                $name .= $char;
+                if ($char === $closer) {
+                    $closer = null;
+                }
+                continue;
+            }
+
+            if ($char === "'" || $char === '"' || $char === '`') {
+                $closer = $char;
+            } elseif ($char === '[') {
+                $closer = ']';
+            } elseif ($char === ',') {
+                $names[] = $name;
+                $name = '';
+                continue;
+            }
+
+            $name .= $char;
+        }
+
+        $names[] = $name;
+
+        $list = array();
+        foreach ($names as $one) {
+            $one = trim($one);
+            if ($one !== '') {
+                $list[] = $one;
+            }
+        }
+        return $list;
+    }
+}

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -21,6 +21,8 @@ use Aura\SqlQuery\Exception\LogicException;
  */
 class Update extends AbstractDmlQuery implements UpdateInterface
 {
+    use TableListTrait;
+
     use WhereTrait;
 
     /**
@@ -40,9 +42,23 @@ class Update extends AbstractDmlQuery implements UpdateInterface
      *
      * @return $this
      *
+     * @throws LogicException when the spec names more than one table.
+     *
      */
     public function table($table)
     {
+        $names = $this->splitNamesList($table);
+        if (count($names) > 1) {
+            throw new LogicException(
+                "An UPDATE takes one table, and '{$table}' names several. "
+                . 'Every database spells a multi-table update differently -- '
+                . 'MySQL with a comma, PostgreSQL and SQLite with FROM, SQL '
+                . 'Server with FROM and a JOIN -- so there is no portable '
+                . 'form to build here. Match the other table with a '
+                . 'sub-select in the WHERE clause instead.'
+            );
+        }
+
         $this->table = $this->quoter->quoteName($table);
         return $this;
     }

--- a/tests/Common/DeleteTest.php
+++ b/tests/Common/DeleteTest.php
@@ -14,6 +14,38 @@ class DeleteTest extends AbstractQueryTest
 {
     protected $query_type = 'delete';
 
+    /**
+     *
+     * `DELETE FROM a, b` is not valid anywhere -- MySQL's multi-table delete
+     * is `DELETE a, b FROM a JOIN b`, a different shape altogether. The list
+     * used to be quoted whole as <<t1,>> <<t2>>, so the statement failed at
+     * execute time with nothing to say why. See #160.
+     *
+     */
+    public function testFromRejectsMultipleTables()
+    {
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage('one table');
+        $this->query->from('t1, t2');
+    }
+
+    /**
+     *
+     * A comma inside a quoted identifier is part of the name, so this is one
+     * table and must not be refused as a list.
+     *
+     */
+    public function testFromAcceptsAQuotedComma()
+    {
+        $name = $this->query->getQuoteNamePrefix()
+              . 'odd,name'
+              . $this->query->getQuoteNameSuffix();
+
+        $this->query->from($name);
+
+        $this->assertSameSql("DELETE FROM {$name}", $this->query->__toString());
+    }
+
     public function testCommon()
     {
         $this->query->from('t1')

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -210,6 +210,34 @@ class SelectTest extends AbstractQueryTest
 
     /**
      *
+     * A closing quote is escaped by doubling it -- `[odd]],name]` on SQL
+     * Server, `"odd"",name"` on the others -- so the name here is `odd?,name`
+     * and the comma is still inside it. Brackets are the case that bites: an
+     * opener and closer that differ cannot close-then-reopen their way back
+     * inside, the way a doubled symmetric quote accidentally does.
+     *
+     */
+    public function testFromDoesNotSplitAnEscapedQuoteInsideAName()
+    {
+        $prefix = $this->query->getQuoteNamePrefix();
+        $suffix = $this->query->getQuoteNameSuffix();
+        $name = $prefix . 'odd' . $suffix . $suffix . ',name' . $suffix;
+
+        $this->query->cols(array('*'));
+        $this->query->from($name);
+
+        $actual = $this->query->__toString();
+        $expect = "
+            SELECT
+                *
+            FROM
+                {$name}
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     *
      * The duplicate-reference guard has to see each table in the list, or a
      * repeat slips through and the database reports it instead.
      *

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -143,6 +143,85 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    /**
+     *
+     * One string naming several tables is the same list as several from()
+     * calls. It used to be read as "table alias" and quoted whole, giving
+     * <<t1,>> <<t2>> -- an identifier no database has. See #160.
+     *
+     */
+    public function testFromMultipleTablesInOneString()
+    {
+        $this->query->cols(array('*'));
+        $this->query->from('t1, t2');
+
+        $actual = $this->query->__toString();
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>>,
+                <<t2>>
+        ';
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testFromMultipleTablesWithSpacesAndAliases()
+    {
+        $this->query->cols(array('*'));
+        $this->query->from('t1 AS a , t2 AS b');
+
+        $actual = $this->query->__toString();
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<t1>> AS <<a>>,
+                <<t2>> AS <<b>>
+        ';
+        $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     *
+     * A comma inside a quoted identifier is part of the name, not a
+     * separator, so it must not split the list. Quoted in this dialect's own
+     * style, the name is already finished and passes through untouched.
+     *
+     */
+    public function testFromDoesNotSplitAQuotedComma()
+    {
+        $name = $this->query->getQuoteNamePrefix()
+              . 'odd,name'
+              . $this->query->getQuoteNameSuffix();
+
+        $this->query->cols(array('*'));
+        $this->query->from($name);
+
+        $actual = $this->query->__toString();
+        $expect = "
+            SELECT
+                *
+            FROM
+                {$name}
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
+    /**
+     *
+     * The duplicate-reference guard has to see each table in the list, or a
+     * repeat slips through and the database reports it instead.
+     *
+     */
+    public function testFromMultipleTablesRejectsADuplicate()
+    {
+        $this->query->cols(array('*'));
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->query->from('t1, t1');
+    }
+
     public function testFromRaw()
     {
         $this->query->cols(array('*'));

--- a/tests/Common/UpdateTest.php
+++ b/tests/Common/UpdateTest.php
@@ -50,6 +50,63 @@ class UpdateTest extends AbstractQueryTest
         $this->assertSame($expect, $actual);
     }
 
+    /**
+     *
+     * `UPDATE a, b SET ...` is MySQL-only grammar; Postgres, SQLite and SQL
+     * Server each spell a multi-table update differently, and none of them
+     * with a comma. The list used to be quoted whole as <<t1,>> <<t2>>, an
+     * identifier no database has, so the statement failed at execute time
+     * with nothing to say why. Refuse it while the caller can still act on
+     * it. See #160.
+     *
+     */
+    public function testTableRejectsMultipleTables()
+    {
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage('one table');
+        $this->query->table('t1, t2');
+    }
+
+    /**
+     *
+     * The message has to point somewhere: a sub-select in the WHERE is the
+     * portable way to update one table against another.
+     *
+     */
+    public function testTableMultipleTablesMessageNamesTheAlternative()
+    {
+        try {
+            $this->query->table('t1, t2');
+            $this->fail('Expected a rejection of the multi-table list.');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            $this->assertStringContainsString('t1, t2', $e->getMessage());
+            $this->assertStringContainsString('sub-select', $e->getMessage());
+        }
+    }
+
+    /**
+     *
+     * A comma inside a quoted identifier is part of the name, so this is one
+     * table and must not be refused as a list.
+     *
+     */
+    public function testTableAcceptsAQuotedComma()
+    {
+        $name = $this->query->getQuoteNamePrefix()
+              . 'odd,name'
+              . $this->query->getQuoteNameSuffix();
+
+        $this->query->table($name)->cols(array('c1'));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            UPDATE {$name}
+            SET
+                <<c1>> = :c1
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testHasCols()
     {
         $this->query->table('t1');

--- a/tests/Common/UpdateTest.php
+++ b/tests/Common/UpdateTest.php
@@ -107,6 +107,29 @@ class UpdateTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    /**
+     *
+     * A doubled closing quote escapes it, so this is one table whose name
+     * contains a comma, and refusing it as a list would be wrong.
+     *
+     */
+    public function testTableAcceptsAnEscapedQuoteInsideAName()
+    {
+        $prefix = $this->query->getQuoteNamePrefix();
+        $suffix = $this->query->getQuoteNameSuffix();
+        $name = $prefix . 'odd' . $suffix . $suffix . ',name' . $suffix;
+
+        $this->query->table($name)->cols(array('c1'));
+
+        $actual = $this->query->__toString();
+        $expect = "
+            UPDATE {$name}
+            SET
+                <<c1>> = :c1
+        ";
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function testHasCols()
     {
         $this->query->table('t1');

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -302,6 +302,51 @@ abstract class AbstractIntegrationTest extends TestCase
         $this->assertSame(['Clara', 'Betty'], array_column($actual, 'name'));
     }
 
+    /**
+     *
+     * Naming several tables in one from() is an old-style join, and it has to
+     * be a list the database accepts -- the names used to be quoted whole as
+     * one identifier, which no server would take. See #160.
+     *
+     */
+    public function testSelectFromMultipleTablesInOneString()
+    {
+        $select = $this->query_factory->newSelect()
+            ->cols(['test_employee.name', 'test_dept.name AS dept_name'])
+            ->from('test_employee, test_dept')
+            ->where('test_employee.dept_id = test_dept.id')
+            ->where('test_dept.id = :id', ['id' => 1])
+            ->orderBy(['test_employee.name']);
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(['Anna', 'Betty'], array_column($actual, 'name'));
+        $this->assertSame('Engineering', $actual[0]['dept_name']);
+    }
+
+    /**
+     *
+     * The same list is refused for UPDATE and DELETE, where no portable form
+     * exists. Refusing at build time beats a server error the caller cannot
+     * act on.
+     *
+     */
+    public function testUpdateAndDeleteRefuseMultipleTables()
+    {
+        try {
+            $this->query_factory->newUpdate()->table('test_employee, test_dept');
+            $this->fail('Expected an UPDATE multi-table rejection.');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            $this->assertStringContainsString('one table', $e->getMessage());
+        }
+
+        try {
+            $this->query_factory->newDelete()->from('test_employee, test_dept');
+            $this->fail('Expected a DELETE multi-table rejection.');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            $this->assertStringContainsString('one table', $e->getMessage());
+        }
+    }
+
     public function testSelectJoinGroupByHaving()
     {
         $select = $this->query_factory->newSelect()


### PR DESCRIPTION
Fixes #160.

`from('t1, t2')` was read as a name and its alias and quoted whole, giving `"t1," "t2"` — an identifier no database has, failing at execute time with nothing to say why. Same on all four dialects, and for `Update::table()` and `Delete::from()`.

- **SELECT** builds the list: each table quoted and reference-checked on its own, identical to calling `from()` once per table.
- **UPDATE/DELETE** throw `LogicException` naming the sub-select alternative. There is no portable statement to build — MySQL `UPDATE a, b`, PG/SQLite `UPDATE a … FROM b`, SQL Server `UPDATE a … FROM a JOIN b`, and `DELETE FROM a, b` is valid nowhere.

The split is quote-aware, so a comma inside an identifier stays part of the name. Making that reachable meant also letting `quoteName()` leave an already-quoted identifier alone — the #183 rule, which until now applied only inside expressions, so `table('"odd,name"')` rendered `""odd,name""`. It is dialect-aware: MySQL still wraps a double-quoted name.

Lives in a new `Common\\TableListTrait` used by Select/Update/Delete. Nothing public changed — `QuoterInterface` is untouched, so third-party implementers are unaffected.

Five guards, each mutation-tested to failure. Integration test runs the multi-table FROM against MySQL, PostgreSQL and SQLite (SQL Server in CI). 787 unit, 115 integration, 19 doc examples (up from 17 — the two new ones carry `sql` blocks so the checker actually verifies them), PHPStan clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `SELECT` `from()` now supports comma-separated table names (including aliases) in a single call, while preserving quoted identifiers.

* **Bug Fixes**
  * Fixed identifier handling for comma-separated inputs so already-quoted names aren’t re-processed and generated SQL stays valid.
  * `UPDATE` (`table()`) and `DELETE` (`from()`) now strictly require a single table and throw a clear error suggesting a sub-select alternative.

* **Documentation**
  * Updated `FROM`, `UPDATE`, and `DELETE` docs with the new multi-table behavior and examples.

* **Tests**
  * Added coverage for splitting, quoted-comma behavior, duplicate detection, and the new validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->