### PR TITLE
Say what AbstractQuery's arrays hold, and raise PHPStan to level 5

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,6 @@
 # messages PHPStan emits for them are identical wherever they occur, so there
 # is nothing to key a pattern on.
 parameters:
-    level: 4
+    level: 5
     paths:
         - src

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -415,7 +415,7 @@ abstract class AbstractQuery
      *
      * Reports two parts of the query claiming one placeholder name.
      *
-     * @param string $name The placeholder name.
+     * @param int|string $name The placeholder name.
      *
      * @param string $prior The part of the query holding the name.
      *

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -220,7 +220,7 @@ abstract class AbstractQuery
      *
      * Binds a single value to the query.
      *
-     * @param string $name The placeholder name or number.
+     * @param int|string $name The placeholder name or number.
      *
      * @param mixed $value The value to bind to the placeholder.
      *
@@ -247,7 +247,7 @@ abstract class AbstractQuery
      * always overwrite: rebinding before execution, and reusing a query
      * object with fresh values, are both legitimate.
      *
-     * @param string $name The placeholder name or number.
+     * @param int|string $name The placeholder name or number.
      *
      * @param mixed $value The value to bind to the placeholder.
      *

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -25,7 +25,7 @@ abstract class AbstractQuery
      *
      * Data to be bound to the query.
      *
-     * @var array
+     * @var array<int|string, mixed>
      *
      */
     protected $bind_values = [];
@@ -35,7 +35,7 @@ abstract class AbstractQuery
      * Which part of the query bound each placeholder name; null means it was
      * bound by hand. Keys match $bind_values.
      *
-     * @var array
+     * @var array<int|string, string>
      *
      */
     protected $bind_sources = [];
@@ -47,7 +47,7 @@ abstract class AbstractQuery
      * stays with the union, but the name is not free while this clause is
      * still using it. Keys match $bind_sources.
      *
-     * @var array
+     * @var array<int|string, string>
      *
      */
     protected $bind_shared = [];
@@ -56,7 +56,7 @@ abstract class AbstractQuery
      *
      * Human-readable names for the $bind_sources values, for error messages.
      *
-     * @var array
+     * @var array<string, string>
      *
      */
     protected $bind_source_labels = [
@@ -77,7 +77,7 @@ abstract class AbstractQuery
      *
      * The list of WHERE conditions.
      *
-     * @var array
+     * @var list<string>
      *
      */
     protected $where = [];
@@ -86,7 +86,7 @@ abstract class AbstractQuery
      *
      * ORDER BY these columns.
      *
-     * @var array
+     * @var list<string>
      *
      */
     protected $order_by = [];
@@ -95,7 +95,7 @@ abstract class AbstractQuery
      *
      * The list of flags.
      *
-     * @var array
+     * @var array<string, true>
      *
      */
     protected $flags = [];
@@ -200,7 +200,8 @@ abstract class AbstractQuery
      *
      * Binds multiple values to placeholders; merges with existing values.
      *
-     * @param array $bind_values Values to bind to placeholders.
+     * @param array<int|string, mixed> $bind_values Values to bind to
+     * placeholders.
      *
      * @return $this
      *
@@ -470,7 +471,7 @@ abstract class AbstractQuery
      *
      * Gets the values to bind to placeholders.
      *
-     * @return array
+     * @return array<int|string, mixed>
      *
      */
     public function getBindValues()
@@ -596,7 +597,8 @@ abstract class AbstractQuery
      *
      * @param string|Closure $cond The WHERE condition.
      *
-     * @param array $bind arguments to bind to placeholders
+     * @param array<int|string, mixed> $bind arguments to bind to
+     * placeholders
      *
      * @return void
      *
@@ -686,8 +688,8 @@ abstract class AbstractQuery
      *
      * @param string $cond The condition with sequential placeholders.
      *
-     * @param array $bind_values The values to bind to the sequential
-     * placeholders under their named versions.
+     * @param array<int|string, mixed> $bind_values The values to bind to the
+     * sequential placeholders under their named versions.
      *
      * @param string $clause The source clause name.
      *
@@ -719,6 +721,16 @@ abstract class AbstractQuery
         return $cond;
     }
 
