### PR TITLE
Fix 189 union query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,10 @@
   only the one placeholder. The branch is rendered when it is passed, so
   later edits to that query do not reach back into the union, and it is the
   last branch: call `union()` or `unionAll()` again to add another after
-  it, rather than adding columns to the query holding the union.
+  it, rather than building one on the query holding the union. Columns, a
+  WHERE, a JOIN, a LIMIT -- anything set on that query afterwards has
+  nowhere to render and throws when the statement is built, instead of
+  being dropped from it in silence. Binding values is unaffected.
   Passing the query its own object throws rather than guess which reading
   of a self-union was meant; pass a clone. Called with no argument both
   methods behave exactly as before. Fixes #189.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,26 @@
   `cast(col as varchar)`) as a column alias, which produced misquoted
   SQL. Fixes #157.
 
+- [ADD] `union()` and `unionAll()` now accept a Select as the next branch,
+  so branches that differ only in part can be built from one another
+  instead of being spelled out twice on the same query object:
+
+      $select = $queryFactory->newSelect()
+          ->cols(['SUM(amount) AS amount'])
+          ->fromSubSelect($by_owner->union($by_property), 't');
+
+  The values the given query has bound come across with it. Both branches
+  may bind one placeholder name so long as they bind it to the same value,
+  as the two halves of a union already could; two different values throw
+  Aura\SqlQuery\Exception\LogicException, since the rendered statement has
+  only the one placeholder. The branch is rendered when it is passed, so
+  later edits to that query do not reach back into the union, and it is the
+  last branch: call `union()` or `unionAll()` again to add another after
+  it, rather than adding columns to the query holding the union.
+  Passing the query its own object throws rather than guess which reading
+  of a self-union was meant; pass a clone. Called with no argument both
+  methods behave exactly as before. Fixes #189.
+
 - [ADD] Pgsql\Select and Mysql\Select gain `lateralJoinSubSelect()`,
   rendering `JOIN LATERAL` against an aliased sub-select so the
   sub-select can reference columns from the tables to its left. The

--- a/docs/select.md
+++ b/docs/select.md
@@ -295,7 +295,92 @@ mark placeholder in the condition clause.
 ```php
     ->union()                       // UNION with a followup SELECT
     ->unionAll()                    // UNION ALL with a followup SELECT
+    ->union($select)                // UNION with $select as the next branch
+    ->unionAll($select)             // UNION ALL with $select as the next branch
 ```
+
+Called with no argument, `union()` keeps the SELECT built so far as a branch of
+the union and resets the query, so that the calls after it build the next
+branch:
+
+```php
+$select = $queryFactory->newSelect();
+
+$select
+    ->cols(['c1'])
+    ->from('t1')
+    ->union()
+    ->cols(['c2'])
+    ->from('t2');
+```
+
+```sql
+SELECT
+    c1
+FROM
+    "t1"
+UNION
+SELECT
+    c2
+FROM
+    "t2"
+```
+
+Called with a query, that query becomes the next branch, which is convenient
+when the branches are alike enough to build one from the other:
+
+```php
+$by_owner = $queryFactory->newSelect()
+    ->cols(['amount'])
+    ->from('transactions AS t');
+
+// the branches differ only in how they reach the owner
+$by_property = clone $by_owner;
+
+$by_owner->where('t.owner_id = :owner_id', ['owner_id' => 88]);
+
+$by_property
+    ->join('INNER', 'properties AS p', 'p.property_id = t.property_id')
+    ->where('p.owner_id = :owner_id', ['owner_id' => 88]);
+
+$select = $queryFactory->newSelect()
+    ->cols(['SUM(amount) AS amount'])
+    ->fromSubSelect($by_owner->union($by_property), 't');
+```
+
+```sql
+SELECT
+    SUM(amount) AS "amount"
+FROM
+    (
+        SELECT
+            amount
+        FROM
+            "transactions" AS "t"
+        WHERE
+            "t"."owner_id" = :owner_id
+        UNION
+        SELECT
+            amount
+        FROM
+            "transactions" AS "t"
+        INNER JOIN "properties" AS "p" ON "p"."property_id" = "t"."property_id"
+        WHERE
+            "p"."owner_id" = :owner_id
+    ) AS "t"
+```
+
+The values the given query has bound come across with it, so the union carries
+them whether it is issued directly or nested in a larger query as above. Both
+branches may bind the same placeholder name, as `:owner_id` does here, as long
+as they bind it to the same value; binding one name to two different values
+throws a `LogicException`, since the statement they render into has only one
+`:owner_id` to bind.
+
+A query passed this way is rendered as it was at the time of the call, and
+later changes to it do not reach back into the union. It is also the *last*
+branch: to add another after it, call `union()` or `unionAll()` again, rather
+than adding columns to the query holding the union.
 
 ## Flags
 

