### PR TITLE
Hold placeholders from every union branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
   above exists to prevent, arriving one branch later. The claims are
   rebuilt from the retained SQL on each `union()`, and only the newest
   branch was being read. Two-branch unions were unaffected. As elsewhere,
-  branches may share a name so long as they share its value.
+  branches may share a name so long as they share its value. Fixes #248.
 
 - [FIX] Naming several tables in one string no longer produces an identifier
   no database has. `from('t1, t2')` was read as a name and its alias and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@
   branch was being read. Two-branch unions were unaffected. As elsewhere,
   branches may share a name so long as they share its value. Fixes #248.
 
+- [FIX] A union branch no longer holds a placeholder name that only its
+  string literals or comments spell. `where("name = ':a'")` binds nothing
+  by that name, and holding it reported a collision against the next
+  branch's legitimate `:a`. Literals and comments are blanked before the
+  names are read; anything unterminated is read as SQL instead, since
+  keeping a name costs at worst a collision report where losing one lets a
+  later branch overwrite the SQL silently.
+
 - [FIX] Naming several tables in one string no longer produces an identifier
   no database has. `from('t1, t2')` was read as a name and its alias and
   quoted whole, giving `"t1," "t2"`; a Select now builds the list, quoting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,11 @@
   may bind one placeholder name so long as they bind it to the same value,
   as the two halves of a union already could; two different values throw
   Aura\SqlQuery\Exception\LogicException, since the rendered statement has
-  only the one placeholder. The branch is rendered when it is passed, so
+  only the one placeholder. Executing such a statement asks the driver to
+  bind that name at both spellings, which PDO cannot do for a driver with no
+  named parameters of its own -- pdo_sqlsrv reports SQLSTATE 07002, and
+  pdo_mysql with ATTR_EMULATE_PREPARES off reports HY093 -- so give each
+  branch a name of its own there. The branch is rendered when it is passed, so
   later edits to that query do not reach back into the union, and it is the
   last branch: call `union()` or `unionAll()` again to add another after
   it, rather than building one on the query holding the union. Columns, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,16 @@
   conditions. Part of #241; the remaining half of that issue, bulk
   placeholders bypassing collision tracking, is still open.
 
+- [FIX] A union of three or more branches now holds the placeholder names
+  from every branch, not just the one most recently retained. A third
+  branch could bind `:a` to a value of its own while the first branch's
+  rendered SQL still read `a = :a`, overwriting what that branch needed
+  with nothing reported -- the silent overwrite the placeholder tracking
+  above exists to prevent, arriving one branch later. The claims are
+  rebuilt from the retained SQL on each `union()`, and only the newest
+  branch was being read. Two-branch unions were unaffected. As elsewhere,
+  branches may share a name so long as they share its value.
+
 - [FIX] Naming several tables in one string no longer produces an identifier
   no database has. `from('t1, t2')` was read as a name and its alias and
   quoted whole, giving `"t1," "t2"`; a Select now builds the list, quoting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,14 +95,16 @@
   branches may share a name so long as they share its value. Fixes #248.
 
 - [FIX] A union branch no longer holds a placeholder name that only its
-  string literals or comments spell. `where("name = ':a'")` binds nothing
-  by that name, and holding it reported a collision against the next
-  branch's legitimate `:a`. Literals and comments are passed over before the
-  names are read, each dialect by its own rules -- on MySQL a backslash
-  escapes the quote after it and a `#` begins a comment, where the standard
-  reading gives a backslash no such power. Anything unterminated is read as
-  SQL instead, since keeping a name costs at worst a collision report where
-  losing one lets a later branch overwrite the SQL silently.
+  string literals, comments or quoted identifiers spell. `where("name =
+  ':a'")` binds nothing by that name, and holding it reported a collision
+  against the next branch's legitimate `:a`. All three are passed over
+  before the names are read, each dialect by its own rules -- on MySQL a
+  backslash escapes the quote after it and a `#` begins a comment, where the
+  standard reading gives a backslash no such power, and a name is quoted
+  with backticks there, brackets on SQL Server, double quotes elsewhere.
+  Anything unterminated is read as SQL instead, since keeping a name costs
+  at worst a collision report where losing one lets a later branch overwrite
+  the SQL silently.
 
 - [FIX] Naming several tables in one string no longer produces an identifier
   no database has. `from('t1, t2')` was read as a name and its alias and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,10 +97,12 @@
 - [FIX] A union branch no longer holds a placeholder name that only its
   string literals or comments spell. `where("name = ':a'")` binds nothing
   by that name, and holding it reported a collision against the next
-  branch's legitimate `:a`. Literals and comments are blanked before the
-  names are read; anything unterminated is read as SQL instead, since
-  keeping a name costs at worst a collision report where losing one lets a
-  later branch overwrite the SQL silently.
+  branch's legitimate `:a`. Literals and comments are passed over before the
+  names are read, each dialect by its own rules -- on MySQL a backslash
+  escapes the quote after it and a `#` begins a comment, where the standard
+  reading gives a backslash no such power. Anything unterminated is read as
+  SQL instead, since keeping a name costs at worst a collision report where
+  losing one lets a later branch overwrite the SQL silently.
 
 - [FIX] Naming several tables in one string no longer produces an identifier
   no database has. `from('t1, t2')` was read as a name and its alias and

