### PR TITLE
Widen docblocks to the types the code accepts, and raise PHPStan to level 4

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,9 +1,33 @@
 # Start at the highest level that passes clean; raise the level as the 6.x
-# typing work lands. Level 4 currently reports 8 docblocks that claim a
-# narrower type than the code accepts -- a @param string on a method that
-# tests `instanceof Closure`, and three that compare against null -- so the
-# code is right and the tags are wrong. Fixing those is the next step.
+# typing work lands.
+#
+# Each ignore below carries a count, so it suppresses only the occurrences
+# described here: a new one anywhere in the file fails the run rather than
+# being absorbed silently.
 parameters:
-    level: 3
+    level: 4
     paths:
         - src
+    ignoreErrors:
+        # addClauseCondClosure() empties $this->$clause, hands the query to
+        # the closure, and reads the clause back to see what the closure
+        # added. PHPStan does not model mutation through the closure, so it
+        # still believes the clause is the empty array assigned above: the
+        # test reads as always true and everything after it as unreachable.
+        # The code is correct -- reachable via where(function ($q) { ... }).
+        -
+            identifier: booleanNot.alwaysTrue
+            path: src/AbstractQuery.php
+            count: 1
+        -
+            identifier: deadCode.unreachable
+            path: src/AbstractQuery.php
+            count: 1
+        # getCond() asserts the array key it was handed is an int, which PHP
+        # guarantees for array keys once the string case above has returned.
+        # Kept as a deliberate guard rather than removed; whether it costs
+        # anything at runtime depends on zend.assertions.
+        -
+            identifier: function.alreadyNarrowedType
+            path: src/AbstractQuery.php
+            count: 2

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,33 +1,11 @@
 # Start at the highest level that passes clean; raise the level as the 6.x
 # typing work lands.
 #
-# Each ignore below carries a count, so it suppresses only the occurrences
-# described here: a new one anywhere in the file fails the run rather than
-# being absorbed silently.
+# Suppressions live inline at the line they describe, not here: a file-scoped
+# ignore would also absorb an unrelated diagnostic introduced later, and the
+# messages PHPStan emits for them are identical wherever they occur, so there
+# is nothing to key a pattern on.
 parameters:
     level: 4
     paths:
         - src
-    ignoreErrors:
-        # addClauseCondClosure() empties $this->$clause, hands the query to
-        # the closure, and reads the clause back to see what the closure
-        # added. PHPStan does not model mutation through the closure, so it
-        # still believes the clause is the empty array assigned above: the
-        # test reads as always true and everything after it as unreachable.
-        # The code is correct -- reachable via where(function ($q) { ... }).
-        -
-            identifier: booleanNot.alwaysTrue
-            path: src/AbstractQuery.php
-            count: 1
-        -
-            identifier: deadCode.unreachable
-            path: src/AbstractQuery.php
-            count: 1
-        # getCond() asserts the array key it was handed is an int, which PHP
-        # guarantees for array keys once the string case above has returned.
-        # Kept as a deliberate guard rather than removed; whether it costs
-        # anything at runtime depends on zend.assertions.
-        -
-            identifier: function.alreadyNarrowedType
-            path: src/AbstractQuery.php
-            count: 2

--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -96,7 +96,7 @@ abstract class AbstractDmlQuery extends AbstractQuery
      *
      * @param string $col The column name.
      *
-     * @param string $value The column value expression.
+     * @param string|null $value The column value expression.
      *
      * @return $this
      *

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -621,7 +621,11 @@ abstract class AbstractQuery
         // invoke the closure, which will re-populate the $this->$clause
         $closure($this);
 
