### PR TITLE
Take common table expressions on INSERT, UPDATE and DELETE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
   outside it now has four more methods to declare; extending the concrete
   query, or using Common\WithTrait, supplies them.
 
+- [BRK] AbstractQuery::getStatement() is abstract. Select and AbstractDmlQuery
+  both write clauses above the ones build() renders -- the union branches, the
+  WITH clause -- so nothing was left for the base implementation to do, and a
+  query type extending AbstractQuery directly now says how its statement is
+  assembled rather than inheriting `return $this->build();`.
+
 - [ADD] SELECT queries take common table expressions, via with() and
   withRecursive():
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## 6.0.0 (unreleased)
 
+- [ADD] INSERT, UPDATE and DELETE queries take common table expressions too,
+  via the same with() and withRecursive():
+
+        $delete->with('seniors', $seniors)
+               ->from('employee')
+               ->where('id IN (SELECT id FROM seniors)');
+
+  The clause is the one SELECT already had -- WithTrait moved up to
+  AbstractDmlQuery and buildWith() to Common\AbstractBuilder -- so a CTE
+  behaves the same wherever it is written: the sub-select is rendered on the
+  spot with the values it bound, RECURSIVE is spelled once for the clause,
+  and resetWith() releases the names.
+
+  MySQL is the one dialect that takes no WITH on INSERT: it allows a CTE only
+  inside the SELECT an `INSERT ... SELECT` draws from, which this package does
+  not build, so Mysql\Insert::with() throws BadMethodCallException rather than
+  building a statement that could only fail at execute time. UPDATE and DELETE
+  are unaffected there. SQL Server still infers the recursion and rejects the
+  keyword, so withRecursive() renders a plain WITH on all four query types.
+  Fixes #261.
+
+- [BRK] InsertInterface, UpdateInterface and DeleteInterface extend
+  WithInterface, the way SelectInterface already did. Nothing shipped by this
+  package changes hands, but an implementation of one of those interfaces
+  outside it now has four more methods to declare; extending the concrete
+  query, or using Common\WithTrait, supplies them.
+
 - [ADD] SELECT queries take common table expressions, via with() and
   withRecursive():
 

