### PR TITLE
Say which literal and comment forms the union scan reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,9 +102,15 @@
   backslash escapes the quote after it and a `#` begins a comment, where the
   standard reading gives a backslash no such power, and a name is quoted
   with backticks there, brackets on SQL Server, double quotes elsewhere.
-  Anything unterminated is read as SQL instead, since keeping a name costs
-  at worst a collision report where losing one lets a later branch overwrite
-  the SQL silently.
+
+  The forms read are the ordinary ones, and the reading stops where the
+  dialects part company: a Postgres dollar-quoted or `E''` string, a MySQL
+  string in double quotes, a SQL Server name in double quotes, and a nested
+  block comment are all left as SQL, as is anything unterminated. Each keeps
+  the names it spells, which costs at worst the needless collision report
+  this fix is about, where losing a name the branch does bind would let a
+  later branch overwrite the SQL silently -- so every doubtful reading falls
+  that way on purpose.
 
 - [FIX] Naming several tables in one string no longer produces an identifier
   no database has. `from('t1, t2')` was read as a name and its alias and


### PR DESCRIPTION
The union placeholder entry claimed every string literal, comment and quoted identifier was passed over. The scan stops where the dialects spell those differently: a Postgres dollar-quoted or `E''` string, a MySQL string in double quotes, a SQL Server name in double quotes, and a nested block comment are read as SQL and keep the names they spell.

Those forms are pinned as `gap:` rows in the dialect tables in `tests/*/SelectTest.php`; this only brings the changelog into line with them, and notes that the doubtful reading falls that way on purpose -- a name kept costs a needless collision report, a name lost lets a later branch overwrite the SQL silently.

Changelog only; no code change. Raised in review of #249, after the branch had merged.