-        // are there new clause elements?
+        // are there new clause elements? PHPStan does not model the closure
+        // above repopulating the clause, so it still sees the empty array
+        // assigned before the call: this test reads as always true to it, and
+        // everything after it as unreachable.
+        /** @phpstan-ignore booleanNot.alwaysTrue */
         if (! $this->$clause) {
             // no: restore the old ones, and done
             $this->$clause = $set;
@@ -630,6 +634,7 @@ abstract class AbstractQuery
 
         // append an opening parenthesis to the prior set of conditions,
         // with AND/OR as needed ...
+        /** @phpstan-ignore deadCode.unreachable */
         if ($set) {
             $set[] = "{$andor} (";
         } else {
@@ -729,6 +734,10 @@ abstract class AbstractQuery
         if (is_string($key)) {
             return str_replace(':' . $key, $this->inlineArray($val), $cond);
         }
+        // a deliberate guard; PHP guarantees an int key once the string case
+        // above has returned, so PHPStan reports both the assert and the
+        // is_int() inside it as always true
+        /** @phpstan-ignore function.alreadyNarrowedType, function.alreadyNarrowedType */
         assert(is_int($key));
 
         if (preg_match_all('/\?/', $cond, $matches, PREG_OFFSET_CAPTURE) !== false) {

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -567,7 +567,7 @@ abstract class AbstractQuery
      * @param string $andor Add the condition using this operator, typically
      * 'AND' or 'OR'.
      *
-     * @param string $cond The WHERE condition.
+     * @param string|Closure $cond The WHERE condition.
      *
      * @param array $bind arguments to bind to placeholders
      *

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -221,7 +221,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * @param string $col   The column name.
      *
-     * @param string $value The column value expression.
+     * @param string|null $value The column value expression.
      *
      * @return $this
      *
@@ -394,7 +394,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * Sets a column value directly for the UPDATE on conflict.
      *
      * @param string $col
-     * @param string $value
+     * @param string|null $value
      * @throws BadMethodCallException
      * @return static
      *

--- a/src/Common/LateralJoinTrait.php
+++ b/src/Common/LateralJoinTrait.php
@@ -33,7 +33,7 @@ trait LateralJoinTrait
      *
      * @param string $name The alias name for the sub-select.
      *
-     * @param string $cond Join on this condition. A LATERAL join requires an
+     * @param string|null $cond Join on this condition. A LATERAL join requires an
      * ON clause except on the join types that forbid one, so when no
      * condition is given for the other types, "ON true" is used.
      *

--- a/src/Common/OnConflictUpdateInterface.php
+++ b/src/Common/OnConflictUpdateInterface.php
@@ -64,7 +64,7 @@ interface OnConflictUpdateInterface
      *
      * @param string $col The column name.
      *
-     * @param string $value The column value expression.
+     * @param string|null $value The column value expression.
      *
      * @return $this
      *

--- a/src/Common/OnConflictUpdateTrait.php
+++ b/src/Common/OnConflictUpdateTrait.php
@@ -194,7 +194,7 @@ trait OnConflictUpdateTrait
      *
      * @param string $col The column name.
      *
-     * @param string $value The column value expression.
+     * @param string|null $value The column value expression.
      *
      * @return $this
      *

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -659,7 +659,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @param array $bind Values to bind to ?-placeholders in the condition.
      *
@@ -683,7 +683,7 @@ class Select extends AbstractQuery implements SelectInterface
      * Fixes a JOIN condition to quote names in the condition and prefix it
      * with a condition type ('ON' is the default and 'USING' is recognized).
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @param array $bind Values to bind to ?-placeholders in the condition.
      *
@@ -716,7 +716,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @param array $bind Values to bind to ?-placeholders in the condition.
      *
@@ -736,7 +736,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @param array $bind Values to bind to ?-placeholders in the condition.
      *
@@ -762,7 +762,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string $name The alias name for the sub-select.
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @param array $bind Values to bind to ?-placeholders in the condition.
      *
@@ -822,7 +822,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Adds a HAVING condition to the query by AND.
      *
-     * @param string $cond The HAVING condition.
+     * @param string|\Closure $cond The HAVING condition.
      *
      * @param array $bind arguments to bind to placeholders
      *
@@ -839,7 +839,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Adds a HAVING condition to the query by OR.
      *
-     * @param string $cond The HAVING condition.
+     * @param string|\Closure $cond The HAVING condition.
      *
      * @param array $bind arguments to bind to placeholders
      *

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -171,7 +171,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @return $this
      *
@@ -184,7 +184,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @param array $bind Values to bind to ?-placeholders in the condition.
      *
@@ -201,7 +201,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @param string $spec The table specification; "foo" or "foo AS bar".
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @param array $bind Values to bind to ?-placeholders in the condition.
      *
@@ -224,7 +224,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @param string $name The alias name for the sub-select.
      *
-     * @param string $cond Join on this condition.
+     * @param string|null $cond Join on this condition.
      *
      * @return $this
      *
@@ -246,7 +246,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * Adds a HAVING condition to the query by AND.
      *
-     * @param string $cond The HAVING condition.
+     * @param string|\Closure $cond The HAVING condition.
      *
      * @param array $bind Values to be bound to placeholders.
      *
@@ -259,7 +259,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * Adds a HAVING condition to the query by OR.
      *
-     * @param string $cond The HAVING condition.
+     * @param string|\Closure $cond The HAVING condition.
      *
      * @param array $bind Values to be bound to placeholders.
      *

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -166,7 +166,7 @@ class Update extends AbstractDmlQuery implements UpdateInterface
      *
      * @param string $col The column name.
      *
-     * @param string $value The column value expression.
+     * @param string|null $value The column value expression.
      *
      * @return $this
      *

--- a/src/Common/ValuesInterface.php
+++ b/src/Common/ValuesInterface.php
@@ -52,7 +52,7 @@ interface ValuesInterface
      *
      * @param string $col The column name.
      *
-     * @param string $value The column value expression.
+     * @param string|null $value The column value expression.
      *
      * @return $this
      *

--- a/src/Common/WhereInterface.php
+++ b/src/Common/WhereInterface.php
@@ -23,7 +23,7 @@ interface WhereInterface
      * ?-placeholders, additional arguments to the method will be bound to
      * those placeholders sequentially.
      *
-     * @param string $cond The WHERE condition.
+     * @param string|\Closure $cond The WHERE condition.
      *
      * @param array $bind Values to be bound to placeholders.
      *
@@ -38,7 +38,7 @@ interface WhereInterface
      * ?-placeholders, additional arguments to the method will be bound to
      * those placeholders sequentially.
      *
-     * @param string $cond The WHERE condition.
+     * @param string|\Closure $cond The WHERE condition.
      *
      * @param array $bind Values to be bound to placeholders.
      *

--- a/src/Common/WhereTrait.php
+++ b/src/Common/WhereTrait.php
@@ -21,7 +21,7 @@ trait WhereTrait
      *
      * Adds a WHERE condition to the query by AND.
      *
-     * @param string $cond The WHERE condition.
+     * @param string|\Closure $cond The WHERE condition.
      *
      * @param array $bind Values to be bound to placeholders
      *
@@ -40,7 +40,7 @@ trait WhereTrait
      * ?-placeholders, additional arguments to the method will be bound to
      * those placeholders sequentially.
      *
-     * @param string $cond The WHERE condition.
+     * @param string|\Closure $cond The WHERE condition.
      *
      * @param array $bind Values to be bound to placeholders
      *

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -184,7 +184,7 @@ class Insert extends Common\Insert
      *
      * @param string $col The column name.
      *
-     * @param string $value The column value expression.
+     * @param string|null $value The column value expression.
      *
      * @return $this
      *


### PR DESCRIPTION
Follow-on to #257. Docblocks only; no code changes, no behaviour change.

Each widening was checked by building the SQL rather than read off the
signature:

    Update::set(col, null)                -> UPDATE "t" SET "c" = NULL
    Mysql onDuplicateKeyUpdate(col, null) -> ON DUPLICATE KEY UPDATE `c` = NULL
    Select::where(Closure)                -> WHERE ( x = 1 )
    Select::having(Closure)               -> HAVING ( n > 1 OR n < 0 )
    Select::leftJoin('u')                 -> LEFT JOIN "u"

So `@param string $value` becomes `string|null` where passing null renders
SQL NULL, `@param string $cond` becomes `string|Closure` on the WHERE and
HAVING family, and the 10 join conditions become `string|null` -- they
default to null and a join with no condition is a supported call.

Joins do NOT take a closure (`preg_split(): Argument #2 must be of type
string, Closure given`), so those stay `string`, not `string|Closure`. The
distinction is why each case was built rather than swept.

Level 3 -> 4, with three ignores in phpstan.neon.dist:

* `addClauseCondClosure()` empties a clause, hands the query to a closure,
  then reads the clause back. PHPStan does not model mutation through the
  closure, so it reports the test as always true and the rest as unreachable.
  The code is correct and is what makes `where(function ($q) { ... })`
  produce grouped parentheses.
* `getCond()` asserts an array key is an int, which PHP guarantees once the
  string case has returned. Kept as a deliberate guard.

Each ignore carries a `count`, so it suppresses only the occurrences it
describes -- verified by injecting an unreachable statement elsewhere in
AbstractQuery.php and confirming the run fails.

Checks unchanged: 1303 unit, 132 integration, 24 doc examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PHPDoc to reflect that condition parameters may accept strings, closures, or `null` where supported.
  * Updated value parameter documentation to allow `null`, documenting that it is represented as SQL `NULL`.
  * Improved consistency of PHPDoc across query building, joins, where clauses, insert/update, and conflict-handling APIs.
* **Chores**
  * Tweaked static analysis configuration and refined suppression/scoping notes (no runtime behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->