### PR TITLE
Use short array syntax in src

### DIFF
--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -25,7 +25,7 @@ abstract class AbstractDmlQuery extends AbstractQuery
      * @param array
      *
      */
-    protected $col_values = array();
+    protected $col_values = [];
 
     /**
      *

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -28,7 +28,7 @@ abstract class AbstractQuery
      * @var array
      *
      */
-    protected $bind_values = array();
+    protected $bind_values = [];
 
     /**
      *
@@ -38,7 +38,7 @@ abstract class AbstractQuery
      * @var array
      *
      */
-    protected $bind_sources = array();
+    protected $bind_sources = [];
 
     /**
      *
@@ -50,7 +50,7 @@ abstract class AbstractQuery
      * @var array
      *
      */
-    protected $bind_shared = array();
+    protected $bind_shared = [];
 
     /**
      *
@@ -59,7 +59,7 @@ abstract class AbstractQuery
      * @var array
      *
      */
-    protected $bind_source_labels = array(
+    protected $bind_source_labels = [
         'col' => 'cols()',
         'cond' => 'a condition',
         'where' => 'a WHERE condition',
@@ -71,7 +71,7 @@ abstract class AbstractQuery
         'conflict' => 'doUpdateCol()',
         'duplicate_key' => 'onDuplicateKeyUpdateCol()',
         'bulk_col' => 'a bulk-insert row',
-    );
+    ];
 
     /**
      *
@@ -80,7 +80,7 @@ abstract class AbstractQuery
      * @var array
      *
      */
-    protected $where = array();
+    protected $where = [];
 
     /**
      *
@@ -89,7 +89,7 @@ abstract class AbstractQuery
      * @var array
      *
      */
-    protected $order_by = array();
+    protected $order_by = [];
 
     /**
      *
@@ -98,7 +98,7 @@ abstract class AbstractQuery
      * @var array
      *
      */
-    protected $flags = array();
+    protected $flags = [];
 
     /**
      *
@@ -287,7 +287,7 @@ abstract class AbstractQuery
         // must be the one holding the name first. Widening that is a change
         // to how union() behaves, wanted or not, and it belongs to union
         // rather than to the clause being added here.
-        $prior_owns = in_array($prior, array('union', 'with'), true);
+        $prior_owns = in_array($prior, ['union', 'with'], true);
         $source_owns = $source === 'with';
 
         if (
@@ -460,9 +460,9 @@ abstract class AbstractQuery
      */
     public function resetBindValues()
     {
-        $this->bind_values = array();
-        $this->bind_sources = array();
-        $this->bind_shared = array();
+        $this->bind_values = [];
+        $this->bind_sources = [];
+        $this->bind_shared = [];
         return $this;
     }
 
@@ -553,7 +553,7 @@ abstract class AbstractQuery
      */
     public function resetFlags()
     {
-        $this->flags = array();
+        $this->flags = [];
         return $this;
     }
 

--- a/src/Common/BuildOnConflictTrait.php
+++ b/src/Common/BuildOnConflictTrait.php
@@ -72,7 +72,7 @@ trait BuildOnConflictTrait
      */
     protected function buildConflictUpdateValues(array $update_values)
     {
-        $values = array();
+        $values = [];
         foreach ($update_values as $key => $row) {
             $values[] = $key . ' = ' . $row;
         }

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -67,7 +67,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * @var array
      *
      */
-    protected $col_values_bulk = array();
+    protected $col_values_bulk = [];
 
     /**
      *
@@ -76,7 +76,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * @var array
      *
      */
-    protected $bind_values_bulk = array();
+    protected $bind_values_bulk = [];
 
     /**
      *
@@ -88,7 +88,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * @var array
      *
      */
-    protected $bind_sources_bulk = array();
+    protected $bind_sources_bulk = [];
 
     /**
      *
@@ -98,7 +98,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * @var array
      *
      */
-    protected $col_order = array();
+    protected $col_order = [];
 
     /**
      *
@@ -288,7 +288,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * @return $this
      *
      */
-    public function addRow(array $cols = array())
+    public function addRow(array $cols = [])
     {
         if (empty($this->col_values)) {
             return $this->cols($cols);
@@ -440,7 +440,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
             }
         }
 
-        $this->col_values = array();
+        $this->col_values = [];
     }
 
     /**
@@ -521,8 +521,8 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      */
     public function resetBindValues()
     {
-        $this->bind_values_bulk = array();
-        $this->bind_sources_bulk = array();
+        $this->bind_values_bulk = [];
+        $this->bind_sources_bulk = [];
         return parent::resetBindValues();
     }
 

