### PR TITLE
Filter empty placeholder captures explicitly, and raise PHPStan to level 5

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,6 @@
 # messages PHPStan emits for them are identical wherever they occur, so there
 # is nothing to key a pattern on.
 parameters:
-    level: 4
+    level: 5
     paths:
         - src

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -1109,7 +1109,7 @@ class Select extends AbstractQuery implements SelectInterface
         $spelled = [];
         foreach ($this->union as $branch) {
             preg_match_all($find, $branch, $matches);
-            $spelled += array_flip(array_filter($matches[1], 'strlen'));
+            $spelled += array_flip(array_filter($matches[1], static fn ($name) => $name !== ''));
         }
 
         $this->bind_sources = [];


### PR DESCRIPTION
The last level 5 error: `array_filter($matches[1], 'strlen')` passes a
callback returning int where a bool is expected. Replaced with an explicit
`$name !== ''`, which is what the idiom means.

The filter is there because the pattern reads past quoted names and string
literals, and those alternation branches capture nothing:

    group 1 captures for `... WHERE a = :x AND b = 'lit'`  ->  ["", "x", ""]

so `$spelled` should hold `x` alone.

No behaviour change, and checked rather than assumed. The only strings the
two spellings treat differently are `''` and `'0'`; the first is what is
being filtered out, and the second is marked union-owned by the
`ctype_digit()` clause below whether or not it survives the filter. Binding
`:0` across union branches, with agreeing and with conflicting values, gives
identical results either way, so no test is added -- one would pass against
both spellings.

Note the obvious shortening, plain `array_filter($matches[1])`, drops `'0'`
as well and only behaves the same here by coincidence.

Level 4 -> 5. Level 6 is 156 errors, 153 of them a single identifier
(`missingType.iterableValue`, every bare `array` that does not say what it
holds), which is its own piece of work.

Checks unchanged: 1303 unit, 132 integration, 24 doc examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty identifiers when processing combined query results, supporting more reliable rendering behavior.

* **Quality Improvements**
  * Strengthened automated code-quality checks to catch additional issues during development and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->