### PR TITLE
Ignore the formatting-only sweeps in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Commits that changed formatting only, and so should not be blamed for the
+# lines they touched. See CONTRIBUTING.md for how to make git use this file.
+
+# Use short array syntax in src
+8966e329e35bbff966ebc387264b796e6bfca8e4
+
+# Use short array syntax in tests
+dfdc144a84248a0a9ea95207198741159857310a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,27 @@ The time between submitting a contribution and its review one may be extensive; 
 
 Thanks!
 
+## Ignoring formatting-only commits in `git blame`
+
+A commit that only reformats code — converting `array()` to `[]`, say — still
+touches every line it rewrites, so `git blame` credits it for lines whose author
+and reason lie further back. `.git-blame-ignore-revs` lists those commits, and
+blame looks through them to the change that actually mattered.
+
+GitHub reads the file on its own. Local `git blame` needs telling once per
+clone, since this is not something a repository can configure for you:
+
+```sh
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+Add a commit to the file when it changes formatting and nothing else, with a
+comment naming it. Use the full SHA of the commit that made the change rather
+than the merge commit, and take it after the merge has landed on `6.x`: a
+revision the repository does not have is skipped in silence, so a SHA that is
+wrong, or that a squash merge replaced, leaves blame noisy with nothing to say
+so. Check an affected line with `git blame` afterwards.
+
 ## Running the tests
 
 ```sh


### PR DESCRIPTION
The two `array()` sweeps (#254, #255) rewrote 782 lines without changing
behaviour, so `git blame` now credits them for lines whose author and reason
are years older. `.git-blame-ignore-revs` lists both commits and blame looks
through them.

Before and after, on a line the tests sweep touched:

```
off: dfdc144a  Hari K T         2026-07-30   $expect = [
on:  5cad658b  Rasmus Schultz   2014-01-28   $expect = [
```

GitHub reads the file by itself. Local blame needs `git config
blame.ignoreRevsFile .git-blame-ignore-revs` once per clone, which CONTRIBUTING
now documents along with how to add future entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for excluding formatting-only commits from `git blame` results.
  * Documented how to configure Git and add formatting commit revisions for clearer change history.
  * Added references to formatting conventions in source code and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->