--- a/src/Common/InsertBuilder.php
+++ b/src/Common/InsertBuilder.php
@@ -69,7 +69,7 @@ class InsertBuilder extends AbstractBuilder
     public function buildValuesForBulkInsert(array $col_order, array $col_values_bulk)
     {
         $cols = "    (" . implode(', ', $col_order) . ")";
-        $vals = array();
+        $vals = [];
         foreach ($col_values_bulk as $row_values) {
             $vals[] = "    (" . implode(', ', $row_values) . ")";
         }

--- a/src/Common/InsertInterface.php
+++ b/src/Common/InsertInterface.php
@@ -81,5 +81,5 @@ interface InsertInterface extends QueryInterface, ValuesInterface
      * @return $this
      *
      */
-    public function addRow(array $cols = array());
+    public function addRow(array $cols = []);
 }

--- a/src/Common/OnConflictUpdateTrait.php
+++ b/src/Common/OnConflictUpdateTrait.php
@@ -71,7 +71,7 @@ trait OnConflictUpdateTrait
     public function onConflict($target)
     {
         if (is_array($target)) {
-            $cols = array();
+            $cols = [];
             foreach ($target as $col) {
                 $cols[] = $this->quoter->quoteName($this->assertConflictName($col));
             }

--- a/src/Common/Quoter.php
+++ b/src/Common/Quoter.php
@@ -94,7 +94,7 @@ class Quoter implements QuoterInterface
             return $spec;
         }
 
-        $seps = array(' AS ', ' ', '.');
+        $seps = [' AS ', ' ', '.'];
         foreach ($seps as $sep) {
             $pos = strripos($spec, $sep);
             if ($pos) {

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -32,7 +32,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @var array
      *
      */
-    protected $union = array();
+    protected $union = [];
 
     /**
      *
@@ -79,7 +79,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @var array
      *
      */
-    protected $cols = array();
+    protected $cols = [];
 
     /**
      *
@@ -88,7 +88,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @var array
      *
      */
-    protected $from = array();
+    protected $from = [];
 
     /**
      *
@@ -106,7 +106,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @var array
      *
      */
-    protected $join = array();
+    protected $join = [];
 
     /**
      *
@@ -115,7 +115,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @var array
      *
      */
-    protected $group_by = array();
+    protected $group_by = [];
 
     /**
      *
@@ -124,7 +124,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @var array
      *
      */
-    protected $having = array();
+    protected $having = [];
 
     /**
      *
@@ -151,7 +151,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @var array
      *
      */
-    protected $table_refs = array();
+    protected $table_refs = [];
 
     /**
      *
@@ -553,7 +553,7 @@ class Select extends AbstractQuery implements SelectInterface
 
         // an empty spec is nobody's list; leave it to quoteName() as before
         if (empty($names)) {
-            $names = array($spec);
+            $names = [$spec];
         }
 
         foreach ($names as $name) {
@@ -591,7 +591,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function addFrom($spec)
     {
-        $this->from[] = array($spec);
+        $this->from[] = [$spec];
         $this->from_key ++;
         return $this;
     }
@@ -659,7 +659,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws LogicException
      *
      */
-    public function join($join, $spec, $cond = null, array $bind = array())
+    public function join($join, $spec, $cond = null, array $bind = [])
     {
         $join = strtoupper(ltrim("$join JOIN"));
         $this->addTableRef($join, $spec);
@@ -716,7 +716,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws LogicException
      *
      */
-    public function innerJoin($spec, $cond = null, array $bind = array())
+    public function innerJoin($spec, $cond = null, array $bind = [])
     {
         return $this->join('INNER', $spec, $cond, $bind);
     }
@@ -736,7 +736,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws LogicException
      *
      */
-    public function leftJoin($spec, $cond = null, array $bind = array())
+    public function leftJoin($spec, $cond = null, array $bind = [])
     {
         return $this->join('LEFT', $spec, $cond, $bind);
     }
@@ -762,7 +762,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @throws LogicException
      *
      */
-    public function joinSubSelect($join, $spec, $name, $cond = null, array $bind = array())
+    public function joinSubSelect($join, $spec, $name, $cond = null, array $bind = [])
     {
         $join = strtoupper(ltrim("$join JOIN"));
         $this->addTableRef("$join (SELECT ...) AS", $name);
@@ -1097,13 +1097,13 @@ class Select extends AbstractQuery implements SelectInterface
         // placeholders between them.
         $find = "/{$this->getQuotedNamePattern()}|{$this->text_pattern}"
               . "|(?<!:):(\w+)/s";
-        $spelled = array();
+        $spelled = [];
         foreach ($this->union as $branch) {
             preg_match_all($find, $branch, $matches);
             $spelled += array_flip(array_filter($matches[1], 'strlen'));
         }
 
-        $this->bind_sources = array();
+        $this->bind_sources = [];
         foreach (array_keys($this->bind_values) as $name) {
             if (isset($spelled[$name]) || ctype_digit((string) $name)) {
                 $this->bind_sources[$name] = 'union';
@@ -1113,7 +1113,7 @@ class Select extends AbstractQuery implements SelectInterface
         // every name now belongs to the union or to a CTE, including any a
         // clause of the branch just rendered was sharing: that clause is SQL
         // now, so there is no live claimant left to hand a name back to.
-        $this->bind_shared = array();
+        $this->bind_shared = [];
 
         // put the CTEs' claims back after the union's. A name only a CTE
         // binds passes to it outright; one the union spells as well is held
@@ -1189,7 +1189,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function resetCols()
     {
-        $this->cols = array();
+        $this->cols = [];
         return $this;
     }
 
@@ -1202,10 +1202,10 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function resetTables()
     {
-        $this->from = array();
+        $this->from = [];
         $this->from_key = -1;
-        $this->join = array();
-        $this->table_refs = array();
+        $this->join = [];
+        $this->table_refs = [];
         $this->removeBindSources('join');
         $this->removeBindSources('table');
         return $this;
@@ -1220,7 +1220,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function resetWhere()
     {
-        $this->where = array();
+        $this->where = [];
         $this->removeBindSources('where');
         return $this;
     }
@@ -1234,7 +1234,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function resetGroupBy()
     {
-        $this->group_by = array();
+        $this->group_by = [];
         return $this;
     }
 
@@ -1247,7 +1247,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function resetHaving()
     {
-        $this->having = array();
+        $this->having = [];
         $this->removeBindSources('having');
         return $this;
     }
@@ -1261,7 +1261,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function resetOrderBy()
     {
-        $this->order_by = array();
+        $this->order_by = [];
         return $this;
     }
 
@@ -1274,7 +1274,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     public function resetUnions()
     {
-        $this->union = array();
+        $this->union = [];
         $this->union_tail = null;
 
         // the rendered branches are gone, so nothing binds their placeholders
@@ -1292,7 +1292,7 @@ class Select extends AbstractQuery implements SelectInterface
      */
     protected function build()
     {
-        $cols = array();
+        $cols = [];
         foreach ($this->cols as $key => $val) {
             if (is_int($key)) {
                 $cols[] = $this->quoter->quoteNamesIn($val);

--- a/src/Common/SelectBuilder.php
+++ b/src/Common/SelectBuilder.php
@@ -55,7 +55,7 @@ class SelectBuilder extends AbstractBuilder
             return ''; // not applicable
         }
 
-        $refs = array();
+        $refs = [];
         foreach ($from as $from_key => $from_val) {
             if (isset($join[$from_key])) {
                 $from_val = array_merge($from_val, $join[$from_key]);

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -193,7 +193,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * @throws \Aura\SqlQuery\Exception\LogicException
      *
      */
-    public function innerJoin($spec, $cond = null, array $bind = array());
+    public function innerJoin($spec, $cond = null, array $bind = []);
 
     /**
      *
@@ -210,7 +210,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * @throws \Aura\SqlQuery\Exception\LogicException
      *
      */
-    public function leftJoin($spec, $cond = null, array $bind = array());
+    public function leftJoin($spec, $cond = null, array $bind = []);
 
     /**
      *

--- a/src/Common/TableListTrait.php
+++ b/src/Common/TableListTrait.php
@@ -40,7 +40,7 @@ trait TableListTrait
      */
     protected function splitNamesList($spec)
     {
-        $names = array();
+        $names = [];
         $name = '';
         $closer = null;
         $len = strlen($spec);
@@ -84,7 +84,7 @@ trait TableListTrait
 
         $names[] = $name;
 
-        $list = array();
+        $list = [];
         foreach ($names as $one) {
             $one = trim($one);
             if ($one !== '') {

--- a/src/Common/UpdateBuilder.php
+++ b/src/Common/UpdateBuilder.php
@@ -42,7 +42,7 @@ class UpdateBuilder extends AbstractBuilder
      */
     public function buildValuesForUpdate(array $col_values)
     {
-        $values = array();
+        $values = [];
         foreach ($col_values as $col => $value) {
             $values[] = "{$col} = {$value}";
         }

--- a/src/Common/WithInterface.php
+++ b/src/Common/WithInterface.php
@@ -30,7 +30,7 @@ interface WithInterface
      * @return $this
      *
      */
-    public function with($name, $spec, array $cols = array());
+    public function with($name, $spec, array $cols = []);
 
     /**
      *
@@ -45,7 +45,7 @@ interface WithInterface
      * @return $this
      *
      */
-    public function withRecursive($name, $spec, array $cols = array());
+    public function withRecursive($name, $spec, array $cols = []);
 
     /**
      *

--- a/src/Common/WithTrait.php
+++ b/src/Common/WithTrait.php
@@ -27,7 +27,7 @@ trait WithTrait
      * @var array
      *
      */
-    protected $with = array();
+    protected $with = [];
 
     /**
      *
@@ -87,7 +87,7 @@ trait WithTrait
      * is already taken.
      *
      */
-    public function with($name, $spec, array $cols = array())
+    public function with($name, $spec, array $cols = [])
     {
         // a query cannot be a CTE of itself: it would have to be rendered
         // into the clause at the moment it must stand apart from it. The
@@ -116,7 +116,7 @@ trait WithTrait
 
         $head = $this->quoter->quoteName($name);
         if (! empty($cols)) {
-            $quoted = array();
+            $quoted = [];
             foreach ($cols as $col) {
                 $quoted[] = $this->quoter->quoteName($col);
             }
@@ -164,7 +164,7 @@ trait WithTrait
      * @return $this
      *
      */
-    public function withRecursive($name, $spec, array $cols = array())
+    public function withRecursive($name, $spec, array $cols = [])
     {
         // added first, so that a CTE that cannot render leaves the clause as
         // it was rather than marking it recursive on the way to throwing.
@@ -194,7 +194,7 @@ trait WithTrait
      */
     public function resetWith()
     {
-        $this->with = array();
+        $this->with = [];
         $this->with_recursive = false;
 
         // the CTEs are gone, so nothing binds their placeholders any more:

--- a/src/Mysql/InsertBuilder.php
+++ b/src/Mysql/InsertBuilder.php
@@ -55,9 +55,9 @@ class InsertBuilder extends Common\InsertBuilder
             return ''; // not applicable
         }
 
-        $values = array();
+        $values = [];
         foreach ($col_on_update_values as $key => $row) {
-            $values[] = $this->indent(array($key . ' = ' . $row));
+            $values[] = $this->indent([$key . ' = ' . $row]);
         }
 
         return ' ON DUPLICATE KEY UPDATE'

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -47,7 +47,7 @@ class QueryFactory
      * @var array
      *
      */
-    protected $last_insert_id_names = array();
+    protected $last_insert_id_names = [];
 
     /**
      *


### PR DESCRIPTION
Rewrites the 68 remaining `array()` literals in src/ to `[]`, leaving the codebase on one convention.

Done token-aware rather than by regex: only T_ARRAY followed by `(` is a literal, so `array $cols` type hints, `(array)` casts and is_array()/in_array() are untouched. Delimiters only -- no reformatting, no reflowing, so the diff is 69 insertions against 69 deletions, one line for one line.

Zero behavior change; both forms compile to the same opcode. Worth a `git blame -w` or a .git-blame-ignore-revs entry.

tests/ is a separate sweep -- 713 literals, and bundling them would bury this diff.

Verified: 1303 unit, 132 integration, 24 doc examples, PHPStan clean -- all identical counts to 6.x before the change.