--- a/docs/select.md
+++ b/docs/select.md
@@ -380,7 +380,11 @@ throws a `LogicException`, since the statement they render into has only one
 A query passed this way is rendered as it was at the time of the call, and
 later changes to it do not reach back into the union. It is also the *last*
 branch: to add another after it, call `union()` or `unionAll()` again, rather
-than adding columns to the query holding the union.
+than building one on the query holding the union. Columns, a `WHERE`, a `JOIN`,
+a `LIMIT` -- anything set on that query after the branch is passed has nowhere
+to render, and throws a `LogicException` when the statement is built rather
+than disappearing from it. Binding values is unaffected: they belong to the
+union, so the branch already rendered can still be given fresh ones.
 
 ## Flags
 

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -35,6 +35,16 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
+     * The last branch of a union when it was supplied as a query of its own,
+     * already rendered; null when this query is building that branch itself.
+     *
+     * @var string|null
+     *
+     */
+    protected $union_tail = null;
+
+    /**
+     *
      * Is this a SELECT FOR UPDATE?
      *
      * @var
@@ -136,7 +146,40 @@ class Select extends AbstractQuery implements SelectInterface
         if (! empty($this->union)) {
             $union = implode(PHP_EOL, $this->union) . PHP_EOL;
         }
+
+        if ($this->union_tail !== null) {
+            $this->assertNoBranchAfterUnionTail();
+            return $union . $this->union_tail;
+        }
+
         return $union . $this->build();
+    }
+
+    /**
+     *
+     * Reports properties set on this query after a branch was supplied whole,
+     * which the union has no place to render.
+     *
+     * The supplied branch is the last one, and columns set afterwards can only
+     * mean a further branch -- one this query cannot render, because the SQL
+     * already retained ends at that branch with no UNION to carry on from.
+     * Whether that next branch is UNION or UNION ALL is the caller's to say,
+     * so the fix is to say it, and the alternative is to drop the columns from
+     * the statement without a word.
+     *
+     * @return void
+     *
+     * @throws LogicException when this query holds columns of its own.
+     *
+     */
+    protected function assertNoBranchAfterUnionTail()
+    {
+        if (! empty($this->cols)) {
+            throw new LogicException(
+                'The query passed to union() is the last branch; '
+                . 'call union() or unionAll() again to add another after it.'
+            );
+        }
     }
 
     /**
@@ -803,14 +846,15 @@ class Select extends AbstractQuery implements SelectInterface
      * Takes the current select properties and retains them, then sets
      * UNION for the next set of properties.
      *
+     * @param SelectInterface|null $select The next branch as a query of its
+     * own; when omitted, this query is reset to build that branch itself.
+     *
      * @return $this
      *
      */
-    public function union()
+    public function union(?SelectInterface $select = null)
     {
-        $this->union[] = $this->build() . PHP_EOL . 'UNION';
-        $this->resetAfterRendering();
-        return $this;
+        return $this->addUnion('UNION', $select);
     }
 
     /**
@@ -818,14 +862,84 @@ class Select extends AbstractQuery implements SelectInterface
      * Takes the current select properties and retains them, then sets
      * UNION ALL for the next set of properties.
      *
+     * @param SelectInterface|null $select The next branch as a query of its
+     * own; when omitted, this query is reset to build that branch itself.
+     *
      * @return $this
      *
      */
