### PR TITLE
Document the WITH-clause throw on union()

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -900,6 +900,9 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @return $this
      *
+     * @throws LogicException when handed this very query, or a branch
+     * defining a WITH clause of its own.
+     *
      */
     public function union(?SelectInterface $select = null)
     {
@@ -915,6 +918,9 @@ class Select extends AbstractQuery implements SelectInterface
      * own; when omitted, this query is reset to build that branch itself.
      *
      * @return $this
+     *
+     * @throws LogicException when handed this very query, or a branch
+     * defining a WITH clause of its own.
      *
      */
     public function unionAll(?SelectInterface $select = null)
@@ -944,7 +950,10 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @return $this
      *
-     * @throws LogicException when handed this very query.
+     * @throws LogicException when handed this very query, or a branch
+     * defining a WITH clause of its own: the clause opens a statement and
+     * there is none here for it to open, so the CTE goes on the query the
+     * union belongs to.
      *
      */
     protected function addUnion($type, ?SelectInterface $select)

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -300,6 +300,9 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @return $this
      *
+     * @throws \Aura\SqlQuery\Exception\LogicException when handed this very
+     * query, or a branch defining a WITH clause of its own.
+     *
      */
     public function union(?SelectInterface $select = null);
 
@@ -312,6 +315,9 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * own; when omitted, this query is reset to build that branch itself.
      *
      * @return $this
+     *
+     * @throws \Aura\SqlQuery\Exception\LogicException when handed this very
+     * query, or a branch defining a WITH clause of its own.
      *
      */
     public function unionAll(?SelectInterface $select = null);


### PR DESCRIPTION
#251 made union() reject a branch that defines its own WITH clause, but no docblock said so: addUnion() still listed only the self-union throw, and union()/unionAll() had no @throws at all.

Adds it to both, and to SelectInterface, which is what an implementer reads. Docblocks only -- no behavior change; CHANGELOG already documents the throw.

Verified: 1303 unit, 132 integration, 24 doc examples, PHPStan clean.