--- a/docs/select.md
+++ b/docs/select.md
@@ -377,6 +377,15 @@ as they bind it to the same value; binding one name to two different values
 throws a `LogicException`, since the statement they render into has only one
 `:owner_id` to bind.
 
+Whether that statement can then be *executed* with one bound value is up to
+your driver, since the name is written into both branches. PDO hands a driver
+with no named parameters of its own one marker per spelling, so binding the
+name once leaves the second unfilled: `pdo_sqlsrv` reports `SQLSTATE[07002]`
+and `pdo_mysql` with `ATTR_EMULATE_PREPARES` turned off reports
+`SQLSTATE[HY093]`. MySQL emulating prepares (its default), PostgreSQL and
+SQLite all execute it as written. Where the driver cannot, give each branch a
+name of its own -- `:low_cutoff` and `:high_cutoff` -- and bind both.
+
 A query passed this way is rendered as it was at the time of the call, and
 later changes to it do not reach back into the union. It is also the *last*
 branch: to add another after it, call `union()` or `unionAll()` again, rather

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -874,13 +874,30 @@ class Select extends AbstractQuery implements SelectInterface
     {
         $this->reset();
 
-        // a name inside a string literal is data, not a placeholder, so this
-        // can claim a name the branch does not really bind. That costs a
-        // needless collision report, where missing a name the branch *does*
-        // bind would let a later branch overwrite it silently.
-        $rendered = implode(PHP_EOL, $this->union);
-        preg_match_all('/(?<!:):(\w+)/', $rendered, $matches);
-        $spelled = array_flip($matches[1]);
+        // a name inside a string literal or a comment is text, not a
+        // placeholder: `where("name = ':a'")` binds nothing, and holding :a
+        // on the strength of it would report a collision against a name the
+        // next branch is free to bind. The alternatives before the capture
+        // consume those regions so that only the names outside them are
+        // captured; the doubled '' an escaped quote spells is consumed with
+        // them.
+        //
+        // Everything doubtful falls the same way: keep the text as SQL. A
+        // name kept by mistake costs a needless collision report, where a
+        // name lost inside a region wrongly read as text would let a later
+        // branch bind it and silently overwrite what the rendered SQL needs.
+        // An unterminated literal or comment therefore matches nothing and is
+        // read straight through, the possessive quantifier holding the
+        // literal to that reading instead of backtracking onto a shorter one.
+        // Each branch is read on its own for the same reason, so that a stray
+        // quote in one cannot pair with a quote in the next and swallow the
+        // placeholders between them.
+        $find = "/'(?:[^']|'')*+'|--[^\n]*|\/\*.*?\*\/|(?<!:):(\w+)/s";
+        $spelled = array();
+        foreach ($this->union as $branch) {
+            preg_match_all($find, $branch, $matches);
+            $spelled += array_flip(array_filter($matches[1], 'strlen'));
+        }
 
         $this->bind_sources = array();
         foreach (array_keys($this->bind_values) as $name) {

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -860,6 +860,13 @@ class Select extends AbstractQuery implements SelectInterface
      * the strength of being bound at all -- the alternative is to release a
      * name the rendered SQL is certainly using.
      *
+     * Every branch retained so far is scanned, not just the one this call
+     * rendered. The claims are rebuilt from nothing each time, so reading only
+     * the newest branch would hand back every name the earlier ones spell, and
+     * a third branch could then bind :a to a value of its own while the first
+     * branch's SQL still reads `a = :a` -- the silent overwrite this whole
+     * method exists to prevent, arriving one branch later.
+     *
      * @return null
      *
      */
@@ -871,7 +878,8 @@ class Select extends AbstractQuery implements SelectInterface
         // can claim a name the branch does not really bind. That costs a
         // needless collision report, where missing a name the branch *does*
         // bind would let a later branch overwrite it silently.
-        preg_match_all('/(?<!:):(\w+)/', end($this->union), $matches);
+        $rendered = implode(PHP_EOL, $this->union);
+        preg_match_all('/(?<!:):(\w+)/', $rendered, $matches);
         $spelled = array_flip($matches[1]);
 
         $this->bind_sources = array();

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -35,6 +35,25 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
+     * Regex alternatives matching the SQL that spells no placeholder: string
+     * literals and comments, in the forms this dialect reads them.
+     *
+     * A quote inside a literal is written by doubling it, and a comment runs
+     * to the end of its line or to the close of its block. Dialects that read
+     * more than this -- MySQL, whose backslash escapes the quote after it and
+     * whose hash begins a comment -- say so by overriding this; the reading
+     * here is the standard one, so a backslash is an ordinary character and a
+     * literal ends at the next lone quote whatever precedes it.
+     *
+     * @var string
+     *
+     * @see resetAfterRendering()
+     *
+     */
+    protected $text_pattern = "'(?:[^']|'')*+'|--[^\n]*|\/\*.*?\*\/";
+
+    /**
+     *
      * Is this a SELECT FOR UPDATE?
      *
      * @var
@@ -877,10 +896,9 @@ class Select extends AbstractQuery implements SelectInterface
         // a name inside a string literal or a comment is text, not a
         // placeholder: `where("name = ':a'")` binds nothing, and holding :a
         // on the strength of it would report a collision against a name the
-        // next branch is free to bind. The alternatives before the capture
-        // consume those regions so that only the names outside them are
-        // captured; the doubled '' an escaped quote spells is consumed with
-        // them.
+        // next branch is free to bind. The dialect's own alternatives run
+        // before the capture and consume those regions, so that only the
+        // names outside them are captured.
         //
         // Everything doubtful falls the same way: keep the text as SQL. A
         // name kept by mistake costs a needless collision report, where a
@@ -892,7 +910,7 @@ class Select extends AbstractQuery implements SelectInterface
         // Each branch is read on its own for the same reason, so that a stray
         // quote in one cannot pair with a quote in the next and swallow the
         // placeholders between them.
-        $find = "/'(?:[^']|'')*+'|--[^\n]*|\/\*.*?\*\/|(?<!:):(\w+)/s";
+        $find = "/{$this->text_pattern}|(?<!:):(\w+)/s";
         $spelled = array();
         foreach ($this->union as $branch) {
             preg_match_all($find, $branch, $matches);

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -893,12 +893,12 @@ class Select extends AbstractQuery implements SelectInterface
     {
         $this->reset();
 
-        // a name inside a string literal or a comment is text, not a
-        // placeholder: `where("name = ':a'")` binds nothing, and holding :a
-        // on the strength of it would report a collision against a name the
-        // next branch is free to bind. The dialect's own alternatives run
-        // before the capture and consume those regions, so that only the
-        // names outside them are captured.
+        // a name inside a string literal, a comment, or a quoted identifier
+        // is text, not a placeholder: `where("name = ':a'")` binds nothing,
+        // and holding :a on the strength of it would report a collision
+        // against a name the next branch is free to bind. The dialect's own
+        // alternatives run before the capture and consume those regions, so
+        // that only the names outside them are captured.
         //
         // Everything doubtful falls the same way: keep the text as SQL. A
         // name kept by mistake costs a needless collision report, where a
@@ -910,7 +910,8 @@ class Select extends AbstractQuery implements SelectInterface
         // Each branch is read on its own for the same reason, so that a stray
         // quote in one cannot pair with a quote in the next and swallow the
         // placeholders between them.
-        $find = "/{$this->text_pattern}|(?<!:):(\w+)/s";
+        $find = "/{$this->getQuotedNamePattern()}|{$this->text_pattern}"
+              . "|(?<!:):(\w+)/s";
         $spelled = array();
         foreach ($this->union as $branch) {
             preg_match_all($find, $branch, $matches);
@@ -928,6 +929,31 @@ class Select extends AbstractQuery implements SelectInterface
         // branch just rendered was sharing: that clause is SQL now, so there
         // is no live claimant left to hand a name back to.
         $this->bind_shared = array();
+    }
+
+    /**
+     *
+     * A regex alternative matching a quoted identifier, in the quoting this
+     * dialect writes: backticks on MySQL, brackets on SQL Server, double
+     * quotes elsewhere.
+     *
+     * A colon inside one is part of the name and no placeholder can stand
+     * there, so a scan for placeholder names must read past it. The quoting
+     * comes from the quoter rather than being spelled here, so that what is
+     * read back is what the builder wrote; the closing quote doubled is how a
+     * name containing one is written, and the name runs on past it.
+     *
+     * @return string
+     *
+     * @see resetAfterRendering()
+     *
+     */
+    protected function getQuotedNamePattern()
+    {
+        $prefix = preg_quote($this->getQuoteNamePrefix(), '/');
+        $suffix = preg_quote($this->getQuoteNameSuffix(), '/');
+
+        return "{$prefix}(?:[^{$suffix}]|{$suffix}{$suffix})*+{$suffix}";
     }
 
     /**

--- a/src/Mysql/Select.php
+++ b/src/Mysql/Select.php
@@ -23,6 +23,26 @@ class Select extends Common\Select
 
     /**
      *
+     * Regex alternatives matching the SQL that spells no placeholder, in the
+     * forms MySQL reads them.
+     *
+     * Three readings differ from the standard. A backslash escapes the
+     * character after it, so `'it\'s :a'` is one literal and the name inside
+     * it is text rather than SQL the standard reading would leave over. A
+     * hash begins a comment, which runs to the end of its line as `--` does.
+     * And the dashes need whitespace after them to begin one at all, so
+     * `c1 > 0--:a` is an operator and a placeholder here, where elsewhere it
+     * is a comment; reading it as one would drop a name the branch binds.
+     *
+     * @var string
+     *
+     * @see Common\Select::$text_pattern
+     *
+     */
+    protected $text_pattern = "'(?:[^'\\\\]|''|\\\\.)*+'|--(?:[ \t\r\n][^\n]*|$)|#[^\n]*|\/\*.*?\*\/";
+
+    /**
+     *
      * Does this join type reject an ON clause outright?
      *
      * MySQL treats CROSS JOIN and INNER JOIN as synonyms and accepts an ON

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -1118,6 +1118,34 @@ class SelectTest extends AbstractQueryTest
      * its own, and neither is reading the statement twice.
      *
      */
+    /**
+     *
+     * A branch supplied whole holds its placeholders on the same terms as one
+     * built here. Its names arrive with the query that bound them, and once a
+     * further union() closes it the SQL joins the branches already retained
+     * and is read for names like any other -- so a third branch asking for
+     * :b with a value of its own is the collision it would be anywhere else.
+     *
+     */
+    public function testUnionWithQueryThenAnotherBranchClaimingItsPlaceholder()
+    {
+        $next = $this->newQuery()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('b = :b', array('b' => 2));
+
+        $this->query->cols(array('c1'))
+                     ->from('t1')
+                     ->union($next)
+                     ->union()
+                     ->cols(array('c3'))
+                     ->from('t3');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':b'");
+        $this->query->where('b = :b', array('b' => 999));
+    }
+
     public function testUnionWithQueryThenBindValues()
     {
         $next = $this->newQuery()

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -1277,6 +1277,48 @@ class SelectTest extends AbstractQueryTest
         $this->assertSameSql($expected, $actual);
     }
 
+    public function testUnionHoldsPlaceholdersFromEveryBranch()
+    {
+        // the third branch asks for a name the first one still spells, with a
+        // value of its own: the first branch cannot be re-read, so this is the
+        // collision a union of two branches already reports
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where('a = :a', array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('b = :b', array('b' => 2))
+            ->union()
+            ->cols(array('c3'))
+            ->from('t3');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':a'");
+        $select->where('a = :a', array('a' => 999));
+    }
+
+    public function testUnionKeepsTheValuesEveryBranchBound()
+    {
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where('a = :a', array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('b = :b', array('b' => 2))
+            ->union()
+            ->cols(array('c3'))
+            ->from('t3')
+            ->where('c = :c', array('c' => 3));
+
+        $expect = array('a' => 1, 'b' => 2, 'c' => 3);
+        $actual = $select->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
     public function testResetUnion()
     {
         $select = $this->query

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -279,7 +279,6 @@ class SelectTest extends AbstractQueryTest
         $this->query->from('t1');
     }
 
-
     public function testDuplicateFromAlias()
     {
         $this->query->cols(array('*'));
@@ -1299,6 +1298,148 @@ class SelectTest extends AbstractQueryTest
         $select->where('a = :a', array('a' => 999));
     }
 
+    /**
+     *
+     * Every name a branch could be reading, in the order it is written: the
+     * ones the scan is meant to keep and the ones it is meant to pass over
+     * alike, so that a case can say which it expects.
+     *
+     * @param string $cond The condition to look in.
+     *
+     * @return array
+     *
+     */
+    protected function everyNameIn($cond)
+    {
+        preg_match_all('/:(\w+)/', $cond, $matches);
+        return array_values(array_unique($matches[1]));
+    }
+
+    /**
+     *
+     * Asks which of the names a condition spells the union holds against a
+     * later branch, by binding each one by hand and then having the next
+     * branch bind it to a value of its own: a held name reports the
+     * collision, a free one takes the new value.
+     *
+     * @param array $expect The names expected to be held, in the order they
+     * appear in the condition.
+     *
+     * @param string $cond The condition to render into a union branch.
+     *
+     * @return void
+     *
+     */
+    protected function assertNamesHeld(array $expect, $cond)
+    {
+        $held = array();
+
+        foreach ($this->everyNameIn($cond) as $name) {
+            $select = $this->newQuery()
+                ->cols(array('c1'))
+                ->from('t1')
+                ->where($cond, array());
+            $select->bindValue($name, 'by hand');
+            $select->union()->cols(array('c2'))->from('t2');
+
+            try {
+                $select->where("z = :{$name}", array($name => 'of its own'));
+            } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+                $held[] = $name;
+            }
+        }
+
+        $this->assertSame($expect, $held, "condition: {$cond}");
+    }
+
+    public static function provideNamesHeldFromABranch()
+    {
+        return array(
+            'placeholder' => array(array('a'), 'a = :a'),
+            'literal' => array(array(), "name = ':a'"),
+            'literal either side' => array(array('a'), "x = 'one' AND a = :a AND y = 'two'"),
+            'doubled quote inside' => array(array(), "note = 'it''s :a'"),
+            'doubled quote before' => array(array('a'), "note = 'q''' AND a = :a"),
+            'line comment' => array(array(), 'c1 > 0 -- :a'),
+            'block comment' => array(array(), 'c1 > 0 /* :a */'),
+            'comment then code' => array(array('a'), "c1 > 0 -- :b\nAND a = :a"),
+            'apostrophe in comment' => array(array('a'), "c1 > 0 -- don't\nAND a = :a"),
+            'cast type' => array(array('a'), "c1::text = :a"),
+            'unclosed literal' => array(array('a'), "note = 'unclosed AND a = :a"),
+            'doubled quote leaves it open' => array(array('a'), "note = ':a''"),
+            'unclosed block comment' => array(array('a'), 'c1 > 0 /* unclosed :a'),
+
+            // read no further than the dialects agree. A name kept here is a
+            // needless collision report and nothing worse, which is why these
+            // are left as they are rather than read into the pattern: every
+            // reading added is a chance to swallow a name that is real.
+            'block comment around a comment' => array(array(), 'c1 > 0 /* /* :a */ */'),
+            'gap: nested block comment' => array(array('a'), 'c1 > 0 /* /* q */ :a */'),
+            'gap: quoted identifier' => array(array('a'), 'x = "odd:a name"'),
+        );
+    }
+
+    /**
+     *
+     * What the scan reads and what it passes over, case by case. The names
+     * held are the names the branch is taken to bind; the rest are free for
+     * the next branch to bind as it likes.
+     *
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideNamesHeldFromABranch')]
+    public function testNamesHeldFromABranch(array $expect, $cond)
+    {
+        $this->assertNamesHeld($expect, $cond);
+    }
+
+    public function testUnionHoldsAPlaceholderFromAMiddleBranch()
+    {
+        // the branch in the middle is neither the newest nor the first, and
+        // its name is held on the same terms as either
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where('a = :a', array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('b = :b', array('b' => 2))
+            ->union()
+            ->cols(array('c3'))
+            ->from('t3')
+            ->where('c = :c', array('c' => 3))
+            ->union()
+            ->cols(array('c4'))
+            ->from('t4');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':b'");
+        $select->where('b = :b', array('b' => 999));
+    }
+
+    public function testUnionSharesAMiddleBranchPlaceholderOnTheSameValue()
+    {
+        // held is not taken: a later branch asking for the value the middle
+        // branch already binds is the shared filter a union is often written
+        // for
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where('a = :a', array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('b = :b', array('b' => 2))
+            ->union()
+            ->cols(array('c3'))
+            ->from('t3')
+            ->where('b = :b', array('b' => 2));
+
+        $expect = array('a' => 1, 'b' => 2);
+        $actual = $select->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
     public function testUnionKeepsTheValuesEveryBranchBound()
     {
         $select = $this->query
@@ -1319,173 +1460,6 @@ class SelectTest extends AbstractQueryTest
         $this->assertSame($expect, $actual);
     }
 
-    public function testUnionLeavesFreeANameOnlySpelledInsideAStringLiteral()
-    {
-        // the branch reads ':a' as text, so it binds nothing by that name and
-        // the next branch is free to use it
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("name = ':a'", array());
-        $select->bindValue('a', 'by hand');
-        $select
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2')
-            ->where('a = :a', array('a' => 999));
-
-        $expect = array('a' => 999);
-        $actual = $select->getBindValues();
-        $this->assertSame($expect, $actual);
-    }
-
-    public function testUnionLeavesFreeANameOnlySpelledInsideAComment()
-    {
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("c1 > 0 -- filter by :a later", array());
-        $select->bindValue('a', 'by hand');
-        $select
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2')
-            ->where('a = :a', array('a' => 999));
-
-        $expect = array('a' => 999);
-        $actual = $select->getBindValues();
-        $this->assertSame($expect, $actual);
-    }
-
-    public function testUnionLeavesFreeANameOnlySpelledAsACastType()
-    {
-        // the second colon of `c1::text` casts a column to a type; it does
-        // not name a placeholder the branch binds
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("c1::text = 'x'", array());
-        $select->bindValue('text', 'by hand');
-        $select
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2')
-            ->where('a = :text', array('text' => 999));
-
-        $expect = array('text' => 999);
-        $actual = $select->getBindValues();
-        $this->assertSame($expect, $actual);
-    }
-
-    public function testUnionHoldsAPlaceholderStandingBesideAStringLiteral()
-    {
-        // the literal is text and the placeholder beside it is not: skipping
-        // the one must not lose the other
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("name = 'one' AND a = :a AND note = 'two'", array('a' => 1))
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2');
-
-        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
-        $this->expectExceptionMessage("The placeholder ':a'");
-        $select->where('a = :a', array('a' => 999));
-    }
-
-    public function testUnionHoldsAPlaceholderAfterAnApostropheInAComment()
-    {
-        // the apostrophe belongs to the comment, and must not open a literal
-        // that swallows the placeholder the next condition really binds
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("c1 > 0 -- don't drop this", array())
-            ->where('a = :a', array('a' => 1))
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2');
-
-        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
-        $this->expectExceptionMessage("The placeholder ':a'");
-        $select->where('a = :a', array('a' => 999));
-    }
-
-    public function testUnionHoldsAPlaceholderFollowingAnUnclosedQuote()
-    {
-        // the quote never closes, so there is no telling where the literal
-        // ends; the placeholder after it is held rather than lost to a
-        // literal that may not be one
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("note = 'unclosed", array())
-            ->where('a = :a', array('a' => 1))
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2');
-
-        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
-        $this->expectExceptionMessage("The placeholder ':a'");
-        $select->where('a = :a', array('a' => 999));
-    }
-
-    public function testUnionHoldsAPlaceholderWhereADoubledQuoteLeavesTheLiteralOpen()
-    {
-        // the doubled quote at the end stands for a quote inside the literal
-        // rather than closing it, leaving nothing closed and the name held
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("note = ':a''", array());
-        $select->bindValue('a', 'by hand');
-        $select
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2');
-
-        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
-        $this->expectExceptionMessage("The placeholder ':a'");
-        $select->where('a = :a', array('a' => 999));
-    }
-
-    public function testUnionLeavesFreeANameInsideALiteralWithADoubledQuote()
-    {
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("note = 'it''s :a'", array());
-        $select->bindValue('a', 'by hand');
-        $select
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2')
-            ->where('a = :a', array('a' => 999));
-
-        $expect = array('a' => 999);
-        $actual = $select->getBindValues();
-        $this->assertSame($expect, $actual);
-    }
-
-    public function testUnionLeavesFreeANameInsideABlockComment()
-    {
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("c1 > 0 /* was :a once */", array());
-        $select->bindValue('a', 'by hand');
-        $select
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2')
-            ->where('a = :a', array('a' => 999));
-
-        $expect = array('a' => 999);
-        $actual = $select->getBindValues();
-        $this->assertSame($expect, $actual);
-    }
-
     public function testUnionReadsEachBranchOnItsOwnForUnclosedQuotes()
     {
         // read end to end, the stray quote in the first branch would pair
@@ -1502,22 +1476,6 @@ class SelectTest extends AbstractQueryTest
             ->union()
             ->cols(array('c3'))
             ->from('t3');
-
-        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
-        $this->expectExceptionMessage("The placeholder ':a'");
-        $select->where('a = :a', array('a' => 999));
-    }
-
-    public function testUnionHoldsAPlaceholderFollowingAnUnclosedBlockComment()
-    {
-        $select = $this->query
-            ->cols(array('c1'))
-            ->from('t1')
-            ->where("c1 > 0 /* unclosed", array())
-            ->where('a = :a', array('a' => 1))
-            ->union()
-            ->cols(array('c2'))
-            ->from('t2');
 
         $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
         $this->expectExceptionMessage("The placeholder ':a'");

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -1375,7 +1375,6 @@ class SelectTest extends AbstractQueryTest
             // reading added is a chance to swallow a name that is real.
             'block comment around a comment' => array(array(), 'c1 > 0 /* /* :a */ */'),
             'gap: nested block comment' => array(array('a'), 'c1 > 0 /* /* q */ :a */'),
-            'gap: quoted identifier' => array(array('a'), 'x = "odd:a name"'),
         );
     }
 
@@ -1390,6 +1389,42 @@ class SelectTest extends AbstractQueryTest
     public function testNamesHeldFromABranch(array $expect, $cond)
     {
         $this->assertNamesHeld($expect, $cond);
+    }
+
+    /**
+     *
+     * A colon inside a quoted identifier is part of the name -- backticks on
+     * MySQL, brackets on SQL Server, double quotes elsewhere -- and no
+     * placeholder can stand there, so nothing inside one is read as a name.
+     * The quoting the builder writes around every name it is given is the
+     * same quoting read back here.
+     *
+     */
+    public function testNamesHeldFromAQuotedIdentifier()
+    {
+        $prefix = $this->query->getQuoteNamePrefix();
+        $suffix = $this->query->getQuoteNameSuffix();
+
+        $this->assertNamesHeld(array(), "x = {$prefix}odd:a name{$suffix}");
+
+        // a closing quote inside the name is written by doubling it, so the
+        // name runs on rather than ending there
+        $this->assertNamesHeld(
+            array(),
+            "x = {$prefix}odd{$suffix}{$suffix}:a name{$suffix}"
+        );
+
+        // and the placeholder standing outside the name is still read
+        $this->assertNamesHeld(
+            array('b'),
+            "x = {$prefix}odd:a name{$suffix} AND b = :b"
+        );
+
+        // an opener that never closes leaves the rest as SQL, as an unclosed
+        // literal does -- including when a doubled quote is what leaves it
+        // open, the name running on past the pair rather than ending at it
+        $this->assertNamesHeld(array('a'), "x = {$prefix}unclosed AND a = :a");
+        $this->assertNamesHeld(array('a'), "x = {$prefix}:a{$suffix}{$suffix}");
     }
 
     public function testUnionHoldsAPlaceholderFromAMiddleBranch()

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -1319,6 +1319,211 @@ class SelectTest extends AbstractQueryTest
         $this->assertSame($expect, $actual);
     }
 
+    public function testUnionLeavesFreeANameOnlySpelledInsideAStringLiteral()
+    {
+        // the branch reads ':a' as text, so it binds nothing by that name and
+        // the next branch is free to use it
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("name = ':a'", array());
+        $select->bindValue('a', 'by hand');
+        $select
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('a = :a', array('a' => 999));
+
+        $expect = array('a' => 999);
+        $actual = $select->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testUnionLeavesFreeANameOnlySpelledInsideAComment()
+    {
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("c1 > 0 -- filter by :a later", array());
+        $select->bindValue('a', 'by hand');
+        $select
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('a = :a', array('a' => 999));
+
+        $expect = array('a' => 999);
+        $actual = $select->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testUnionLeavesFreeANameOnlySpelledAsACastType()
+    {
+        // the second colon of `c1::text` casts a column to a type; it does
+        // not name a placeholder the branch binds
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("c1::text = 'x'", array());
+        $select->bindValue('text', 'by hand');
+        $select
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('a = :text', array('text' => 999));
+
+        $expect = array('text' => 999);
+        $actual = $select->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testUnionHoldsAPlaceholderStandingBesideAStringLiteral()
+    {
+        // the literal is text and the placeholder beside it is not: skipping
+        // the one must not lose the other
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("name = 'one' AND a = :a AND note = 'two'", array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':a'");
+        $select->where('a = :a', array('a' => 999));
+    }
+
+    public function testUnionHoldsAPlaceholderAfterAnApostropheInAComment()
+    {
+        // the apostrophe belongs to the comment, and must not open a literal
+        // that swallows the placeholder the next condition really binds
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("c1 > 0 -- don't drop this", array())
+            ->where('a = :a', array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':a'");
+        $select->where('a = :a', array('a' => 999));
+    }
+
+    public function testUnionHoldsAPlaceholderFollowingAnUnclosedQuote()
+    {
+        // the quote never closes, so there is no telling where the literal
+        // ends; the placeholder after it is held rather than lost to a
+        // literal that may not be one
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("note = 'unclosed", array())
+            ->where('a = :a', array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':a'");
+        $select->where('a = :a', array('a' => 999));
+    }
+
+    public function testUnionHoldsAPlaceholderWhereADoubledQuoteLeavesTheLiteralOpen()
+    {
+        // the doubled quote at the end stands for a quote inside the literal
+        // rather than closing it, leaving nothing closed and the name held
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("note = ':a''", array());
+        $select->bindValue('a', 'by hand');
+        $select
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':a'");
+        $select->where('a = :a', array('a' => 999));
+    }
+
+    public function testUnionLeavesFreeANameInsideALiteralWithADoubledQuote()
+    {
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("note = 'it''s :a'", array());
+        $select->bindValue('a', 'by hand');
+        $select
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('a = :a', array('a' => 999));
+
+        $expect = array('a' => 999);
+        $actual = $select->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testUnionLeavesFreeANameInsideABlockComment()
+    {
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("c1 > 0 /* was :a once */", array());
+        $select->bindValue('a', 'by hand');
+        $select
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where('a = :a', array('a' => 999));
+
+        $expect = array('a' => 999);
+        $actual = $select->getBindValues();
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testUnionReadsEachBranchOnItsOwnForUnclosedQuotes()
+    {
+        // read end to end, the stray quote in the first branch would pair
+        // with the one in the second and mask the placeholder between them
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("note = 'unclosed", array())
+            ->where('a = :a', array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2')
+            ->where("note = 'also unclosed", array())
+            ->union()
+            ->cols(array('c3'))
+            ->from('t3');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':a'");
+        $select->where('a = :a', array('a' => 999));
+    }
+
+    public function testUnionHoldsAPlaceholderFollowingAnUnclosedBlockComment()
+    {
+        $select = $this->query
+            ->cols(array('c1'))
+            ->from('t1')
+            ->where("c1 > 0 /* unclosed", array())
+            ->where('a = :a', array('a' => 1))
+            ->union()
+            ->cols(array('c2'))
+            ->from('t2');
+
+        $this->expectException(\Aura\SqlQuery\Exception\LogicException::class);
+        $this->expectExceptionMessage("The placeholder ':a'");
+        $select->where('a = :a', array('a' => 999));
+    }
+
     public function testResetUnion()
     {
         $select = $this->query

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -511,6 +511,71 @@ abstract class AbstractIntegrationTest extends TestCase
         // both branches asking for the one cutoff is not a collision
         $this->assertSame(['cutoff' => 200], $select->getBindValues());
 
+        // the statement is valid everywhere, but only a driver that binds a
+        // repeated name once can execute this one; the rest are given the
+        // same union with a name per branch, which is what a caller on such
+        // a driver writes. See bindsARepeatedName().
+        $actual = $this->fetchAll(
+            $this->bindsARepeatedName() ? $select : $this->newUnionWithANamePerBranch()
+        );
+        $this->assertSame(['Anna', 'Clara', 'Donna'], array_column($actual, 'name'));
+    }
+
+    /**
+     * The union above, with each branch binding a name of its own.
+     */
+    private function newUnionWithANamePerBranch()
+    {
+        $low = $this->query_factory->newSelect()
+            ->cols(['name'])
+            ->from('test_employee')
+            ->where('salary < :low_cutoff', ['low_cutoff' => 200]);
+
+        $high = $this->query_factory->newSelect()
+            ->cols(['name'])
+            ->from('test_employee')
+            ->where('salary > :high_cutoff', ['high_cutoff' => 200]);
+
+        return $this->query_factory->newSelect()
+            ->cols(['name'])
+            ->fromSubSelect($low->union($high), 'edges')
+            ->orderBy(['name']);
+    }
+
+    /**
+     * A statement may spell one placeholder name in two places -- the two
+     * halves of a union filtering on one cutoff -- and this library binds it
+     * once. Whether that reaches the server is PDO's affair, not the
+     * statement's: a driver with no named parameters of its own is handed one
+     * marker per occurrence, and one bound value then leaves the second
+     * unfilled. MySQL reports HY093 that way with emulated prepares turned
+     * off, and SQL Server reports 07002 through the ODBC driver, which is why
+     * this is asked of the driver rather than assumed.
+     */
+    protected function bindsARepeatedName(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Pins the answer above, so that a driver that starts binding a repeated
+     * name -- or stops -- is reported here rather than in a union test that
+     * looks like a query builder bug.
+     */
+    public function testRepeatedPlaceholderName()
+    {
+        $select = $this->query_factory->newSelect()
+            ->cols(['name'])
+            ->from('test_employee')
+            ->where('salary < :cutoff OR salary > :cutoff', ['cutoff' => 200])
+            ->orderBy(['name']);
+
+        if (! $this->bindsARepeatedName()) {
+            $this->expectException(\PDOException::class);
+            $this->fetchAll($select);
+            return;
+        }
+
         $actual = $this->fetchAll($select);
         $this->assertSame(['Anna', 'Clara', 'Donna'], array_column($actual, 'name'));
     }

--- a/tests/Integration/SqlsrvIntegrationTest.php
+++ b/tests/Integration/SqlsrvIntegrationTest.php
@@ -23,6 +23,21 @@ class SqlsrvIntegrationTest extends AbstractIntegrationTest
 {
     protected string $db_type = 'sqlsrv';
 
+    /**
+     * The driver has no named parameters of its own, so PDO hands it one
+     * marker per occurrence and a name spelled twice arrives as two
+     * parameters; binding it once leaves the second unfilled, which the ODBC
+     * driver reports as SQLSTATE 07002, "COUNT field incorrect". The other
+     * dialects tested here each answer the question their own way -- MySQL by
+     * emulating prepares and substituting the value at both spellings,
+     * PostgreSQL by numbering a repeated name once, SQLite by binding names
+     * natively -- so only this one has to bind a name per branch.
+     */
+    protected function bindsARepeatedName(): bool
+    {
+        return false;
+    }
+
     protected function newPdo(): PDO
     {
         $dsn = getenv('DB_SQLSRV_DSN');

--- a/tests/Mysql/SelectTest.php
+++ b/tests/Mysql/SelectTest.php
@@ -155,4 +155,25 @@ class SelectTest extends Common\SelectTest
         $expect = sprintf($this->expected_sql_with_flag, 'SQL_BUFFER_RESULT');
         $this->assertSameSql($expect, $actual);
     }
+
+    public static function provideNamesHeldFromABranch()
+    {
+        return array_merge(Common\SelectTest::provideNamesHeldFromABranch(), array(
+            'backslash escape' => array(array(), "note = 'it\\'s :a'"),
+            'backslash before a backslash' => array(array('a'), "note = 'ends\\\\' AND a = :a"),
+            'hash comment' => array(array(), 'c1 > 0 # :a'),
+            'hash after a literal' => array(array(), "note = 'x' # :a"),
+
+            // MySQL wants whitespace after the dashes before it reads them as
+            // a comment, so this is an operator and a placeholder
+            'no space after the dashes' => array(array('a'), 'c1 > 0--:a'),
+
+            // read no further than this. A double-quoted string is a string
+            // here and an identifier under ANSI_QUOTES, and keeping the name
+            // costs a needless collision report where reading it as a string
+            // would swallow a real placeholder in every ANSI_QUOTES query.
+            'gap: double-quoted string' => array(array('a'), 'x = ":a"'),
+        ));
+    }
+
 }

--- a/tests/Pgsql/SelectTest.php
+++ b/tests/Pgsql/SelectTest.php
@@ -29,4 +29,22 @@ class SelectTest extends Common\SelectTest
             't1.c1 = a2.c1'
         );
     }
+
+    public static function provideNamesHeldFromABranch()
+    {
+        return array_merge(Common\SelectTest::provideNamesHeldFromABranch(), array(
+            // standard strings: the backslash is an ordinary character, so
+            // the literal ends at the quote after it and the rest is SQL
+            'backslash escape' => array(array('a'), "note = 'it\\'s :a'"),
+            'hash is not a comment' => array(array('a'), 'c1 > 0 # :a'),
+
+            // read no further than this. Both spell a literal Postgres alone
+            // has, and a name kept inside one is a needless collision report
+            // where a reading of them gone wrong would swallow a real
+            // placeholder standing outside.
+            'gap: dollar-quoted string' => array(array('a'), 'note = $$ :a $$'),
+            'gap: escape string' => array(array('a'), "note = E'\\':a'"),
+        ));
+    }
+
 }

--- a/tests/Sqlsrv/SelectTest.php
+++ b/tests/Sqlsrv/SelectTest.php
@@ -7,6 +7,17 @@ class SelectTest extends Common\SelectTest
 {
     protected $db_type = 'sqlsrv';
 
+    public static function provideNamesHeldFromABranch()
+    {
+        return array_merge(Common\SelectTest::provideNamesHeldFromABranch(), array(
+            // read no further than this. SQL Server names quoted with double
+            // quotes are legal under QUOTED_IDENTIFIER, but the brackets are
+            // what this builder writes, so a name kept inside a double-quoted
+            // one is a needless collision report and nothing worse.
+            'gap: double-quoted identifier' => array(array('a'), 'x = "odd:a name"'),
+        ));
+    }
+
     public function testLimitOffset()
     {
         $this->query->cols(array('*'));


### PR DESCRIPTION
Fixes #248.

**Bug.** From the third union branch on, a placeholder an earlier branch still binds can be taken by a later one without a word:

```php
$select->cols(['c1'])->from('t1')->where('a = :a', ['a' => 1])
    ->union()->cols(['c2'])->from('t2')->where('b = :b', ['b' => 2])
    ->union()->cols(['c3'])->from('t3')
    ->where('a = :a', ['a' => 999]);
```

Branch 1's retained SQL still reads `a = :a`, so it executes against 999.

**Fix.** `resetAfterRendering()` rebuilds `bind_sources` from nothing on each `union()` and was reading only `end($this->union)`, handing back every name the earlier branches spell. It now scans all retained branches.

**Coverage.** Two tests, both running across all five dialects: the collision above, and a guard that all three branches' values survive. The collision test fails 5x before the fix; restoring `end($this->union)` fails it again. Suite, PHPStan, doc examples and integration are green.

Trial-merges clean with #247 (999 tests green together); the two can land in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UNION placeholder “hold/claim” tracking across three or more branches to prevent silent overwrites.
  * Placeholder detection now avoids placeholder-like text inside SQL string literals and comments, reducing false collision errors.
  * UNION placeholder collisions and reuse now raise clearer errors, and quoted-identifiers are handled so placeholders inside them aren’t scanned.
  * Improved dialect-specific placeholder parsing (MySQL, PostgreSQL, and SQL Server).

* **Tests**
  * Expanded UNION regression coverage for held-placeholders, collision scenarios, and correct bind merging across branches.
  * Added broader parameterized fixtures covering quoting, literals/comments, and edge cases (including unclosed quotes behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->