+    /**
+     *
+     * Binds each value of an array under a generated name, and returns the
+     * placeholder list to write in place of the array.
+     *
+     * @param array<array-key, mixed> $array The values to bind.
+     *
+     * @return string The comma-separated placeholder names.
+     *
+     */
     protected function inlineArray(array $array)
     {
         $keys = [];
@@ -735,7 +747,8 @@ abstract class AbstractQuery
      *
      * Adds a column order to the query.
      *
-     * @param array $spec The columns and direction to order by.
+     * @param array<array-key, string> $spec The columns and direction to
+     * order by.
      *
      * @return $this
      *
@@ -749,10 +762,10 @@ abstract class AbstractQuery
     }
 
     /**
-     * @param int|string $key
-     * @param string     $cond
-     * @param array      $val
-     * @param int        $index
+     * @param int|string               $key
+     * @param string                   $cond
+     * @param array<array-key, mixed>  $val
+     * @param int                      $index
      *
      * @return string
      */

--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -1083,6 +1083,11 @@ class Select extends AbstractQuery implements SelectInterface
         $spelled = [];
         foreach ($this->union as $branch) {
             preg_match_all($find, $branch, $matches);
+            // 'strlen' as a callable string is the idiom for dropping the
+            // empty captures the alternation leaves behind, and reads better
+            // than the closure that would satisfy the callable(string): bool
+            // PHPStan wants; keeping it costs this one line.
+            /** @phpstan-ignore argument.type */
             $spelled += array_flip(array_filter($matches[1], 'strlen'));
         }
 

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -68,7 +68,7 @@ interface QueryInterface
      *
      * Binds a single value to the query.
      *
-     * @param string $name The placeholder name or number.
+     * @param int|string $name The placeholder name or number.
      *
      * @param mixed $value The value to bind to the placeholder.
      *

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -57,7 +57,8 @@ interface QueryInterface
      *
      * Adds values to bind into the query; merges with existing values.
      *
-     * @param array $bind_values Values to bind to the query.
+     * @param array<int|string, mixed> $bind_values Values to bind to the
+     * query.
      *
      * @return $this
      *
@@ -81,7 +82,7 @@ interface QueryInterface
      *
      * Gets the values to bind into the query.
      *
-     * @return array
+     * @return array<int|string, mixed>
      *
      */
     public function getBindValues();


### PR DESCRIPTION
Docblock-only. Adds array shapes to AbstractQuery's 7 array properties and 8
method params/returns, and gives `inlineArray()` the docblock it never had.

With the file clean, PHPStan goes to level 5. That is what makes the inline
`@phpstan-ignore` on the `array_filter(..., 'strlen')` line in Select legal --
below level 5 the annotation is itself an `ignore.unmatchedIdentifier` error,
so the level and the annotation have to arrive together. Level 6 across `src`
drops from 161 errors to 145.

The bind arrays are keyed `int|string`, not `string`: `bindValues()` avoids
`array_merge()` precisely so integer keys survive, and they do --
`bindValues([1 => 'a', 'b' => 'c'])` keeps `1` as an integer key. The three
bind properties, and everything downstream that mirrors them, are shaped that
way. `$bind_sources` and `$bind_shared` hold `string` and never null, both
writes being guarded. `$flags` is `array<string, true>`; only `true` is ever
written.

No behaviour changes. Unit, integration, doc examples and analyse all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Quality Improvements**
  - Raised the configured static analysis level to improve code quality checks.
  - Clarified type documentation for query bindings, clauses, flags, parameters, and return values.
  - Added documentation for inline array handling.
  - Documented a static-analysis exception in query rendering code.
  - No user-facing runtime behavior or public API changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->