### PR TITLE
Correct wrong docblocks and raise PHPStan to level 3

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,9 @@
-# Start at the highest level that passes clean; raise the level as the
-# 6.x native-types work lands (level 2+ currently fails on $this->builder
-# being typed as AbstractBuilder while queries call dialect-builder methods).
+# Start at the highest level that passes clean; raise the level as the 6.x
+# typing work lands. Level 4 currently reports 8 docblocks that claim a
+# narrower type than the code accepts -- a @param string on a method that
+# tests `instanceof Closure`, and three that compare against null -- so the
+# code is right and the tags are wrong. Fixing those is the next step.
 parameters:
-    level: 1
+    level: 3
     paths:
         - src

--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -22,7 +22,7 @@ abstract class AbstractDmlQuery extends AbstractQuery
      * Column values for INSERT or UPDATE queries; the key is the column name and the
      * value is the column value.
      *
-     * @param array
+     * @var array
      *
      */
     protected $col_values = [];

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -104,7 +104,7 @@ abstract class AbstractQuery
      *
      * A helper for quoting identifier names.
      *
-     * @var Common\Quoter
+     * @var Common\QuoterInterface
      *
      */
     protected $quoter;
@@ -127,7 +127,7 @@ abstract class AbstractQuery
      *
      * Constructor.
      *
-     * @param Common\Quoter $quoter A helper for quoting identifier names.
+     * @param Common\QuoterInterface $quoter A helper for quoting identifier names.
      *
      * @param Common\AbstractBuilder $builder A builder for the query.
      *
@@ -518,7 +518,7 @@ abstract class AbstractQuery
      *
      * @param bool $enable Flag status - enabled or not (default true)
      *
-     * @return null
+     * @return void
      *
      */
     protected function setFlag($flag, $enable = true)
@@ -571,7 +571,7 @@ abstract class AbstractQuery
      *
      * @param array $bind arguments to bind to placeholders
      *
-     * @return null
+     * @return void
      *
      */
     protected function addClauseCondWithBind($clause, $andor, $cond, $bind)
@@ -607,7 +607,7 @@ abstract class AbstractQuery
      *
      * @param callable $closure The closure that adds to the clause.
      *
-     * @return null
+     * @return void
      *
      */
     protected function addClauseCondClosure($clause, $andor, $closure)

