### PR TITLE
Add a WITH clause to SELECT (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## 6.0.0 (unreleased)
 
+- [ADD] SELECT queries take common table expressions, via with() and
+  withRecursive():
+
+        $select->with('well_paid', $earners)
+               ->cols(['name'])
+               ->from('well_paid');
+
+  The CTE is given as a Select or as a raw string, with an optional column
+  list, and a Select is rendered on the spot the way a branch passed to
+  union() is; the values it bound come with it. RECURSIVE belongs to the
+  clause rather than to one CTE, so a statement mixing recursive and plain
+  members spells it once. SQL Server infers the recursion and rejects the
+  keyword, so withRecursive() renders a plain WITH there and the same PHP is
+  valid on every dialect.
+
+  A CTE belongs to the statement rather than to a branch, so it survives the
+  reset union() performs and is written once above every branch. The names it
+  binds stay claimed for as long as it is defined, and one other clause may
+  ask for a name when it wants the value already bound -- in either order,
+  since a CTE is written at the top of the statement whenever with() is
+  called. Asking for a second value still throws, and resetWith() releases
+  the names along with the clause. A branch passed to union() may not bring
+  a WITH clause of its own, which would render as `UNION WITH ... SELECT`;
+  it is reported rather than built. union() is otherwise unchanged.
+  Fixes #130.
+
 - [BRK] Two different parts of one query claiming the same placeholder name
   now throws Aura\SqlQuery\Exception\LogicException instead of silently
   discarding one of the values. The common case is a condition that tests a

--- a/docs/select.md
+++ b/docs/select.md
@@ -395,6 +395,109 @@ to render, and throws a `LogicException` when the statement is built rather
 than disappearing from it. Binding values is unaffected: they belong to the
 union, so the branch already rendered can still be given fresh ones.
 
+## WITH
+
+```php
+    ->with($name, $spec, array $cols = array())  // WITH "name" AS ( ... )
+    ->withRecursive($name, $spec, array $cols = array())  // WITH RECURSIVE "name" AS ( ... )
+```
+
+A common table expression prefixes the whole statement, and the name it
+defines is used below it as an ordinary table would be:
+
+```php
+$sub = $queryFactory->newSelect()
+    ->cols(['c1'])
+    ->from('t1');
+
+$select = $queryFactory->newSelect()
+    ->with('cte', $sub)
+    ->cols(['*'])
+    ->from('cte');
+```
+
+```sql
+WITH "cte" AS (
+    SELECT
+        c1
+    FROM
+        "t1"
+)
+SELECT
+    *
+FROM
+    "cte"
+```
+
+The `$spec` is either a _Select_ object or a raw SQL string. A _Select_ is
+rendered on the spot, exactly as a branch passed to `union()` is: it is a
+query with a life of its own, and editing it afterwards does not reach back
+into the statement it was added to. The values it bound come along with it.
+
+Several CTEs may be defined, and a later one may name an earlier one. They are
+written in the order they were added, under a single `WITH`; a name used twice
+throws a `LogicException` rather than replacing the CTE already defined.
+
+`withRecursive()` writes `WITH RECURSIVE`, which the recursive member needs in
+order to name the CTE inside its own definition. RECURSIVE belongs to the
+clause rather than to one CTE, so a statement mixing recursive and plain
+members spells it once:
+
+```php
+$counter = $queryFactory->newSelect()
+    ->cols(['1 AS n'])
+    ->unionAll()
+    ->cols(['n + 1'])
+    ->from('counter')
+    ->where('n < :stop', ['stop' => 3]);
+
+$select = $queryFactory->newSelect()
+    ->withRecursive('counter', $counter, ['n'])
+    ->cols(['n'])
+    ->from('counter');
+```
+
+```sql
+WITH RECURSIVE "counter" ("n") AS (
+    SELECT
+        1 AS "n"
+    UNION ALL
+    SELECT
+        n + 1
+    FROM
+        "counter"
+    WHERE
+        n < :stop
+)
+SELECT
+    n
+FROM
+    "counter"
+```
+
+SQL Server is the exception: it infers the recursion and rejects the keyword,
+so `withRecursive()` there renders a plain `WITH`. The same PHP is valid on
+every dialect.
+
+A CTE belongs to the statement rather than to a branch of it, so it survives
+`union()` and is written once above every branch. A branch passed to `union()`
+may not bring a `WITH` clause of its own, since the clause opens a statement
+and a branch is not one; define the CTE on the query the union belongs to,
+where every branch may name it.
+
+The placeholder names a CTE binds stay claimed for as long as it is defined.
+One other clause may ask for a name if it wants the value already bound --
+in either order, since a CTE is written at the top of the statement whenever
+`with()` is called. Asking for a different value throws rather than
+overwriting what the CTE needs, and so does a second clause asking for the
+same name, whatever value it wants. `resetWith()` releases the names along
+with the clause, except any that a rendered union branch is also spelling.
+
+A sub-select may carry a `WITH` of its own -- `fromSubSelect($inner, 'x')`
+where `$inner` defines a CTE renders the clause inside the parentheses. That
+is valid on PostgreSQL, MySQL and SQLite, but SQL Server allows `WITH` only
+at the head of the statement; there, define the CTE on the outer query.
+
 ## Flags
 
 ```php
@@ -428,6 +531,7 @@ find the total number of rows to be paginated over).
 - `resetWhere()`, `resetGroupBy()`, `resetHaving()`, and `resetOrderBy()`
   remove the respective clauses
 - `resetUnions()` removes all `UNION` and `UNION ALL` clauses
+- `resetWith()` removes all Common Table Expressions
 - `resetFlags()` removes all database-engine-specific flags
 - `resetBindValues()` removes all values bound to named placeholders
 
@@ -436,6 +540,7 @@ find the total number of rows to be paginated over).
     public function resetGroupBy()
     public function resetHaving()
     public function resetOrderBy()
+    public function resetWith()
 
 ## Issuing The Query
 

--- a/docs/sqlsrv.md
+++ b/docs/sqlsrv.md
@@ -1,7 +1,8 @@
 # SQL Server Additions
 
 The 'sqlsrv' query objects have no additional methods specific to Microsoft SQL
-Server. However, `limit()` and `offset()` behaviors are somewhat modified.
+Server. However, `limit()` and `offset()` behaviors are somewhat modified, and
+`withRecursive()` writes its clause the way T-SQL spells it.
 
 In general, `limit()` and `offset()` with Microsoft SQL Server are best
 combined with `orderBy()`. The `limit()` and `offset()` methods on the
@@ -14,3 +15,46 @@ Microsoft SQL Server query objects will generate sqlsrv-specific variations of
   `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY` clause. In this case there *must*
   be an `ORDER BY` clause, as the limiting clause is a sub-clause of `ORDER
   BY`.
+
+## Recursive Common Table Expressions
+
+`RECURSIVE` is not part of the T-SQL grammar: SQL Server infers the recursion
+from the CTE naming itself, and rejects the keyword. So `withRecursive()`
+writes a plain `WITH` here, and the same PHP that runs on the other dialects
+runs unchanged:
+
+```php
+$counter = $queryFactory->newSelect()
+    ->cols(['1 AS n'])
+    ->unionAll()
+    ->cols(['n + 1'])
+    ->from('counter')
+    ->where('n < :stop', ['stop' => 3]);
+
+$select = $queryFactory->newSelect()
+    ->withRecursive('counter', $counter, ['n'])
+    ->cols(['n'])
+    ->from('counter');
+```
+
+```sql
+WITH [counter] ([n]) AS (
+    SELECT
+        1 AS [n]
+    UNION ALL
+    SELECT
+        n + 1
+    FROM
+        [counter]
+    WHERE
+        n < :stop
+)
+SELECT
+    n
+FROM
+    [counter]
+```
+
+Note also that SQL Server wants the statement before a `WITH` terminated with
+a semicolon when it is not the first in the batch; that is the caller's to
+add, since this library issues one statement at a time.

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -67,6 +67,7 @@ abstract class AbstractQuery
         'join' => 'a JOIN condition',
         'table' => 'a sub-select in the FROM clause',
         'union' => 'a rendered UNION branch',
+        'with' => 'a common table expression',
         'conflict' => 'doUpdateCol()',
         'duplicate_key' => 'onDuplicateKeyUpdateCol()',
         'bulk_col' => 'a bulk-insert row',
@@ -250,8 +251,8 @@ abstract class AbstractQuery
      *
      * @param string|null $source The part of the query binding the value:
      * 'col', 'where', 'having', 'join', 'cond' for a condition with no
-     * clause of its own, 'conflict', 'duplicate_key', 'union', or null when
-     * bound by hand.
+     * clause of its own, 'conflict', 'duplicate_key', 'union', 'with', or
+     * null when bound by hand.
      *
      * @return $this
      *
@@ -265,28 +266,60 @@ abstract class AbstractQuery
             ? $this->bind_sources[$name]
             : null;
 
-        // A rendered UNION branch owns its placeholders, but a later branch
-        // filtering on the same value -- one tenant id across both halves --
+        // A rendered UNION branch owns its placeholders, and so does a CTE:
+        // both are SQL the statement keeps whole, and neither has a clause
+        // left to hand its names back to. A later clause filtering on the
+        // same value -- one tenant id in the CTE and in the outer WHERE --
         // asks for exactly what is already bound, and nothing is lost by
-        // letting it through. Ownership stays with the union: were it to pass
-        // to the new clause, a later resetWhere() would free a name the
-        // rendered SQL still binds. Record the clause as a second claimant
-        // all the same, so that resetUnions() hands the name over to it
-        // instead of freeing a name this clause is still using.
+        // letting it through. Ownership stays with the union or the CTE:
+        // were it to pass to the clause, a later resetWhere() would free a
+        // name that retained SQL still binds. Record the clause as a second
+        // claimant all the same, so that resetUnions() or resetWith() hands
+        // the name over to it instead of freeing a name it is still using.
+        //
+        // A CTE also shares in the other direction, arriving after the clause
+        // that bound the name. It is written at the top of the statement
+        // whenever the caller reaches with(), so which of the two was called
+        // first says nothing about what the statement means, and making the
+        // order matter would only be a rule to remember.
+        //
+        // A union branch keeps the reading it already had, where the branch
+        // must be the one holding the name first. Widening that is a change
+        // to how union() behaves, wanted or not, and it belongs to union
+        // rather than to the clause being added here.
+        $prior_owns = in_array($prior, array('union', 'with'), true);
+        $source_owns = $source === 'with';
+
         if (
-            $prior === 'union'
+            ($prior_owns || $source_owns)
             && array_key_exists($name, $this->bind_values)
             && $this->bind_values[$name] === $value
         ) {
-            if ($source !== null && $source !== 'union') {
+            $owner = $prior_owns ? $prior : $source;
+            $sharer = $prior_owns ? $source : $prior;
+
+            // a hand-bound value claims nothing, so there is no second
+            // claimant to record: null in bind_shared would name a clause
+            // that does not exist. Nothing reads it as one today, since
+            // removeBindSources() asks isset() and a null entry answers the
+            // same as an absent one -- this keeps the list honest rather
+            // than fixing a behaviour, and is why no test can tell.
+            if ($sharer !== null && $sharer !== $owner) {
                 $shared = isset($this->bind_shared[$name])
                     ? $this->bind_shared[$name]
                     : null;
-                if ($shared !== null && $shared !== $source) {
-                    $this->throwCollision($name, $shared, $source);
+                if ($shared !== null && $shared !== $sharer) {
+                    $this->throwCollision($name, $shared, $sharer);
                 }
-                $this->bind_shared[$name] = $source;
+
+                $this->bind_shared[$name] = $sharer;
             }
+
+            // the owner may be the source arriving now, when a clause held
+            // the name first and a CTE has come for it: the CTE is the SQL
+            // that outlives the clause, so the claim passes to it and the
+            // clause becomes the sharer recorded above.
+            $this->bind_sources[$name] = $owner;
             return $this;
         }
 

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -23,6 +23,7 @@ class Select extends AbstractQuery implements SelectInterface
     use WhereTrait;
     use TableListTrait;
     use LimitOffsetTrait { limit as setLimit; offset as setOffset; }
+    use WithTrait;
 
     /**
      *
@@ -161,6 +162,14 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function getStatement()
     {
+        // the WITH clause belongs to the statement, not to a branch of it:
+        // it is written once, at the top, and every branch of the union
+        // below may name the CTEs it defines. It is prefixed here rather
+        // than in build() for that reason, and because build() is what the
+        // dialects post-process -- SQL Server injects its TOP by matching
+        // SELECT at the head of the string a branch renders to.
+        $with = $this->builder->buildWith($this->with, $this->with_recursive);
+
         $union = '';
         if (! empty($this->union)) {
             $union = implode(PHP_EOL, $this->union) . PHP_EOL;
@@ -168,10 +177,10 @@ class Select extends AbstractQuery implements SelectInterface
 
         if ($this->union_tail !== null) {
             $this->assertNoBranchAfterUnionTail();
-            return $union . $this->union_tail;
+            return $with . $union . $this->union_tail;
         }
 
-        return $union . $this->build();
+        return $with . $union . $this->build();
     }
 
     /**
@@ -951,6 +960,18 @@ class Select extends AbstractQuery implements SelectInterface
             );
         }
 
+        // a branch cannot bring a WITH clause of its own: the clause opens a
+        // statement and there is no statement here for it to open, so it
+        // would render as `UNION WITH ... SELECT`, which no dialect reads.
+        // The CTE goes on the query the union belongs to, where every branch
+        // may name it.
+        if ($select instanceof WithInterface && $select->hasWith()) {
+            throw new LogicException(
+                'The query passed to union() defines its own WITH clause; '
+                . 'define the CTE on the query the union belongs to instead.'
+            );
+        }
+
         $branch = $select === null ? null : $select->getStatement();
 
         // the branch being closed is the supplied one when there is one, and
@@ -1026,6 +1047,26 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function resetAfterRendering()
     {
+        // A CTE belongs to the statement rather than to the branch, so its
+        // claims outlive the branch this call renders, and they are not
+        // among what the scan below can find: a CTE's SQL is written at the
+        // top of the statement, not into $this->union. Rebuilt from nothing,
+        // every name a CTE binds would be handed back, and the next branch
+        // could then bind one to a value of its own with nothing to report
+        // the clash -- the CTE running against the wrong data, which is the
+        // silent overwrite this method exists to prevent.
+        //
+        // A CTE holding a name as the second claimant counts the same. The
+        // shared list is cleared below, so a CTE sharing a name with the
+        // union -- both wanting the one tenant id -- would otherwise have
+        // nothing left recording its claim at all.
+        $with_names = array_keys($this->bind_sources, 'with', true);
+        foreach ($this->bind_shared as $shared_name => $shared_source) {
+            if ($shared_source === 'with') {
+                $with_names[] = $shared_name;
+            }
+        }
+
         $this->reset();
 
         // a name inside a string literal, a comment, or a quoted identifier
@@ -1060,10 +1101,26 @@ class Select extends AbstractQuery implements SelectInterface
             }
         }
 
-        // every name now belongs to the union, including any a clause of the
-        // branch just rendered was sharing: that clause is SQL now, so there
-        // is no live claimant left to hand a name back to.
+        // every name now belongs to the union or to a CTE, including any a
+        // clause of the branch just rendered was sharing: that clause is SQL
+        // now, so there is no live claimant left to hand a name back to.
         $this->bind_shared = array();
+
+        // put the CTEs' claims back after the union's. A name only a CTE
+        // binds passes to it outright; one the union spells as well is held
+        // by both, and recording the CTE as the second claimant is what lets
+        // either reset hand the name to the other. Overwriting the union's
+        // claim instead would leave resetWith() freeing a name the retained
+        // branch still binds -- the same silent overwrite, the other way
+        // round.
+        foreach ($with_names as $name) {
+            if (isset($this->bind_sources[$name])) {
+                $this->bind_shared[$name] = 'with';
+                continue;
+            }
+
+            $this->bind_sources[$name] = 'with';
+        }
     }
 
     /**

--- a/src/Common/SelectBuilder.php
+++ b/src/Common/SelectBuilder.php
@@ -118,4 +118,40 @@ class SelectBuilder extends AbstractBuilder
 
         return PHP_EOL . 'FOR UPDATE';
     }
+
+    /**
+     *
+     * Builds the WITH clause.
+     *
+     * @param array $with The CTE elements.
+     *
+     * @param bool $recursive True if recursive, false if not.
+     *
+     * @return string
+     *
+     */
+    public function buildWith(array $with, $recursive = false)
+    {
+        if (empty($with)) {
+            return ''; // not applicable
+        }
+
+        $keyword = $recursive && $this->allowsRecursiveKeyword()
+            ? 'WITH RECURSIVE'
+            : 'WITH';
+
+        return $keyword . ' ' . implode(',' . PHP_EOL, $with) . PHP_EOL;
+    }
+
+    /**
+     *
+     * Does this dialect allow the RECURSIVE keyword in WITH?
+     *
+     * @return bool
+     *
+     */
+    protected function allowsRecursiveKeyword()
+    {
+        return true;
+    }
 }

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -17,7 +17,7 @@ use Aura\SqlQuery\QueryInterface;
  * @package Aura.SqlQuery
  *
  */
-interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterface, LimitOffsetInterface
+interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterface, LimitOffsetInterface, WithInterface
 {
     /**
      *

--- a/src/Common/WithInterface.php
+++ b/src/Common/WithInterface.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+/**
+ *
+ * An interface for WITH clauses.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+interface WithInterface
+{
+    /**
+     *
+     * Adds a common table expression (CTE) to the query.
+     *
+     * @param string $name The CTE name.
+     *
+     * @param string|SelectInterface $spec The CTE specification.
+     *
+     * @param array $cols Optional column list for the CTE.
+     *
+     * @return $this
+     *
+     */
+    public function with($name, $spec, array $cols = array());
+
+    /**
+     *
+     * Adds a recursive common table expression (CTE) to the query.
+     *
+     * @param string $name The CTE name.
+     *
+     * @param string|SelectInterface $spec The CTE specification.
+     *
+     * @param array $cols Optional column list for the CTE.
+     *
+     * @return $this
+     *
+     */
+    public function withRecursive($name, $spec, array $cols = array());
+
+    /**
+     *
+     * Does the query define any common table expressions?
+     *
+     * @return bool
+     *
+     */
+    public function hasWith();
+
+    /**
+     *
+     * Resets the WITH clause.
+     *
+     * @return $this
+     *
+     */
+    public function resetWith();
+}

--- a/src/Common/WithTrait.php
+++ b/src/Common/WithTrait.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Common;
+
+use Aura\SqlQuery\Exception\InvalidArgumentException;
+use Aura\SqlQuery\Exception\LogicException;
+
+/**
+ *
+ * A trait implementing WithInterface.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait WithTrait
+{
+    /**
+     *
+     * The common table expressions, already rendered, keyed by name.
+     *
+     * @var array
+     *
+     */
+    protected $with = array();
+
+    /**
+     *
+     * Is this a recursive CTE query?
+     *
+     * @var bool
+     *
+     */
+    protected $with_recursive = false;
+
+    /**
+     *
+     * Renders a sub-SELECT and takes over the values it bound.
+     *
+     * Declared here because it is not part of AbstractQuery: it belongs to
+     * Select, which is the only query this trait can be mixed into today.
+     * Using the trait on a query without it is a fatal error at the call
+     * rather than a silent one, and adding CTEs to INSERT, UPDATE or DELETE
+     * means giving them this first.
+     *
+     * @param string|SelectInterface $spec A sub-SELECT specification.
+     *
+     * @param string $indent Indent each line with this string.
+     *
+     * @param string $source The part of this query the sub-select is being
+     * rendered into, which claims the names it binds.
+     *
+     * @return string
+     *
+     */
+    abstract protected function subSelect($spec, $indent, $source = 'table');
+
+    /**
+     *
+     * Adds a common table expression (CTE) to the query.
+     *
+     * The CTE is rendered on the spot rather than kept as an object, as a
+     * union branch is and for the same reason: it is a second query with a
+     * life of its own, and holding it would have edits made to it after this
+     * call reach back into a statement it was only ever added to once.
+     *
+     * The names it binds pass to 'with', which belongs to the statement
+     * rather than to any one clause of it -- a CTE is written once at the
+     * top and every branch of a union below may name it.
+     *
+     * @param string $name The CTE name.
+     *
+     * @param string|SelectInterface $spec The CTE specification.
+     *
+     * @param array $cols Optional column list for the CTE.
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException when the CTE has no name.
+     *
+     * @throws LogicException when handed this very query, or when the name
+     * is already taken.
+     *
+     */
+    public function with($name, $spec, array $cols = array())
+    {
+        // a query cannot be a CTE of itself: it would have to be rendered
+        // into the clause at the moment it must stand apart from it. The
+        // recursion a CTE does allow is written inside the sub-select, by
+        // naming the CTE in its own FROM; a clone is what this asks for.
+        if ($spec === $this) {
+            throw new LogicException(
+                'Cannot use a query as a CTE of itself; pass a clone of it instead.'
+            );
+        }
+
+        $name = trim((string) $name);
+        if ($name === '') {
+            throw new InvalidArgumentException('with() requires a CTE name.');
+        }
+
+        // a repeated name is not two CTEs: the statement can only mean one
+        // of them and SQL does not say which, so the second would replace
+        // the first without a word.
+        if (isset($this->with[$name])) {
+            throw new LogicException(
+                "The CTE '{$name}' is already defined; use a different name, "
+                . 'or call resetWith() first.'
+            );
+        }
+
+        $head = $this->quoter->quoteName($name);
+        if (! empty($cols)) {
+            $quoted = array();
+            foreach ($cols as $col) {
+                $quoted[] = $this->quoter->quoteName($col);
+            }
+            $head .= ' (' . implode(', ', $quoted) . ')';
+        }
+
+        // the sub-select's values are taken over as it is rendered, and one
+        // of them may collide with a name a clause of this query already
+        // holds. That leaves the values bound before it claimed for a CTE
+        // this query is not going to have: names held against nothing, and
+        // placeholders reported by getBindValues() that the statement never
+        // spells. Put them back and let the collision through.
+        $bind_values = $this->bind_values;
+        $bind_sources = $this->bind_sources;
+        $bind_shared = $this->bind_shared;
+
+        try {
+            $body = $this->subSelect($spec, '    ', 'with');
+        } catch (\Exception $e) {
+            $this->bind_values = $bind_values;
+            $this->bind_sources = $bind_sources;
+            $this->bind_shared = $bind_shared;
+            throw $e;
+        }
+
+        $this->with[$name] = $head . ' AS (' . $body . ')';
+        return $this;
+    }
+
+    /**
+     *
+     * Adds a recursive common table expression (CTE) to the query.
+     *
+     * RECURSIVE is written once for the whole clause rather than per CTE,
+     * which is what standard SQL spells: `WITH RECURSIVE a AS (...), b AS
+     * (...)`, where a non-recursive member is still legal. So one recursive
+     * CTE makes the clause recursive and the others are unaffected.
+     *
+     * @param string $name The CTE name.
+     *
+     * @param string|SelectInterface $spec The CTE specification.
+     *
+     * @param array $cols Optional column list for the CTE.
+     *
+     * @return $this
+     *
+     */
+    public function withRecursive($name, $spec, array $cols = array())
+    {
+        // added first, so that a CTE that cannot render leaves the clause as
+        // it was rather than marking it recursive on the way to throwing.
+        $this->with($name, $spec, $cols);
+        $this->with_recursive = true;
+        return $this;
+    }
+
+    /**
+     *
+     * Does the query define any common table expressions?
+     *
+     * @return bool
+     *
+     */
+    public function hasWith()
+    {
+        return (bool) $this->with;
+    }
+
+    /**
+     *
+     * Resets the WITH clause.
+     *
+     * @return $this
+     *
+     */
+    public function resetWith()
+    {
+        $this->with = array();
+        $this->with_recursive = false;
+
+        // the CTEs are gone, so nothing binds their placeholders any more:
+        // release the names they were holding. A name a clause is sharing
+        // passes to that clause rather than being freed.
+        $this->removeBindSources('with');
+        return $this;
+    }
+}

--- a/src/Sqlsrv/SelectBuilder.php
+++ b/src/Sqlsrv/SelectBuilder.php
@@ -71,4 +71,16 @@ class SelectBuilder extends Common\SelectBuilder
         return $stm . PHP_EOL . "OFFSET {$offset} ROWS "
                     . "FETCH NEXT {$limit} ROWS ONLY";
     }
+
+    /**
+     *
+     * SQL Server does not support the RECURSIVE keyword in CTE.
+     *
+     * @return bool
+     *
+     */
+    protected function allowsRecursiveKeyword()
+    {
+        return false;
+    }
 }

--- a/tests/CollisionTest.php
+++ b/tests/CollisionTest.php
@@ -1178,4 +1178,288 @@ class CollisionTest extends TestCase
             $insert->getBindValues()
         );
     }
+
+    /**
+     *
+     * A union added after a CTE must keep the CTE's claims. If a subsequent
+     * clause or branch tries to rebind one to a different value, it must throw
+     * a collision.
+     *
+     */
+    public function testUnionAfterWithKeepsCteClaimsAndThrowsOnConflict()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->with('cte', $sub);
+
+        // Render the CTE branch into a union branch
+        $select->cols(['*'])->from('cte')->union();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->cols(['*'])->from('t2')->where('id = :id', ['id' => 2]);
+    }
+
+    /**
+     *
+     * A CTE's claim belongs to the statement, not to a branch. So resetting
+     * unions must not free a CTE's name, but resetWith() must.
+     *
+     */
+    public function testCteClaimsSurviveResetUnionsButResetWithFreesThem()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->with('cte', $sub);
+
+        // Render the CTE branch into a union branch
+        $select->cols(['*'])->from('cte')->union();
+
+        // Reset unions
+        $select->resetUnions();
+
+        // The CTE's claim on :id should still be active, so a conflicting rebind throws
+        try {
+            $select->where('id = :id', ['id' => 2]);
+            $this->fail('Expected collision since CTE claim should survive resetUnions()');
+        } catch (Exception\LogicException $e) {
+            // expected
+        }
+
+        // Reset with
+        $select->resetWith();
+
+        // Now we should be able to bind it to a different value without collision
+        $select->where('id = :id', ['id' => 2]);
+        $this->assertSame(['id' => 2], $select->getBindValues());
+    }
+
+    /**
+     *
+     * A rendered branch may spell a name the CTE binds, when a clause of that
+     * branch was sharing it. The CTE is the live claimant, so the name must
+     * come out of the reset labelled 'with' rather than 'union': labelled the
+     * other way, resetUnions() frees a name the CTE still binds, and the next
+     * clause may then bind it to a value of its own with nothing to report
+     * the clash. This is what fixes the order the claims are restored in.
+     *
+     */
+    public function testCteKeepsAClaimARenderedBranchAlsoSpells()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->with('cte', $sub)
+               ->cols(['*'])
+               ->from('cte')
+               ->where('id = :id', ['id' => 1])
+               ->union()
+               ->cols(['*'])
+               ->from('t2');
+
+        // the union is gone; the CTE is not, and it still binds :id
+        $select->resetUnions();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = :id', ['id' => 2]);
+    }
+
+    /**
+     *
+     * The union may hold a name a CTE only shares. The shared list does not
+     * survive the render, so a CTE recorded there and nowhere else would come
+     * out of the next union() holding nothing, and the branch after that
+     * could rebind the name the CTE is still spelling.
+     *
+     */
+    public function testCteKeepsAClaimItOnlySharesWithTheUnion()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(['*'])->from('a')->where('id = :id', ['id' => 1])->union();
+
+        // the union holds :id already, so the CTE comes in as the sharer
+        $select->with('cte', $sub);
+
+        $select->cols(['*'])->from('b')->union();
+        $select->resetUnions();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = :id', ['id' => 999]);
+    }
+
+    /**
+     *
+     * And the mirror: a name the CTE holds which a rendered branch also
+     * spells belongs to both, so resetWith() hands it to the union rather
+     * than freeing it. Freed, the branch would go on reading a placeholder
+     * the next clause is at liberty to rebind.
+     *
+     */
+    public function testResetWithHandsBackANameARenderedBranchSpells()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->with('cte', $sub)
+               ->cols(['*'])
+               ->from('cte')
+               ->where('id = :id', ['id' => 1])
+               ->union()
+               ->cols(['*'])
+               ->from('t2');
+
+        // the CTE is gone, but the branch retained above still spells :id
+        $select->resetWith();
+
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = :id', ['id' => 777]);
+    }
+
+    /**
+     *
+     * An outer clause reusing a CTE name with the same value is allowed,
+     * but reusing it with a different value throws.
+     *
+     */
+    public function testOuterClauseReusingCteNameSameValueAllowedDifferentValueThrows()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->with('cte', $sub);
+
+        // Same value is allowed
+        $select->where('id = :id', ['id' => 1]);
+
+        // Different value throws
+        $select2 = $this->query_factory->newSelect();
+        $select2->with('cte', $sub);
+
+        $this->expectException(Exception\LogicException::class);
+        $select2->where('id = :id', ['id' => 2]);
+    }
+
+    /**
+     *
+     * union() reaches the sharing rule only ever holding the name itself:
+     * addUnion() renders the branch being closed and re-reads the claims from
+     * that SQL before the supplied branch's values are bound, so a clause's
+     * claim has already passed to the union by then. The CTE rule added
+     * beside this one therefore leaves union() where it was; this pins that,
+     * since the two are read in one place and it would be easy to widen the
+     * wrong one.
+     *
+     */
+    public function testUnionKeepsItsOwnSharingRule()
+    {
+        $branch = $this->query_factory->newSelect();
+        $branch->cols(['*'])->from('b')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->cols(['*'])->from('a')->where('id = :id', ['id' => 1]);
+        $select->union($branch);
+
+        $this->assertSame(['id' => 1], $select->getBindValues());
+
+        // the union holds the name, so a branch wanting a different value for
+        // it is still caught
+        $this->expectException(Exception\LogicException::class);
+        $select->where('id = :id', ['id' => 2]);
+    }
+
+    /**
+     *
+     * A hand-bound value claims nothing, so a CTE asking for the same name
+     * and value takes the claim and records no second claimant. Recording
+     * one would put a name in the shared list that no clause is holding,
+     * and resetWith() would then hand the name to nobody.
+     *
+     */
+    public function testCteTakesTheClaimOnAHandBoundName()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 5]);
+
+        $select = $this->query_factory->newSelect();
+        $select->bindValue('id', 5);
+        $select->with('cte', $sub);
+
+        // the CTE holds it now, so a clause wanting a different value throws
+        try {
+            $select->where('id = :id', ['id' => 6]);
+            $this->fail('Expected the CTE to hold the placeholder name.');
+        } catch (Exception\LogicException $e) {
+            $this->assertStringContainsString("':id'", $e->getMessage());
+            $this->assertStringContainsString('common table expression', $e->getMessage());
+        }
+
+        // and once the CTE is gone the name is free again, rather than being
+        // handed to a sharer that was never there
+        $select->resetWith();
+        $select->where('id = :id', ['id' => 6]);
+        $this->assertSame(['id' => 6], $select->getBindValues());
+    }
+
+    /**
+     *
+     * resetWith() hands a shared name over to the WHERE clause sharing it,
+     * so that resetting the CTE does not release the name when the WHERE is
+     * still using it.
+     *
+     */
+    public function testResetWithHandsSharedNameToSharingClause()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->with('cte', $sub);
+
+        // Share the name in WHERE
+        $select->where('id = :id', ['id' => 1]);
+
+        // Reset the CTE
+        $select->resetWith();
+
+        // The WHERE still uses the name, so a conflicting rebind in HAVING should throw
+        $this->expectException(Exception\LogicException::class);
+        $select->having('id = :id', ['id' => 2]);
+    }
+
+    /**
+     *
+     * Reusing a name when the WHERE is bound first and the CTE is bound second
+     * is also allowed if values are identical.
+     *
+     */
+    public function testCteReusingOuterClauseNameSameValueAllowed()
+    {
+        $sub = $this->query_factory->newSelect();
+        $sub->cols(['c1'])->from('t1')->where('id = :id', ['id' => 1]);
+
+        $select = $this->query_factory->newSelect();
+        $select->where('id = :id', ['id' => 1]);
+
+        // Same value is allowed
+        $select->with('cte', $sub);
+
+        // Different value throws
+        $select2 = $this->query_factory->newSelect();
+        $select2->where('id = :id', ['id' => 1]);
+
+        $sub2 = $this->query_factory->newSelect();
+        $sub2->cols(['c1'])->from('t1')->where('id = :id', ['id' => 2]);
+
+        $this->expectException(Exception\LogicException::class);
+        $select2->with('cte', $sub2);
+    }
 }

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -2160,4 +2160,403 @@ class SelectTest extends AbstractQueryTest
         $actual = (string) $select->getStatement();
         $this->assertSameSql($expect, $actual);
     }
+
+    protected function withRecursiveKeyword()
+    {
+        return 'WITH RECURSIVE';
+    }
+
+    public function testWith()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query->with('cte', $sub)->cols(['*'])->from('cte');
+        $expect = '
+            WITH <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithCols()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query->with('cte', $sub, ['col1'])->cols(['*'])->from('cte');
+        $expect = '
+            WITH <<cte>> (<<col1>>) AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithMultiple()
+    {
+        $sub1 = $this->newQuery()->cols(['c1'])->from('t1');
+        $sub2 = $this->newQuery()->cols(['c2'])->from('t2');
+        $this->query
+            ->with('cte1', $sub1)
+            ->with('cte2', $sub2)
+            ->cols(['*'])
+            ->from('cte1')
+            ->join('INNER', 'cte2', 'cte1.c1 = cte2.c2');
+        $expect = '
+            WITH <<cte1>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            ),
+            <<cte2>> AS (
+                SELECT
+                    c2
+                FROM
+                    <<t2>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte1>>
+                INNER JOIN <<cte2>> ON <<cte1>>.<<c1>> = <<cte2>>.<<c2>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithRecursive()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query->withRecursive('cte', $sub)->cols(['*'])->from('cte');
+
+        $keyword = $this->withRecursiveKeyword();
+        $expect = '
+            ' . $keyword . ' <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithRecursiveAndPlainMixed()
+    {
+        $sub1 = $this->newQuery()->cols(['c1'])->from('t1');
+        $sub2 = $this->newQuery()->cols(['c2'])->from('t2');
+        $this->query
+            ->with('cte1', $sub1)
+            ->withRecursive('cte2', $sub2)
+            ->cols(['*'])
+            ->from('cte1');
+
+        $keyword = $this->withRecursiveKeyword();
+        $expect = '
+            ' . $keyword . ' <<cte1>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            ),
+            <<cte2>> AS (
+                SELECT
+                    c2
+                FROM
+                    <<t2>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte1>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithReferencingEarlierCte()
+    {
+        $sub1 = $this->newQuery()->cols(['c1'])->from('t1');
+        $sub2 = $this->newQuery()->cols(['c2'])->from('cte1');
+        $this->query
+            ->with('cte1', $sub1)
+            ->with('cte2', $sub2)
+            ->cols(['*'])
+            ->from('cte2');
+        $expect = '
+            WITH <<cte1>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            ),
+            <<cte2>> AS (
+                SELECT
+                    c2
+                FROM
+                    <<cte1>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte2>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithRawStringSpec()
+    {
+        $this->query->with('cte', 'SELECT c1 FROM t1')->cols(['*'])->from('cte');
+        $expect = '
+            WITH <<cte>> AS (
+                SELECT c1 FROM t1
+            )
+            SELECT
+                *
+            FROM
+                <<cte>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithIdempotent()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query->with('cte', $sub)->cols(['*'])->from('cte');
+        $stmt1 = $this->query->getStatement();
+        $stmt2 = $this->query->getStatement();
+        $this->assertSame($stmt1, $stmt2);
+    }
+
+    public function testWithSubSelectHasUnion()
+    {
+        $sub1 = $this->newQuery()->cols(['c1'])->from('t1');
+        $sub2 = $this->newQuery()->cols(['c2'])->from('t2');
+        $sub1->union($sub2);
+
+        $this->query->with('cte', $sub1)->cols(['*'])->from('cte');
+
+        $expect = '
+            WITH <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+                UNION
+                SELECT
+                    c2
+                FROM
+                    <<t2>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithEmptyName()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->expectException('Aura\SqlQuery\Exception\InvalidArgumentException');
+        $this->query->with('', $sub);
+    }
+
+    public function testWithDuplicateName()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query->with('cte', $sub);
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->query->with('cte', $sub);
+    }
+
+    public function testWithSelfCte()
+    {
+        // the query has columns, so it would render if the guard were gone;
+        // without them it throws 'No columns in the SELECT' instead, and the
+        // test passes whether the guard is there or not.
+        $this->query->cols(['c1'])->from('t1');
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('Cannot use a query as a CTE of itself');
+        $this->query->with('cte', $this->query);
+    }
+
+    /**
+     *
+     * A CTE is statement-level, so it survives the reset union() performs to
+     * open the next branch, and is written once above the whole union.
+     *
+     */
+    public function testWithThenUnion()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query
+            ->with('cte', $sub)
+            ->cols(['*'])
+            ->from('cte')
+            ->union()
+            ->cols(['*'])
+            ->from('t2');
+        $expect = '
+            WITH <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte>>
+            UNION
+            SELECT
+                *
+            FROM
+                <<t2>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    /**
+     *
+     * A CTE added after a branch was supplied whole is not a further branch:
+     * it is the clause the whole union sits under, and it has somewhere to
+     * render. See assertNoBranchAfterUnionTail().
+     *
+     */
+    public function testWithAfterSuppliedUnionTail()
+    {
+        $branch = $this->newQuery()->cols(['c2'])->from('t2');
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+
+        $this->query->cols(['*'])->from('cte')->union($branch);
+        $this->query->with('cte', $sub);
+
+        $expect = '
+            WITH <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            SELECT
+                *
+            FROM
+                <<cte>>
+            UNION
+            SELECT
+                c2
+            FROM
+                <<t2>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testResetWith()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query->with('cte', $sub)->cols(['*'])->from('cte');
+        $this->query->resetWith();
+
+        $expect = '
+            SELECT
+                *
+            FROM
+                <<cte>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    /**
+     *
+     * resetWith() clears the recursive flag along with the CTEs, so the next
+     * clause built on the query is not silently made recursive -- which SQL
+     * Server rejects outright and the rest read as a different statement.
+     *
+     */
+    public function testResetWithClearsTheRecursiveFlag()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query->withRecursive('cte', $sub);
+        $this->query->resetWith();
+
+        $this->query->with('plain', $sub)->cols(['*'])->from('plain');
+        $expect = '
+            WITH <<plain>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            SELECT
+                *
+            FROM
+                <<plain>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    /**
+     *
+     * A WITH clause opens a statement, and a union branch is not one: the
+     * branch would render as `UNION WITH ... SELECT`, which no dialect reads.
+     *
+     */
+    public function testUnionBranchCannotBringItsOwnWith()
+    {
+        $cte = $this->newQuery()->cols(['c1'])->from('t1');
+        $branch = $this->newQuery()->with('bcte', $cte)->cols(['*'])->from('bcte');
+
+        $this->query->cols(['*'])->from('a');
+
+        $this->expectException('Aura\SqlQuery\Exception\LogicException');
+        $this->expectExceptionMessage('defines its own WITH clause');
+        $this->query->union($branch);
+    }
+
+    /**
+     *
+     * A CTE whose values collide with a clause of this query leaves nothing
+     * behind: the names it bound before the collision are released with it,
+     * rather than being held for a CTE the query does not have.
+     *
+     */
+    public function testWithLeavesNoBindsBehindWhenItThrows()
+    {
+        $sub = $this->newQuery()
+            ->cols(['c1'])
+            ->from('t1')
+            ->where('a = :a AND b = :b', ['a' => 1, 'b' => 2]);
+
+        $this->query->cols(['*'])->from('t2')->where('b = :b', ['b' => 99]);
+
+        try {
+            $this->query->with('cte', $sub);
+            $this->fail('Expected the colliding placeholder to be reported.');
+        } catch (\Aura\SqlQuery\Exception\LogicException $e) {
+            // the CTE's own :a is not left bound to a clause that never took
+            $this->assertSame(['b' => 99], $this->query->getBindValues());
+        }
+
+        // and :a is free for whatever wants it next
+        $this->query->having('a = :a', ['a' => 42]);
+        $this->assertSame(['b' => 99, 'a' => 42], $this->query->getBindValues());
+    }
 }

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -580,6 +580,56 @@ abstract class AbstractIntegrationTest extends TestCase
         $this->assertSame(['Anna', 'Clara', 'Donna'], array_column($actual, 'name'));
     }
 
+    /**
+     * A CTE against a real server: the WITH clause has to open the statement,
+     * the CTE name has to be usable as an ordinary table below it, and the
+     * value the sub-select bound has to survive the trip. See #130.
+     */
+    public function testSelectWithCte()
+    {
+        $earners = $this->query_factory->newSelect()
+            ->cols(['name', 'salary'])
+            ->from('test_employee')
+            ->where('salary >= :cutoff', ['cutoff' => 200]);
+
+        $select = $this->query_factory->newSelect()
+            ->with('well_paid', $earners)
+            ->cols(['name'])
+            ->from('well_paid')
+            ->orderBy(['name']);
+
+        $this->assertStatementContains('WITH <<well_paid>> AS (', $select);
+        $this->assertSame(['cutoff' => 200], $select->getBindValues());
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame(['Betty', 'Clara', 'Donna'], array_column($actual, 'name'));
+    }
+
+    /**
+     * A recursive CTE, which is where the dialects disagree: every server
+     * here but SQL Server wants the RECURSIVE keyword, and SQL Server rejects
+     * it. Counting to three is the smallest thing that needs the recursion,
+     * so a server that ignored the clause could not pass this.
+     */
+    public function testSelectWithRecursiveCte()
+    {
+        $counter = $this->query_factory->newSelect()
+            ->cols(['1 AS n'])
+            ->unionAll()
+            ->cols(['n + 1'])
+            ->from('counter')
+            ->where('n < :stop', ['stop' => 3]);
+
+        $select = $this->query_factory->newSelect()
+            ->withRecursive('counter', $counter, ['n'])
+            ->cols(['n'])
+            ->from('counter')
+            ->orderBy(['n']);
+
+        $actual = $this->fetchAll($select);
+        $this->assertSame([1, 2, 3], array_map('intval', array_column($actual, 'n')));
+    }
+
     public function testSelectCastExpression()
     {
         // regression for #157: the quoter must not mangle a CAST() type name

--- a/tests/Sqlsrv/SelectTest.php
+++ b/tests/Sqlsrv/SelectTest.php
@@ -51,4 +51,28 @@ class SelectTest extends Common\SelectTest
         $actual = $this->query->__toString();
         $this->assertSameSql($expect, $actual);
     }
+
+    protected function withRecursiveKeyword()
+    {
+        return 'WITH';
+    }
+
+    public function testWithLimit()
+    {
+        $sub = $this->newQuery()->cols(['c1'])->from('t1');
+        $this->query->with('cte', $sub)->cols(['*'])->from('cte')->limit(10);
+        $expect = '
+            WITH <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            SELECT TOP 10
+                *
+            FROM
+                <<cte>>
+        ';
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
 }


### PR DESCRIPTION
Adds common table expressions to SELECT, requested in #130.

```php
$select->with('well_paid', $earners)
       ->cols(['name'])
       ->from('well_paid');
```

- `with($name, $spec, $cols = [])` and `withRecursive()`; `$spec` is a Select or a raw string, rendered on the spot the way a branch passed to `union()` is.
- The clause prefixes the statement, so a union writes it once above every branch and each branch may name the CTEs.
- SQL Server infers the recursion and rejects the keyword, so `withRecursive()` writes a plain `WITH` there. The same PHP is valid on every dialect.
- `resetWith()` releases the clause and the names it claimed.

The placeholder bookkeeping is the fiddly part. A CTE belongs to the statement rather than to a branch, so its claims have to survive the reset `union()` performs — a name only the CTE holds passes to it, and one a rendered branch also spells is held by both, so either reset hands the name over instead of freeing it. Freeing it would let a later clause rebind a placeholder the retained SQL still spells, silently.

A branch passed to `union()` may not bring a `WITH` of its own; it would render as `UNION WITH ... SELECT`, so it is reported.

Covered by unit tests across all four dialects, collision tests for the bind ownership, and integration tests including a recursive CTE that counts 1→3 against a real server. Every guard was mutation-tested — deleted, with the named test confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Common Table Expressions (CTEs) in SELECT queries through `with()` and `withRecursive()`.
  * Supports multiple CTEs, column lists, raw SQL definitions, recursive queries, unions, and bound values.
  * Added `resetWith()` to clear CTE definitions.
  * Added SQL Server-specific handling for recursive CTE syntax and query limits.

* **Bug Fixes**
  * Improved placeholder collision handling across CTEs, unions, and query resets.

* **Documentation**
  * Added comprehensive CTE usage and SQL Server guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->