--- a/docs/delete.md
+++ b/docs/delete.md
@@ -31,3 +31,45 @@ $sth = $pdo->prepare($delete->getStatement())
 // execute with bound values
 $sth->execute($delete->getBindValues());
 ```
+
+## WITH
+
+```php
+    ->with($name, $spec, array $cols = array())  // WITH "name" AS ( ... )
+    ->withRecursive($name, $spec, array $cols = array())  // WITH RECURSIVE "name" AS ( ... )
+```
+
+A common table expression prefixes the whole statement, and the name it
+defines is used below it as an ordinary table would be -- typically in the
+`WHERE` that picks the rows to delete:
+
+```php
+$seniors = $queryFactory->newSelect()
+    ->cols(['id'])
+    ->from('employee')
+    ->where('salary >= :cutoff', ['cutoff' => 300]);
+
+$delete = $queryFactory->newDelete()
+    ->with('seniors', $seniors)
+    ->from('employee')
+    ->where('id IN (SELECT id FROM seniors)');
+```
+
+```sql
+WITH "seniors" AS (
+    SELECT
+        id
+    FROM
+        "employee"
+    WHERE
+        salary >= :cutoff
+)
+DELETE FROM "employee"
+WHERE
+    id IN (SELECT id FROM seniors)
+```
+
+The clause behaves exactly as it does on a _Select_: see [the WITH section of
+the SELECT page](select.md) for `$spec` as a string or a _Select_, several
+CTEs at once, `withRecursive()`, the placeholder names a CTE claims, and
+`resetWith()`.

--- a/docs/delete.md
+++ b/docs/delete.md
@@ -70,6 +70,7 @@ WHERE
 ```
 
 The clause behaves exactly as it does on a _Select_: see [the WITH section of
-the SELECT page](select.md) for `$spec` as a string or a _Select_, several
-CTEs at once, `withRecursive()`, the placeholder names a CTE claims, and
+the SELECT page](select.md#with) for `$spec` as a string or a _Select_, several
+CTEs at once, `withRecursive()` -- which renders a plain `WITH` on SQL Server,
+as it does for a _Select_ -- the placeholder names a CTE claims, and
 `resetWith()`.

--- a/docs/insert.md
+++ b/docs/insert.md
@@ -98,13 +98,14 @@ INSERT INTO "employee" (
 
 MySQL is the exception: it allows a CTE only inside the `SELECT` an
 `INSERT ... SELECT` draws from, which this package does not build, so
-`with()` on a MySQL _Insert_ throws
+`with()` and `withRecursive()` on a MySQL _Insert_ throw
 `Aura\SqlQuery\Exception\BadMethodCallException` rather than building a
 statement that could only fail at execute time.
 
 The clause otherwise behaves exactly as it does on a _Select_: see [the WITH
-section of the SELECT page](select.md) for `$spec` as a string or a _Select_,
-several CTEs at once, `withRecursive()`, the placeholder names a CTE claims,
+section of the SELECT page](select.md#with) for `$spec` as a string or a _Select_,
+several CTEs at once, `withRecursive()` -- which renders a plain `WITH` on SQL Server,
+as it does for a _Select_ -- the placeholder names a CTE claims,
 and `resetWith()`.
 
 ## Multiple-Row (Bulk) Insert

--- a/docs/insert.md
+++ b/docs/insert.md
@@ -54,6 +54,59 @@ $name = $insert->getLastInsertIdName('id');
 $id = $pdo->lastInsertId($name);
 ```
 
+## WITH
+
+```php
+    ->with($name, $spec, array $cols = array())  // WITH "name" AS ( ... )
+    ->withRecursive($name, $spec, array $cols = array())  // WITH RECURSIVE "name" AS ( ... )
+```
+
+A common table expression prefixes the whole statement. An _Insert_ built here
+takes `VALUES` rather than a `SELECT`, so the CTE is named from a scalar
+sub-select in one of those values:
+
+```php
+$seniors = $queryFactory->newSelect()
+    ->cols(['MAX(salary) AS top_salary'])
+    ->from('employee')
+    ->where('salary >= :cutoff', ['cutoff' => 300]);
+
+$insert = $queryFactory->newInsert()
+    ->with('seniors', $seniors)
+    ->into('employee')
+    ->cols(['name'])
+    ->set('salary', '(SELECT top_salary FROM seniors)');
+```
+
+```sql
+WITH "seniors" AS (
+    SELECT
+        MAX(salary) AS "top_salary"
+    FROM
+        "employee"
+    WHERE
+        salary >= :cutoff
+)
+INSERT INTO "employee" (
+    "name",
+    "salary"
+) VALUES (
+    :name,
+    (SELECT top_salary FROM seniors)
+)
+```
+
+MySQL is the exception: it allows a CTE only inside the `SELECT` an
+`INSERT ... SELECT` draws from, which this package does not build, so
+`with()` on a MySQL _Insert_ throws
+`Aura\SqlQuery\Exception\BadMethodCallException` rather than building a
+statement that could only fail at execute time.
+
+The clause otherwise behaves exactly as it does on a _Select_: see [the WITH
+section of the SELECT page](select.md) for `$spec` as a string or a _Select_,
+several CTEs at once, `withRecursive()`, the placeholder names a CTE claims,
+and `resetWith()`.
+
 ## Multiple-Row (Bulk) Insert
 
 If you want to do a multiple-row or bulk insert, call the `addRow()` method

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -154,6 +154,14 @@ that `onDuplicateKeyUpdateCols(['name'])` with no value emits a *new* placeholde
 for you to bind, where the `doUpdateCols(['name'])` of those dialects reuses the
 value you tried to insert.
 
+MySQL takes no `WITH` clause on INSERT: it allows a CTE only inside the
+`SELECT` an `INSERT ... SELECT` draws from, which this package does not build.
+`with()` and `withRecursive()` on a MySQL _Insert_ therefore throw
+`Aura\SqlQuery\Exception\BadMethodCallException`, rather than building a
+statement that could only fail at execute time. UPDATE and DELETE take the
+clause as the other dialects do; see [the UPDATE page](./update.md) and
+[the DELETE page](./delete.md).
+
 ## UPDATE
 
 - `lowPriority()` to add or remove `LOW_PRIORITY` flag

--- a/docs/update.md
+++ b/docs/update.md
@@ -147,3 +147,48 @@ $sth = $pdo->prepare($update->getStatement())
 // execute with bound values
 $sth->execute($update->getBindValues());
 ```
+
+## WITH
+
+```php
+    ->with($name, $spec, array $cols = array())  // WITH "name" AS ( ... )
+    ->withRecursive($name, $spec, array $cols = array())  // WITH RECURSIVE "name" AS ( ... )
+```
+
+A common table expression prefixes the whole statement, and the name it
+defines is used below it as an ordinary table would be -- typically in the
+`WHERE` that picks the rows to update:
+
+```php
+$juniors = $queryFactory->newSelect()
+    ->cols(['id'])
+    ->from('employee')
+    ->where('salary < :cutoff', ['cutoff' => 300]);
+
+$update = $queryFactory->newUpdate()
+    ->with('juniors', $juniors)
+    ->table('employee')
+    ->cols(['salary'])
+    ->where('id IN (SELECT id FROM juniors)');
+```
+
+```sql
+WITH "juniors" AS (
+    SELECT
+        id
+    FROM
+        "employee"
+    WHERE
+        salary < :cutoff
+)
+UPDATE "employee"
+SET
+    "salary" = :salary
+WHERE
+    id IN (SELECT id FROM juniors)
+```
+
+The clause behaves exactly as it does on a _Select_: see [the WITH section of
+the SELECT page](select.md) for `$spec` as a string or a _Select_, several
+CTEs at once, `withRecursive()`, the placeholder names a CTE claims, and
+`resetWith()`.

--- a/docs/update.md
+++ b/docs/update.md
@@ -189,6 +189,7 @@ WHERE
 ```
 
 The clause behaves exactly as it does on a _Select_: see [the WITH section of
-the SELECT page](select.md) for `$spec` as a string or a _Select_, several
-CTEs at once, `withRecursive()`, the placeholder names a CTE claims, and
+the SELECT page](select.md#with) for `$spec` as a string or a _Select_, several
+CTEs at once, `withRecursive()` -- which renders a plain `WITH` on SQL Server,
+as it does for a _Select_ -- the placeholder names a CTE claims, and
 `resetWith()`.

--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -8,6 +8,8 @@
  */
 namespace Aura\SqlQuery;
 
+use Aura\SqlQuery\Common\WithTrait;
+
 /**
  *
  * Abstract query object for data manipulation (Insert, Update, and Delete).
@@ -17,6 +19,8 @@ namespace Aura\SqlQuery;
  */
 abstract class AbstractDmlQuery extends AbstractQuery
 {
+    use WithTrait;
+
     /**
      *
      * Column values for INSERT or UPDATE queries; the key is the column name and the
@@ -26,6 +30,25 @@ abstract class AbstractDmlQuery extends AbstractQuery
      *
      */
     protected $col_values = [];
+
+    /**
+     *
+     * Returns this query object as an SQL statement string.
+     *
+     * The WITH clause belongs to the statement rather than to a clause of it:
+     * it is written once, at the top. It is prefixed here rather than in
+     * build() for the same reason Select does it here -- build() is what the
+     * dialects override and post-process, and each of them expects the string
+     * it produces to begin with the verb.
+     *
+     * @return string An SQL statement string.
+     *
+     */
+    public function getStatement()
+    {
+        return $this->builder->buildWith($this->with, $this->with_recursive)
+             . $this->build();
+    }
 
     /**
      *

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -154,13 +154,14 @@ abstract class AbstractQuery
      *
      * Returns this query object as an SQL statement string.
      *
+     * Left to the subclass because a statement is more than the clauses
+     * build() renders: Select writes the union branches above them, and both
+     * it and the data-modifying queries write the WITH clause above that.
+     *
      * @return string
      *
      */
-    public function getStatement()
-    {
-        return $this->build();
-    }
+    abstract public function getStatement();
 
     /**
      *

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -385,6 +385,32 @@ abstract class AbstractQuery
 
     /**
      *
+     * Formats a sub-SELECT statement, binding values from a Select object as
+     * needed.
+     *
+     * @param string|SelectInterface $spec A sub-SELECT specification.
+     *
+     * @param string $indent Indent each line with this string.
+     *
+     * @param string $source The part of this query the sub-select is being
+     * rendered into, which claims the names it binds.
+     *
+     * @return string The sub-SELECT string.
+     *
+     */
+    protected function subSelect($spec, $indent, $source = 'table')
+    {
+        if ($spec instanceof SelectInterface) {
+            $this->bindValuesFromSelect($spec, $source);
+        }
+
+        return PHP_EOL . $indent
+            . ltrim(preg_replace('/^/m', $indent, (string) $spec))
+            . PHP_EOL;
+    }
+
+    /**
+     *
      * Reports two parts of the query claiming one placeholder name.
      *
      * @param string $name The placeholder name.

--- a/src/Common/AbstractBuilder.php
+++ b/src/Common/AbstractBuilder.php
@@ -38,6 +38,42 @@ abstract class AbstractBuilder
 
     /**
      *
+     * Builds the WITH clause.
+     *
+     * @param array $with The CTE elements.
+     *
+     * @param bool $recursive True if recursive, false if not.
+     *
+     * @return string
+     *
+     */
+    public function buildWith(array $with, $recursive = false)
+    {
+        if (empty($with)) {
+            return ''; // not applicable
+        }
+
+        $keyword = $recursive && $this->allowsRecursiveKeyword()
+            ? 'WITH RECURSIVE'
+            : 'WITH';
+
+        return $keyword . ' ' . implode(',' . PHP_EOL, $with) . PHP_EOL;
+    }
+
+    /**
+     *
+     * Does this dialect allow the RECURSIVE keyword in WITH?
+     *
+     * @return bool
+     *
+     */
+    protected function allowsRecursiveKeyword()
+    {
+        return true;
+    }
+
+    /**
+     *
      * Builds the `WHERE` clause of the statement.
      *
      * @param array $where The WHERE elements.

--- a/src/Common/DeleteInterface.php
+++ b/src/Common/DeleteInterface.php
@@ -17,7 +17,7 @@ use Aura\SqlQuery\QueryInterface;
  * @package Aura.SqlQuery
  *
  */
-interface DeleteInterface extends QueryInterface, WhereInterface
+interface DeleteInterface extends QueryInterface, WhereInterface, WithInterface
 {
     /**
      *

--- a/src/Common/InsertInterface.php
+++ b/src/Common/InsertInterface.php
@@ -17,7 +17,7 @@ use Aura\SqlQuery\QueryInterface;
  * @package Aura.SqlQuery
  *
  */
-interface InsertInterface extends QueryInterface, ValuesInterface
+interface InsertInterface extends QueryInterface, ValuesInterface, WithInterface
 {
     /**
      *

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -627,32 +627,6 @@ class Select extends AbstractQuery implements SelectInterface
 
     /**
      *
-     * Formats a sub-SELECT statement, binding values from a Select object as
-     * needed.
-     *
-     * @param string|SelectInterface $spec A sub-SELECT specification.
-     *
-     * @param string $indent Indent each line with this string.
-     *
-     * @param string $source The part of this query the sub-select is being
-     * rendered into, which claims the names it binds.
-     *
-     * @return string The sub-SELECT string.
-     *
-     */
-    protected function subSelect($spec, $indent, $source = 'table')
-    {
-        if ($spec instanceof SelectInterface) {
-            $this->bindValuesFromSelect($spec, $source);
-        }
-
-        return PHP_EOL . $indent
-            . ltrim(preg_replace('/^/m', $indent, (string) $spec))
-            . PHP_EOL;
-    }
-
-    /**
-     *
      * Adds a JOIN table and columns to the query.
      *
      * @param string $join The join type: inner, left, natural, etc.

--- a/src/Common/SelectBuilder.php
+++ b/src/Common/SelectBuilder.php
@@ -118,40 +118,4 @@ class SelectBuilder extends AbstractBuilder
 
         return PHP_EOL . 'FOR UPDATE';
     }
-
-    /**
-     *
-     * Builds the WITH clause.
-     *
-     * @param array $with The CTE elements.
-     *
-     * @param bool $recursive True if recursive, false if not.
-     *
-     * @return string
-     *
-     */
-    public function buildWith(array $with, $recursive = false)
-    {
-        if (empty($with)) {
-            return ''; // not applicable
-        }
-
-        $keyword = $recursive && $this->allowsRecursiveKeyword()
-            ? 'WITH RECURSIVE'
-            : 'WITH';
-
-        return $keyword . ' ' . implode(',' . PHP_EOL, $with) . PHP_EOL;
-    }
-
-    /**
-     *
-     * Does this dialect allow the RECURSIVE keyword in WITH?
-     *
-     * @return bool
-     *
-     */
-    protected function allowsRecursiveKeyword()
-    {
-        return true;
-    }
 }

--- a/src/Common/UpdateInterface.php
+++ b/src/Common/UpdateInterface.php
@@ -17,7 +17,7 @@ use Aura\SqlQuery\QueryInterface;
  * @package Aura.SqlQuery
  *
  */
-interface UpdateInterface extends QueryInterface, WhereInterface, ValuesInterface
+interface UpdateInterface extends QueryInterface, WhereInterface, ValuesInterface, WithInterface
 {
     /**
      *

--- a/src/Common/WithTrait.php
+++ b/src/Common/WithTrait.php
@@ -40,28 +40,6 @@ trait WithTrait
 
     /**
      *
-     * Renders a sub-SELECT and takes over the values it bound.
-     *
-     * Declared here because it is not part of AbstractQuery: it belongs to
-     * Select, which is the only query this trait can be mixed into today.
-     * Using the trait on a query without it is a fatal error at the call
-     * rather than a silent one, and adding CTEs to INSERT, UPDATE or DELETE
-     * means giving them this first.
-     *
-     * @param string|SelectInterface $spec A sub-SELECT specification.
-     *
-     * @param string $indent Indent each line with this string.
-     *
-     * @param string $source The part of this query the sub-select is being
-     * rendered into, which claims the names it binds.
-     *
-     * @return string
-     *
-     */
-    abstract protected function subSelect($spec, $indent, $source = 'table');
-
-    /**
-     *
      * Adds a common table expression (CTE) to the query.
      *
      * The CTE is rendered on the spot rather than kept as an object, as a

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -272,6 +272,33 @@ class Insert extends Common\Insert
 
     /**
      *
+     * MySQL is the one dialect here that does not take a WITH clause on
+     * INSERT: it allows a CTE only inside the SELECT an `INSERT ... SELECT`
+     * draws from, which this package does not build. Rendering the clause
+     * anyway would produce a statement that can only fail at execute time,
+     * and it would fail there with a bare syntax error naming the WITH the
+     * caller wrote deliberately. So it is refused here instead.
+     *
+     * @param string $name The CTE name.
+     *
+     * @param string|Common\SelectInterface $spec The CTE specification.
+     *
+     * @param array $cols Optional column list for the CTE.
+     *
+     * @return $this
+     *
+     * @throws Exception\BadMethodCallException always.
+     *
+     */
+    public function with($name, $spec, array $cols = [])
+    {
+        throw new Exception\BadMethodCallException(
+            'MySQL does not allow a WITH clause on INSERT.'
+        );
+    }
+
+    /**
+     *
      * Builds this query object into a string.
      *
      * @return string

--- a/src/Sqlsrv/DeleteBuilder.php
+++ b/src/Sqlsrv/DeleteBuilder.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Sqlsrv;
+
+use Aura\SqlQuery\Common;
+
+/**
+ *
+ * An object for Sqlsrv DELETE queries.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+class DeleteBuilder extends Common\DeleteBuilder
+{
+    use NoRecursiveKeywordTrait;
+}

--- a/src/Sqlsrv/InsertBuilder.php
+++ b/src/Sqlsrv/InsertBuilder.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Sqlsrv;
+
+use Aura\SqlQuery\Common;
+
+/**
+ *
+ * An object for Sqlsrv INSERT queries.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+class InsertBuilder extends Common\InsertBuilder
+{
+    use NoRecursiveKeywordTrait;
+}

--- a/src/Sqlsrv/NoRecursiveKeywordTrait.php
+++ b/src/Sqlsrv/NoRecursiveKeywordTrait.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Sqlsrv;
+
+/**
+ *
+ * SQL Server infers the recursion and rejects the RECURSIVE keyword, so every
+ * builder for this dialect renders a plain WITH.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+trait NoRecursiveKeywordTrait
+{
+    /**
+     *
+     * SQL Server does not support the RECURSIVE keyword in CTE.
+     *
+     * @return bool
+     *
+     */
+    protected function allowsRecursiveKeyword()
+    {
+        return false;
+    }
+}

--- a/src/Sqlsrv/SelectBuilder.php
+++ b/src/Sqlsrv/SelectBuilder.php
@@ -19,6 +19,8 @@ use Aura\SqlQuery\Common;
  */
 class SelectBuilder extends Common\SelectBuilder
 {
+    use NoRecursiveKeywordTrait;
+
     /**
      *
      * Override so that LIMIT equivalent will be applied by applyLimit().
@@ -70,17 +72,5 @@ class SelectBuilder extends Common\SelectBuilder
         // a sub-clause of the ORDER clause. cannot use FETCH without OFFSET.
         return $stm . PHP_EOL . "OFFSET {$offset} ROWS "
                     . "FETCH NEXT {$limit} ROWS ONLY";
-    }
-
-    /**
-     *
-     * SQL Server does not support the RECURSIVE keyword in CTE.
-     *
-     * @return bool
-     *
-     */
-    protected function allowsRecursiveKeyword()
-    {
-        return false;
     }
 }

--- a/src/Sqlsrv/UpdateBuilder.php
+++ b/src/Sqlsrv/UpdateBuilder.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\SqlQuery\Sqlsrv;
+
+use Aura\SqlQuery\Common;
+
+/**
+ *
+ * An object for Sqlsrv UPDATE queries.
+ *
+ * @package Aura.SqlQuery
+ *
+ */
+class UpdateBuilder extends Common\UpdateBuilder
+{
+    use NoRecursiveKeywordTrait;
+}

--- a/tests/Common/DeleteTest.php
+++ b/tests/Common/DeleteTest.php
@@ -12,7 +12,21 @@ use Aura\SqlQuery\AbstractQueryTest;
 
 class DeleteTest extends AbstractQueryTest
 {
+    use WithTestTrait;
+
     protected $query_type = 'delete';
+
+    protected function withBody()
+    {
+        $this->query
+            ->from('t1')
+            ->where('id IN (SELECT c1 FROM cte)');
+        return '
+            DELETE FROM <<t1>>
+            WHERE
+                id IN (SELECT c1 FROM cte)
+        ';
+    }
 
     /**
      *

--- a/tests/Common/InsertTest.php
+++ b/tests/Common/InsertTest.php
@@ -5,7 +5,21 @@ use Aura\SqlQuery\AbstractQueryTest;
 
 class InsertTest extends AbstractQueryTest
 {
+    use WithTestTrait;
+
     protected $query_type = 'insert';
+
+    protected function withBody()
+    {
+        $this->query->into('t1')->cols(['c1']);
+        return '
+            INSERT INTO <<t1>> (
+                <<c1>>
+            ) VALUES (
+                :c1
+            )
+        ';
+    }
 
     protected function newQuery()
     {

--- a/tests/Common/UpdateTest.php
+++ b/tests/Common/UpdateTest.php
@@ -5,7 +5,24 @@ use Aura\SqlQuery\AbstractQueryTest;
 
 class UpdateTest extends AbstractQueryTest
 {
+    use WithTestTrait;
+
     protected $query_type = 'update';
+
+    protected function withBody()
+    {
+        $this->query
+            ->table('t1')
+            ->cols(['c1'])
+            ->where('id IN (SELECT c1 FROM cte)');
+        return '
+            UPDATE <<t1>>
+            SET
+                <<c1>> = :c1
+            WHERE
+                id IN (SELECT c1 FROM cte)
+        ';
+    }
 
     public function testExceptionWithNoCols()
     {

--- a/tests/Common/WithTestTrait.php
+++ b/tests/Common/WithTestTrait.php
@@ -1,0 +1,262 @@
+<?php
+namespace Aura\SqlQuery\Common;
+
+use Aura\SqlQuery\Exception\InvalidArgumentException;
+use Aura\SqlQuery\Exception\LogicException;
+
+/**
+ *
+ * Shared WITH assertions for the data-modifying queries.
+ *
+ * The clause itself is the same on all three, so the only thing each test
+ * class has to say is what its own statement looks like below the clause:
+ * withBody() fills the query in and returns the SQL it renders to.
+ *
+ */
+trait WithTestTrait
+{
+    /**
+     *
+     * Fills in the query below the WITH clause.
+     *
+     * @return string The SQL the filled-in query renders to.
+     *
+     */
+    abstract protected function withBody();
+
+    /**
+     *
+     * SQL Server infers the recursion and rejects the keyword.
+     *
+     * @return string
+     *
+     */
+    protected function withRecursiveKeyword()
+    {
+        return 'WITH RECURSIVE';
+    }
+
+    /**
+     *
+     * MySQL takes no WITH clause on INSERT, and refuses it rather than
+     * building a statement that can only fail at execute time.
+     *
+     * @return bool
+     *
+     */
+    protected function supportsWith()
+    {
+        return true;
+    }
+
+    protected function skipWithoutWith()
+    {
+        if (! $this->supportsWith()) {
+            $this->markTestSkipped(
+                'This query takes no WITH clause on this dialect.'
+            );
+        }
+    }
+
+    protected function newCte()
+    {
+        return $this->query_factory->newSelect()->cols(['c1'])->from('t1');
+    }
+
+    public function testWith()
+    {
+        $this->skipWithoutWith();
+        $this->query->with('cte', $this->newCte());
+        $body = trim($this->withBody());
+        $expect = "
+            WITH <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            {$body}
+        ";
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithCols()
+    {
+        $this->skipWithoutWith();
+        $this->query->with('cte', $this->newCte(), ['col1']);
+        $body = trim($this->withBody());
+        $expect = "
+            WITH <<cte>> (<<col1>>) AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            {$body}
+        ";
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithString()
+    {
+        $this->skipWithoutWith();
+        $this->query->with('cte', 'SELECT c1 FROM t1');
+        $body = trim($this->withBody());
+        $expect = "
+            WITH <<cte>> AS (
+                SELECT c1 FROM t1
+            )
+            {$body}
+        ";
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithMultiple()
+    {
+        $this->skipWithoutWith();
+        $sub2 = $this->query_factory->newSelect()->cols(['c2'])->from('t2');
+        $this->query
+            ->with('cte1', $this->newCte())
+            ->with('cte2', $sub2);
+        $body = trim($this->withBody());
+        $expect = "
+            WITH <<cte1>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            ),
+            <<cte2>> AS (
+                SELECT
+                    c2
+                FROM
+                    <<t2>>
+            )
+            {$body}
+        ";
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    public function testWithRecursive()
+    {
+        $this->skipWithoutWith();
+        $this->query->withRecursive('cte', $this->newCte());
+        $body = trim($this->withBody());
+        $keyword = $this->withRecursiveKeyword();
+        $expect = "
+            {$keyword} <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            {$body}
+        ";
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+
+    /**
+     *
+     * The values the CTE bound come with it, claimed for the statement rather
+     * than for any one clause of it.
+     *
+     */
+    public function testWithBindValues()
+    {
+        $this->skipWithoutWith();
+        $sub = $this->query_factory->newSelect()
+            ->cols(['c1'])
+            ->from('t1')
+            ->where('c2 = :v', ['v' => 9]);
+
+        $this->query->with('cte', $sub);
+        $this->withBody();
+
+        $this->assertSame(['v' => 9], $this->query->getBindValues());
+    }
+
+    public function testHasWith()
+    {
+        $this->skipWithoutWith();
+        $this->assertFalse($this->query->hasWith());
+        $this->query->with('cte', $this->newCte());
+        $this->assertTrue($this->query->hasWith());
+    }
+
+    public function testResetWith()
+    {
+        $this->skipWithoutWith();
+        $this->query->with('cte', $this->newCte());
+        $this->query->resetWith();
+
+        $body = trim($this->withBody());
+        $this->assertSameSql($body, $this->query->getStatement());
+        $this->assertFalse($this->query->hasWith());
+    }
+
+    /**
+     *
+     * Once the clause is gone the names it held are free, so the clause that
+     * asks for one next may have it.
+     *
+     */
+    public function testResetWithReleasesBindSources()
+    {
+        $this->skipWithoutWith();
+        $sub = $this->query_factory->newSelect()
+            ->cols(['c1'])
+            ->from('t1')
+            ->where('c2 = :v', ['v' => 9]);
+
+        $this->query->with('cte', $sub);
+        $this->query->resetWith();
+
+        $this->query->bindValue('v', 10);
+        $this->assertSame(['v' => 10], $this->query->getBindValues());
+    }
+
+    public function testWithRequiresName()
+    {
+        $this->skipWithoutWith();
+        $this->expectException(InvalidArgumentException::class);
+        $this->query->with('', $this->newCte());
+    }
+
+    public function testWithRejectsDuplicateName()
+    {
+        $this->skipWithoutWith();
+        $this->query->with('cte', $this->newCte());
+        $this->expectException(LogicException::class);
+        $this->query->with('cte', $this->newCte());
+    }
+
+    /**
+     *
+     * A CTE that cannot render leaves the clause as it was, rather than
+     * marking it recursive on the way to throwing.
+     *
+     */
+    public function testWithRecursiveDoesNotSetFlagWhenWithThrows()
+    {
+        $this->skipWithoutWith();
+        try {
+            $this->query->withRecursive('', $this->newCte());
+            $this->fail('Expected an InvalidArgumentException.');
+        } catch (InvalidArgumentException $e) {
+            // expected
+        }
+
+        $this->query->with('cte', $this->newCte());
+        $body = trim($this->withBody());
+        $expect = "
+            WITH <<cte>> AS (
+                SELECT
+                    c1
+                FROM
+                    <<t1>>
+            )
+            {$body}
+        ";
+        $this->assertSameSql($expect, $this->query->getStatement());
+    }
+}

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -817,4 +817,97 @@ abstract class AbstractIntegrationTest extends TestCase
         $this->assertSame(2, $this->exec($delete));
         $this->assertSame(['Anna', 'Betty'], $this->fetchNames());
     }
+
+    /**
+     * Does this dialect take a WITH clause on INSERT?
+     *
+     * MySQL is the one that does not: it allows a CTE only inside the SELECT
+     * an `INSERT ... SELECT` draws from, which this package does not build.
+     */
+    protected function allowsWithOnInsert(): bool
+    {
+        return true;
+    }
+
+    /**
+     * A CTE against a real server, on the statements that modify data. The
+     * clause has to open the statement ahead of the verb, the CTE name has to
+     * be usable as an ordinary table in the WHERE below it, and the value the
+     * sub-select bound has to survive the trip. See #261.
+     */
+    public function testUpdateWithCte()
+    {
+        $juniors = $this->query_factory->newSelect()
+            ->cols(['id'])
+            ->from('test_employee')
+            ->where('salary < :cutoff', ['cutoff' => 300]);
+
+        $update = $this->query_factory->newUpdate()
+            ->with('juniors', $juniors)
+            ->table('test_employee')
+            ->cols(['salary' => 150])
+            ->where('id IN (SELECT id FROM juniors)');
+
+        $this->assertStatementContains('WITH <<juniors>> AS (', $update);
+        $this->assertSame(['cutoff' => 300, 'salary' => 150], $update->getBindValues());
+
+        $this->assertSame(2, $this->exec($update));
+
+        $actual = $this->pdo
+            ->query('SELECT salary FROM test_employee ORDER BY seq')
+            ->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([150, 150, 300, 400], array_map('intval', $actual));
+    }
+
+    public function testDeleteWithCte()
+    {
+        $seniors = $this->query_factory->newSelect()
+            ->cols(['id'])
+            ->from('test_employee')
+            ->where('salary >= :cutoff', ['cutoff' => 300]);
+
+        $delete = $this->query_factory->newDelete()
+            ->with('seniors', $seniors)
+            ->from('test_employee')
+            ->where('id IN (SELECT id FROM seniors)');
+
+        $this->assertStatementContains('WITH <<seniors>> AS (', $delete);
+        $this->assertSame(['cutoff' => 300], $delete->getBindValues());
+
+        $this->assertSame(2, $this->exec($delete));
+        $this->assertSame(['Anna', 'Betty'], $this->fetchNames());
+    }
+
+    /**
+     * The INSERT this package builds takes VALUES rather than a SELECT, so a
+     * CTE reaches it as a scalar sub-select in one of those values. That is
+     * also the form SQL Server needs, which asks that the statement below the
+     * clause reference the CTE.
+     */
+    public function testInsertWithCte()
+    {
+        if (! $this->allowsWithOnInsert()) {
+            $this->markTestSkipped('This dialect takes no WITH clause on INSERT.');
+        }
+
+        $seniors = $this->query_factory->newSelect()
+            ->cols(['MAX(salary) AS top_salary'])
+            ->from('test_employee')
+            ->where('salary >= :cutoff', ['cutoff' => 300]);
+
+        $insert = $this->query_factory->newInsert()
+            ->with('seniors', $seniors)
+            ->into('test_employee')
+            ->cols(['name' => 'Edna', 'dept_id' => 1, 'seq' => 5])
+            ->set('salary', '(SELECT top_salary FROM seniors)');
+
+        $this->assertStatementContains('WITH <<seniors>> AS (', $insert);
+
+        $this->assertSame(1, $this->exec($insert));
+
+        $actual = $this->pdo
+            ->query('SELECT salary FROM test_employee WHERE seq = 5')
+            ->fetchColumn();
+        $this->assertSame(400, (int) $actual);
+    }
 }

--- a/tests/Integration/MysqlIntegrationTest.php
+++ b/tests/Integration/MysqlIntegrationTest.php
@@ -15,6 +15,11 @@ class MysqlIntegrationTest extends AbstractIntegrationTest
 {
     protected string $db_type = 'mysql';
 
+    protected function allowsWithOnInsert(): bool
+    {
+        return false;
+    }
+
     protected function newPdo(): PDO
     {
         $dsn = getenv('DB_MYSQL_DSN');

--- a/tests/Mysql/InsertTest.php
+++ b/tests/Mysql/InsertTest.php
@@ -8,6 +8,31 @@ class InsertTest extends Common\InsertTest
 {
     protected $db_type = 'mysql';
 
+    protected function supportsWith()
+    {
+        return false;
+    }
+
+    /**
+     *
+     * MySQL allows a CTE only inside the SELECT an `INSERT ... SELECT` draws
+     * from, which this package does not build; the clause is refused rather
+     * than rendered into a statement that can only fail at execute time.
+     *
+     */
+    public function testWithIsRefused()
+    {
+        $this->expectException('Aura\\SqlQuery\\Exception\\BadMethodCallException');
+        $this->expectExceptionMessage('MySQL does not allow a WITH clause on INSERT.');
+        $this->query->with('cte', $this->query_factory->newSelect());
+    }
+
+    public function testWithRecursiveIsRefused()
+    {
+        $this->expectException('Aura\\SqlQuery\\Exception\\BadMethodCallException');
+        $this->query->withRecursive('cte', $this->query_factory->newSelect());
+    }
+
     protected $expected_sql_no_cols = "
         INSERT INTO <<t1>> () VALUES ()
     ";

--- a/tests/Sqlsrv/DeleteTest.php
+++ b/tests/Sqlsrv/DeleteTest.php
@@ -7,6 +7,11 @@ class DeleteTest extends Common\DeleteTest
 {
     protected $db_type = 'sqlsrv';
 
+    protected function withRecursiveKeyword()
+    {
+        return 'WITH';
+    }
+
     /**
      * SQL Server has no IGNORE; asking for it has to say so rather than
      * fatal on an undefined method.

--- a/tests/Sqlsrv/InsertTest.php
+++ b/tests/Sqlsrv/InsertTest.php
@@ -7,6 +7,11 @@ class InsertTest extends Common\InsertTest
 {
     protected $db_type = 'sqlsrv';
 
+    protected function withRecursiveKeyword()
+    {
+        return 'WITH';
+    }
+
     /**
      * SQL Server has no REPLACE; asking for it has to say so rather than
      * fatal on an undefined method.

--- a/tests/Sqlsrv/UpdateTest.php
+++ b/tests/Sqlsrv/UpdateTest.php
@@ -7,6 +7,11 @@ class UpdateTest extends Common\UpdateTest
 {
     protected $db_type = 'sqlsrv';
 
+    protected function withRecursiveKeyword()
+    {
+        return 'WITH';
+    }
+
     /**
      * SQL Server has no IGNORE; asking for it has to say so rather than
      * fatal on an undefined method.


### PR DESCRIPTION
Follow-on to the SELECT CTE work: `with()` and `withRecursive()` now work on
the data-modifying queries too. Fixes #261.

`WithTrait` moves to `AbstractDmlQuery`, `subSelect()` to `AbstractQuery`, and
`buildWith()` to `Common\AbstractBuilder`. New Sqlsrv DML builders so SQL
Server renders a plain `WITH` on all four query types.

MySQL takes no `WITH` on INSERT — it allows a CTE only inside the SELECT an
`INSERT ... SELECT` draws from, which this package does not build — so
`Mysql\Insert::with()` throws instead of emitting unexecutable SQL.

[BRK] `InsertInterface`, `UpdateInterface` and `DeleteInterface` extend
`WithInterface`, as `SelectInterface` already did.

Coverage: shared `WithTestTrait` on the three Common DML test classes, so every
dialect inherits it, plus integration tests that execute against a real server.
CI green on SQLite, MySQL 8.0/8.4, Postgres 15/17 and SQL Server 2019/2022.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added common table expression (CTE) support for `INSERT`, `UPDATE`, and `DELETE` queries.
  * Added standard and recursive CTEs, including multiple CTEs, column lists, and parameter binding.
  * Added SQL Server support with dialect-appropriate CTE syntax.

* **Bug Fixes**
  * MySQL `INSERT` queries now clearly reject unsupported CTE usage.

* **Documentation**
  * Added usage examples and dialect-specific guidance for CTE-enabled data modification queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->