--- a/src/Common/Delete.php
+++ b/src/Common/Delete.php
@@ -21,6 +21,15 @@ use Aura\SqlQuery\Exception\LogicException;
  */
 class Delete extends AbstractDmlQuery implements DeleteInterface
 {
+    /**
+     *
+     * A builder for the query.
+     *
+     * @var DeleteBuilder
+     *
+     */
+    protected $builder;
+
     use WhereTrait;
     use TableListTrait;
 

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -23,6 +23,15 @@ class Insert extends AbstractDmlQuery implements InsertInterface
 {
     /**
      *
+     * A builder for the query.
+     *
+     * @var InsertBuilder
+     *
+     */
+    protected $builder;
+
+    /**
+     *
      * The table to insert into (quoted).
      *
      * @var string
@@ -424,7 +433,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * last row, so those names would go missing from a statement that still
      * spells them, and execute() would fail on the unbound placeholder.
      *
-     * @return null
+     * @return void
      *
      */
     protected function finishRow()

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -20,6 +20,15 @@ use Aura\SqlQuery\Exception\LogicException;
  */
 class Select extends AbstractQuery implements SelectInterface
 {
+    /**
+     *
+     * A builder for the query.
+     *
+     * @var SelectBuilder
+     *
+     */
+    protected $builder;
+
     use WhereTrait;
     use TableListTrait;
     use LimitOffsetTrait { limit as setLimit; offset as setOffset; }
@@ -67,7 +76,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Is this a SELECT FOR UPDATE?
      *
-     * @var
+     * @var bool
      *
      */
     protected $for_update = false;
@@ -336,7 +345,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @param mixed $val If $key was an integer, the column to be added;
      * otherwise, the column alias.
      *
-     * @return null
+     * @return void
      *
      */
     protected function addCol($key, $val)
@@ -356,7 +365,7 @@ class Select extends AbstractQuery implements SelectInterface
      * @param string $spec The column specification: "col alias",
      * "col AS alias", or something else entirely.
      *
-     * @return null
+     * @return void
      *
      */
     protected function addColWithAlias($spec)
@@ -510,7 +519,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string $spec The table and alias name.
      *
-     * @return null
+     * @return void
      *
      * @throws LogicException when the reference has already been used.
      *
@@ -865,7 +874,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Updates the limit and offset values when changing pagination.
      *
-     * @return null
+     * @return void
      *
      */
     protected function setPagingLimitOffset()
@@ -1051,7 +1060,7 @@ class Select extends AbstractQuery implements SelectInterface
      * branch's SQL still reads `a = :a` -- the silent overwrite this whole
      * method exists to prevent, arriving one branch later.
      *
-     * @return null
+     * @return void
      *
      */
     protected function resetAfterRendering()
@@ -1162,7 +1171,7 @@ class Select extends AbstractQuery implements SelectInterface
      * Clears the current select properties; generally used after adding a
      * union.
      *
-     * @return null
+     * @return void
      *
      */
     public function reset()

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -327,7 +327,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * Clears the current select properties, usually called after a union.
      * You may need to call resetUnions() if you have used one
      *
-     * @return null
+     * @return void
      *
      */
     public function reset();

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -21,6 +21,15 @@ use Aura\SqlQuery\Exception\LogicException;
  */
 class Update extends AbstractDmlQuery implements UpdateInterface
 {
+    /**
+     *
+     * A builder for the query.
+     *
+     * @var UpdateBuilder
+     *
+     */
+    protected $builder;
+
     use TableListTrait;
 
     use WhereTrait;

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -22,6 +22,15 @@ class Insert extends Common\Insert
 {
     /**
      *
+     * A builder for the query.
+     *
+     * @var InsertBuilder
+     *
+     */
+    protected $builder;
+
+    /**
+     *
      * if true, use a REPLACE sql command instead of INSERT
      *
      * @var bool
@@ -34,7 +43,7 @@ class Insert extends Common\Insert
      * Column values for ON DUPLICATE KEY UPDATE section of query; the key is
      * the column name and the value is the column value.
      *
-     * @param array
+     * @var array|null
      *
      */
     protected $col_on_update_values;

--- a/src/Pgsql/Delete.php
+++ b/src/Pgsql/Delete.php
@@ -19,6 +19,15 @@ use Aura\SqlQuery\Common;
  */
 class Delete extends Common\Delete implements ReturningInterface
 {
+    /**
+     *
+     * A builder for the query.
+     *
+     * @var DeleteBuilder
+     *
+     */
+    protected $builder;
+
     use ReturningTrait;
 
     /**

--- a/src/Pgsql/Insert.php
+++ b/src/Pgsql/Insert.php
@@ -19,6 +19,15 @@ use Aura\SqlQuery\Common;
  */
 class Insert extends Common\Insert implements ReturningInterface, Common\OnConflictUpdateInterface
 {
+    /**
+     *
+     * A builder for the query.
+     *
+     * @var InsertBuilder
+     *
+     */
+    protected $builder;
+
     use ReturningTrait;
     use Common\OnConflictUpdateTrait;
 

--- a/src/Pgsql/Update.php
+++ b/src/Pgsql/Update.php
@@ -19,6 +19,15 @@ use Aura\SqlQuery\Common;
  */
 class Update extends Common\Update implements ReturningInterface
 {
+    /**
+     *
+     * A builder for the query.
+     *
+     * @var UpdateBuilder
+     *
+     */
+    protected $builder;
+
     use ReturningTrait;
 
     /**

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -26,7 +26,7 @@ class QueryFactory
      *
      * What database are we building for?
      *
-     * @param string
+     * @var string
      *
      */
     protected $db;
@@ -35,7 +35,7 @@ class QueryFactory
      *
      * Build "common" query objects regardless of database type?
      *
-     * @param bool
+     * @var bool
      *
      */
     protected $common = false;
@@ -53,7 +53,7 @@ class QueryFactory
      *
      * A Quoter for identifiers.
      *
-     * @param QuoterInterface
+     * @var Common\QuoterInterface|null
      *
      */
     protected $quoter;
@@ -81,7 +81,7 @@ class QueryFactory
      * @param array $last_insert_id_names A map of `table.col` names to
      * last-insert-id names.
      *
-     * @return null
+     * @return void
      *
      */
     public function setLastInsertIdNames(array $last_insert_id_names)
@@ -188,7 +188,7 @@ class QueryFactory
      *
      * Returns the Quoter object for queries; creates one if needed.
      *
-     * @return Common\Quoter
+     * @return Common\QuoterInterface
      *
      */
     protected function getQuoter()

--- a/src/Sqlite/Insert.php
+++ b/src/Sqlite/Insert.php
@@ -20,6 +20,15 @@ use Aura\SqlQuery\Exception;
  */
 class Insert extends Common\Insert implements Common\OnConflictUpdateInterface
 {
+    /**
+     *
+     * A builder for the query.
+     *
+     * @var InsertBuilder
+     *
+     */
+    protected $builder;
+
     use OrConflictTrait;
     use Common\OnConflictUpdateTrait;
 

--- a/src/Sqlsrv/Select.php
+++ b/src/Sqlsrv/Select.php
@@ -21,6 +21,15 @@ class Select extends Common\Select
 {
     /**
      *
+     * A builder for the query.
+     *
+     * @var SelectBuilder
+     *
+     */
+    protected $builder;
+
+    /**
+     *
      * Builds this query object into a string.
      *
      * @return string


### PR DESCRIPTION
First step of the 6.x typing work. No code changes and no behaviour change --
docblocks only, plus the PHPStan level.

Three kinds of tag were wrong, not merely missing:

* 12 `@return null` on methods that return nothing. `null` means "returns the
  value null", which is why PHPStan reported 16 `return.missing`; the tag is
  `@return void`.
* 6 properties documented with `@param`, or with an empty `@var`. These were
  unparseable, so every one of those properties had no type at all.
* `$quoter` documented as the concrete `Common\Quoter` in two places while the
  constructor already accepts `Common\QuoterInterface`. Nothing in src/ calls a
  method outside the interface, so the interface is the honest type.

`$builder` is redeclared with a narrowed `@var` in the 10 classes that call
their own dialect's builder methods. A `@var` rather than a native property
type on purpose: typed properties are invariant, so once the parent declares
one, a subclass cannot redeclare it at all -- narrower or untyped -- and this
narrowing becomes impossible.

That takes PHPStan from level 1 to level 3 clean. Level 4 reports 8 more
docblocks that claim a narrower type than the code accepts (a `@param string`
on a method testing `instanceof Closure`, three comparing against null); the
code is right and the tags are wrong, so that is the next PR.

Checks unchanged: 1303 unit, 132 integration, 24 doc examples. Each half was
mutation-tested by reverting it and confirming PHPStan fails again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type declarations and documentation for query builders and properties.
  * Clarified method return types and interface annotations across query components.
  * Improved support for static analysis by raising the configured analysis level.
* **Bug Fixes**
  * Replaced implicit builder properties with explicit declarations to improve reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->