-    public function unionAll()
+    public function unionAll(?SelectInterface $select = null)
     {
-        $this->union[] = $this->build() . PHP_EOL . 'UNION ALL';
+        return $this->addUnion('UNION ALL', $select);
+    }
+
+    /**
+     *
+     * Retains the branch being built and opens the next one, either as a
+     * query supplied whole or as this query reset to build it.
+     *
+     * A supplied branch is rendered on the spot rather than kept as an
+     * object. It is a second query with a life of its own, and holding it
+     * would have edits made to it after this call reach back into a union it
+     * was only ever added to once; the SQL is what was asked for.
+     *
+     * It is rendered before this query changes so that a branch that cannot
+     * render -- one with no columns yet -- leaves this query as it was, rather
+     * than having consumed and reset the branch it was building on the way to
+     * throwing.
+     *
+     * @param string $type 'UNION' or 'UNION ALL'.
+     *
+     * @param SelectInterface|null $select The next branch, or null to build
+     * it on this query.
+     *
+     * @return $this
+     *
+     * @throws LogicException when handed this very query.
+     *
+     */
+    protected function addUnion($type, ?SelectInterface $select)
+    {
+        // a query cannot be a branch of itself: it is being rendered into the
+        // union at the moment it would have to stand apart from it, and each
+        // reading of what that means -- the branch before this call, or the
+        // whole union so far -- is a different statement. Say so rather than
+        // pick one; a clone is what this asks for.
+        if ($select === $this) {
+            throw new LogicException(
+                'Cannot union a query with itself; pass a clone of it instead.'
+            );
+        }
+
+        $branch = $select === null ? null : $select->getStatement();
+
+        // the branch being closed is the supplied one when there is one, and
+        // otherwise whatever this query has been building.
+        $this->union[] = $this->unionTailOrBuild() . PHP_EOL . $type;
+        $this->union_tail = null;
         $this->resetAfterRendering();
+
+        if ($branch !== null) {
+            $this->union_tail = $branch;
+            $this->bindValuesFromSelect($select, 'union');
+        }
+
         return $this;
+    }
+
+    /**
+     *
+     * Returns the branch this query currently ends with: one supplied whole,
+     * or the properties being built.
+     *
+     * @return string
+     *
+     */
+    protected function unionTailOrBuild()
+    {
+        return $this->union_tail === null
+            ? $this->build()
+            : $this->union_tail;
     }
 
     /**
@@ -1005,6 +1119,7 @@ class Select extends AbstractQuery implements SelectInterface
     public function resetUnions()
     {
         $this->union = array();
+        $this->union_tail = null;
 
         // the rendered branches are gone, so nothing binds their placeholders
         // any more: release the names they were holding.

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -160,21 +160,42 @@ class Select extends AbstractQuery implements SelectInterface
      * Reports properties set on this query after a branch was supplied whole,
      * which the union has no place to render.
      *
-     * The supplied branch is the last one, and columns set afterwards can only
-     * mean a further branch -- one this query cannot render, because the SQL
-     * already retained ends at that branch with no UNION to carry on from.
+     * The supplied branch is the last one, and anything set afterwards can
+     * only mean a further branch -- one this query cannot render, because the
+     * SQL already retained ends at that branch with no UNION to carry on from.
      * Whether that next branch is UNION or UNION ALL is the caller's to say,
-     * so the fix is to say it, and the alternative is to drop the columns from
-     * the statement without a word.
+     * so the fix is to say it, and the alternative is to drop a WHERE, a JOIN,
+     * or a LIMIT from the statement without a word.
+     *
+     * What counts as "set afterwards" is asked of reset(), which is what
+     * union() itself leaves this query in and so is the one description of an
+     * empty branch: every property it clears is compared against a copy that
+     * has just been through it. Naming the clauses here instead would leave
+     * the next one added to the statement unguarded, which is how columns came
+     * to be the only property this checked.
+     *
+     * The bound values are not among them, and are left where they are:
+     * they belong to the union rather than to the branch being built -- that
+     * is what lets the rendered SQL keep its placeholders -- so binding a
+     * fresh value for the branch already rendered is no more a new branch
+     * than reading the statement twice is. A clause that claims a name is
+     * caught as the clause it is.
      *
      * @return void
      *
-     * @throws LogicException when this query holds columns of its own.
+     * @throws LogicException when this query holds a branch of its own.
      *
      */
     protected function assertNoBranchAfterUnionTail()
     {
-        if (! empty($this->cols)) {
+        $empty = clone $this;
+        $empty->reset();
+
+        foreach (get_object_vars($empty) as $key => $value) {
+            if ($this->$key === $value) {
+                continue;
+            }
+
             throw new LogicException(
                 'The query passed to union() is the last branch; '
                 . 'call union() or unionAll() again to add another after it.'

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -295,20 +295,26 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * Takes the current select properties and retains them, then sets
      * UNION for the next set of properties.
      *
+     * @param SelectInterface|null $select The next branch as a query of its
+     * own; when omitted, this query is reset to build that branch itself.
+     *
      * @return $this
      *
      */
-    public function union();
+    public function union(?SelectInterface $select = null);
 
     /**
      *
      * Takes the current select properties and retains them, then sets
      * UNION ALL for the next set of properties.
      *
+     * @param SelectInterface|null $select The next branch as a query of its
+     * own; when omitted, this query is reset to build that branch itself.
+     *
      * @return $this
      *
      */
-    public function unionAll();
+    public function unionAll(?SelectInterface $select = null);
 
     /**
      *

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -1068,6 +1068,89 @@ class SelectTest extends AbstractQueryTest
         $this->query->__toString();
     }
 
+    public static function provideStateAfterUnionTail()
+    {
+        return array(
+            'cols' => array(function ($select) { $select->cols(array('c3')); }),
+            'from' => array(function ($select) { $select->from('t3'); }),
+            'fromRaw' => array(function ($select) { $select->fromRaw('t3'); }),
+            'join' => array(function ($select) { $select->join('LEFT', 't3', 'c1 = c3'); }),
+            'where' => array(function ($select) { $select->where('c1 = 1'); }),
+            'orWhere' => array(function ($select) { $select->orWhere('c1 = 1'); }),
+            'groupBy' => array(function ($select) { $select->groupBy(array('c1')); }),
+            'having' => array(function ($select) { $select->having('COUNT(c1) > 1'); }),
+            'orHaving' => array(function ($select) { $select->orHaving('COUNT(c1) > 1'); }),
+            'orderBy' => array(function ($select) { $select->orderBy(array('c1')); }),
+            'limit' => array(function ($select) { $select->limit(10); }),
+            'offset' => array(function ($select) { $select->offset(10); }),
+            'page' => array(function ($select) { $select->page(2); }),
+            'distinct' => array(function ($select) { $select->distinct(); }),
+            'forUpdate' => array(function ($select) { $select->forUpdate(); }),
+        );
+    }
+
+    /**
+     *
+     * The supplied branch is the last one, and the SQL retained ends at it
+     * with no UNION to carry on from -- so anything set on this query
+     * afterwards has nowhere to render. Every part of the statement is the
+     * same case as the columns: say so rather than drop it in silence.
+     *
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideStateAfterUnionTail')]
+    public function testUnionWithQueryThenMoreState($add)
+    {
+        $next = $this->newQuery()->cols(array('c2'))->from('t2');
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->union($next);
+
+        $add($this->query);
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage('is the last branch');
+        $this->query->__toString();
+    }
+
+    /**
+     *
+     * Binding values against the branch already rendered is not a branch of
+     * its own, and neither is reading the statement twice.
+     *
+     */
+    public function testUnionWithQueryThenBindValues()
+    {
+        $next = $this->newQuery()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('c2 = :c2', array('c2' => 'dib'));
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->union($next);
+
+        $this->query->bindValue('c2', 'zim');
+
+        $expect = '
+            SELECT
+                c1
+            FROM
+                <<t1>>
+            UNION
+            SELECT
+                c2
+            FROM
+                <<t2>>
+            WHERE
+                c2 = :c2
+        ';
+
+        $this->assertSameSql($expect, $this->query->__toString());
+        $this->assertSameSql($expect, $this->query->__toString());
+        $this->assertSame(array('c2' => 'zim'), $this->query->getBindValues());
+    }
+
     public function testUnionWithItself()
     {
         $this->query->cols(array('c1'))->from('t1');

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -865,6 +865,312 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testUnionWithQuery()
+    {
+        $next = $this->newQuery()->cols(array('c2'))->from('t2');
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->union($next);
+
+        $expect = '
+            SELECT
+                c1
+            FROM
+                <<t1>>
+            UNION
+            SELECT
+                c2
+            FROM
+                <<t2>>
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testUnionAllWithQuery()
+    {
+        $next = $this->newQuery()->cols(array('c2'))->from('t2');
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->unionAll($next);
+
+        $expect = '
+            SELECT
+                c1
+            FROM
+                <<t1>>
+            UNION ALL
+            SELECT
+                c2
+            FROM
+                <<t2>>
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testUnionWithQueryChained()
+    {
+        $second = $this->newQuery()->cols(array('c2'))->from('t2');
+        $third = $this->newQuery()->cols(array('c3'))->from('t3');
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->union($second)
+                     ->unionAll($third);
+
+        $expect = '
+            SELECT
+                c1
+            FROM
+                <<t1>>
+            UNION
+            SELECT
+                c2
+            FROM
+                <<t2>>
+            UNION ALL
+            SELECT
+                c3
+            FROM
+                <<t3>>
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testUnionWithQueryThenBuildNextBranch()
+    {
+        $next = $this->newQuery()->cols(array('c2'))->from('t2');
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->union($next)
+                     ->union()
+                     ->cols(array('c3'))
+                     ->from('t3');
+
+        $expect = '
+            SELECT
+                c1
+            FROM
+                <<t1>>
+            UNION
+            SELECT
+                c2
+            FROM
+                <<t2>>
+            UNION
+            SELECT
+                c3
+            FROM
+                <<t3>>
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testUnionWithQueryTakesTheValuesItBound()
+    {
+        $next = $this->newQuery()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('c2 = :baz', array('baz' => 'dib'));
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->where('c1 = :foo', array('foo' => 'bar'))
+                     ->union($next);
+
+        $expect = array('foo' => 'bar', 'baz' => 'dib');
+        $actual = $this->query->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testUnionWithQueryRendersItAsItWasPassed()
+    {
+        $next = $this->newQuery()->cols(array('c2'))->from('t2');
+
+        $this->query->cols(array('c1'))->from('t1')->union($next);
+
+        // the branch was rendered when it was passed, so this does not
+        // reach back into the union.
+        $next->where('c2 = 1');
+
+        $expect = '
+            SELECT
+                c1
+            FROM
+                <<t1>>
+            UNION
+            SELECT
+                c2
+            FROM
+                <<t2>>
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testUnionWithQuerySharingAPlaceholder()
+    {
+        $next = $this->newQuery()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('owner_id = :owner_id', array('owner_id' => 88));
+
+        // both branches filter on the one value, as in a union of two views
+        // of the same owner
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->where('owner_id = :owner_id', array('owner_id' => 88))
+                     ->union($next);
+
+        $expect = array('owner_id' => 88);
+        $actual = $this->query->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testUnionWithQueryClaimingABoundName()
+    {
+        $next = $this->newQuery()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('c2 = :foo', array('foo' => 'dib'));
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->where('c1 = :foo', array('foo' => 'bar'));
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':foo'");
+        $this->query->union($next);
+    }
+
+    public function testUnionWithQueryThenMoreColumns()
+    {
+        $next = $this->newQuery()->cols(array('c2'))->from('t2');
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->union($next)
+                     ->cols(array('c3'));
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage('is the last branch');
+        $this->query->__toString();
+    }
+
+    public function testUnionWithItself()
+    {
+        $this->query->cols(array('c1'))->from('t1');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage('Cannot union a query with itself');
+        $this->query->union($this->query);
+    }
+
+    public function testUnionWithQueryThatCannotRender()
+    {
+        $next = $this->newQuery()->from('t2');
+
+        $this->query->cols(array('c1'))->from('t1');
+
+        try {
+            $this->query->union($next);
+            $this->fail('Expected an exception for the empty branch.');
+        } catch (\Aura\SqlQuery\Exception $e) {
+            $this->assertStringContainsString('No columns', $e->getMessage());
+        }
+
+        // the branch this query was building was not consumed on the way out
+        $expect = '
+            SELECT
+                c1
+            FROM
+                <<t1>>
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testResetUnionsAfterUnionWithQuery()
+    {
+        $next = $this->newQuery()->cols(array('c2'))->from('t2');
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->union($next)
+                     ->resetUnions();
+
+        // the supplied branch was union state, and went with the rest of it;
+        // what is left is this query, which union() had reset.
+        $this->query->cols(array('c3'))->from('t3');
+
+        $expect = '
+            SELECT
+                c3
+            FROM
+                <<t3>>
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testUnionWithQueryInSubSelect()
+    {
+        $next = $this->newQuery()
+            ->cols(array('amount'))
+            ->from('t2')
+            ->where('owner_id = :owner_id', array('owner_id' => 88));
+
+        $branch = $this->newQuery()
+            ->cols(array('amount'))
+            ->from('t1')
+            ->where('owner_id = :owner_id', array('owner_id' => 88));
+
+        $this->query
+            ->cols(array('SUM(amount) AS amount'))
+            ->fromSubSelect($branch->union($next), 't');
+
+        $expect = '
+            SELECT
+                SUM(amount) AS <<amount>>
+            FROM
+                (
+                    SELECT
+                        amount
+                    FROM
+                        <<t1>>
+                    WHERE
+                        owner_id = :owner_id
+                    UNION
+                    SELECT
+                        amount
+                    FROM
+                        <<t2>>
+                    WHERE
+                        owner_id = :owner_id
+                ) AS <<t>>
+        ';
+
+        $actual = $this->query->__toString();
+        $this->assertSameSql($expect, $actual);
+
+        $expect = array('owner_id' => 88);
+        $actual = $this->query->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
     public function testAutobind()
     {
         // do these out of order

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -488,6 +488,33 @@ abstract class AbstractIntegrationTest extends TestCase
         $this->assertSame([1, 2], $dept_ids);
     }
 
+    public function testSelectUnionWithQuery()
+    {
+        // issue #189: the branches differ only in the condition, so build the
+        // second from the first rather than spelling it out again
+        $low = $this->query_factory->newSelect()
+            ->cols(['name'])
+            ->from('test_employee')
+            ->where('salary < :cutoff', ['cutoff' => 200]);
+
+        $high = clone $low;
+        $high->resetWhere()->where('salary > :cutoff', ['cutoff' => 200]);
+
+        $select = $this->query_factory->newSelect()
+            ->cols(['name'])
+            ->fromSubSelect($low->union($high), 'edges')
+            ->orderBy(['name']);
+
+        $this->assertStatementContains('UNION', $select);
+
+        // the branch supplied to union() brought its bound value with it, and
+        // both branches asking for the one cutoff is not a collision
+        $this->assertSame(['cutoff' => 200], $select->getBindValues());
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(['Anna', 'Clara', 'Donna'], array_column($actual, 'name'));
+    }
+
     public function testSelectCastExpression()
     {
         // regression for #157: the quoter must not mangle a CAST() type name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `union()` and `unionAll()` now accept a complete `Select` query as the next UNION branch.
  * Union branch SQL and bound values are captured at add time (later changes to the provided query won’t affect the already-added branch).
  * Placeholder/bind-name collisions are validated, and `resetUnions()` clears prior union state.

* **Documentation**
  * Updated UNION docs with chaining rules, binding behavior, and error conditions after a query-based union tail.

* **Tests**
  * Added unit and integration coverage for query-based unions, bindings, subselect usage, resets, and invalid usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->