### PR TITLE
Use str_contains() and str_starts_with() for the string tests

### DIFF
--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -474,7 +474,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
         $value = $this->col_values[$col];
 
         // is it *not* a placeholder?
-        if (substr($value, 0, 1) != ':') {
+        if (! str_starts_with($value, ':')) {
             // copy the value as-is
             $this->col_values_bulk[$this->row][$col] = $value;
             return null;

--- a/src/Common/Quoter.php
+++ b/src/Common/Quoter.php
@@ -315,8 +315,8 @@ class Quoter implements QuoterInterface
      */
     protected function replaceNamesIn($text)
     {
-        $is_string_literal = strpos($text, "'") !== false
-                        || strpos($text, '"') !== false;
+        $is_string_literal = str_contains($text, "'")
+                        || str_contains($text, '"');
         if ($is_string_literal) {
             return $text;
         }


### PR DESCRIPTION
Three lines, no behaviour change. Both spellings are correct today; the
point is that the replacements cannot be got subtly wrong later.

`strpos()` returns a position, and position 0 is falsy, so dropping the
`!== false` silently inverts the test. That is not hypothetical in
`replaceNamesIn()`, whose input routinely begins with a quote:

    $sql = "'literal' AND x = 1";
    strpos($sql, "'")            -> 0
    if (strpos(...))             -> false   // misses it
    if (strpos(...) !== false)   -> true
    if (str_contains(...))       -> true

`str_contains()` returns a real bool, so the trap is gone rather than
guarded against.

The `substr($value, 0, 1) != ':'` test allocates a one-character string to
compare it, and uses a loose `!=` for what is a prefix test. `col_values`
only ever holds strings, and the two spellings agree on every input tried
(including int, `''` and a bare `':'`), so the loose comparison was never
doing anything loose.

Both lines are covered: inverting the Quoter predicate fails 8 tests,
inverting the Insert one fails 36.

Checks unchanged: 1303 unit, 132 integration, 24 doc examples, PHPStan
level 4 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of parameter placeholders during bulk data operations, helping ensure values are processed consistently.
  - Improved handling of quoted text when replacing SQL identifiers, reducing the risk of incorrect substitutions.

- **Reliability**
  - Strengthened internal query-building behavior without changing the public interface or user-facing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->