### PR TITLE
Say what the clause arrays hold, from setter through to builder

### DIFF
--- a/src/Common/AbstractBuilder.php
+++ b/src/Common/AbstractBuilder.php
@@ -22,7 +22,7 @@ abstract class AbstractBuilder
      *
      * Builds the flags as a space-separated string.
      *
-     * @param array $flags The flags to build.
+     * @param array<string, true> $flags The flags to build.
      *
      * @return string
      *
@@ -40,7 +40,7 @@ abstract class AbstractBuilder
      *
      * Builds the WITH clause.
      *
-     * @param array $with The CTE elements.
+     * @param array<string, string> $with The CTE elements.
      *
      * @param bool $recursive True if recursive, false if not.
      *
@@ -76,7 +76,7 @@ abstract class AbstractBuilder
      *
      * Builds the `WHERE` clause of the statement.
      *
-     * @param array $where The WHERE elements.
+     * @param list<string> $where The WHERE elements.
      *
      * @return string
      *
@@ -94,7 +94,7 @@ abstract class AbstractBuilder
      *
      * Builds the `ORDER BY ...` clause of the statement.
      *
-     * @param array $order_by The ORDER BY elements.
+     * @param list<string> $order_by The ORDER BY elements.
      *
      * @return string
      *

--- a/src/Common/LateralJoinTrait.php
+++ b/src/Common/LateralJoinTrait.php
@@ -37,7 +37,8 @@ trait LateralJoinTrait
      * ON clause except on the join types that forbid one, so when no
      * condition is given for the other types, "ON true" is used.
      *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
+     * @param array<int|string, mixed> $bind Values to bind to
+     * ?-placeholders in the condition.
      *
      * @return $this
      *

--- a/src/Common/OrderByInterface.php
+++ b/src/Common/OrderByInterface.php
@@ -21,7 +21,8 @@ interface OrderByInterface
      *
      * Adds a column order to the query.
      *
-     * @param array $spec The columns and direction to order by.
+     * @param array<array-key, string> $spec The columns and direction to
+     * order by.
      *
      * @return $this
      *

--- a/src/Common/TableListTrait.php
+++ b/src/Common/TableListTrait.php
@@ -35,7 +35,8 @@ trait TableListTrait
      *
      * @param string $spec One or more table names, comma-separated.
      *
-     * @return array The individual names, trimmed, with empty parts dropped.
+     * @return list<string> The individual names, trimmed, with empty parts
+     * dropped.
      *
      */
     protected function splitNamesList($spec)

--- a/src/Common/WhereInterface.php
+++ b/src/Common/WhereInterface.php
@@ -25,7 +25,8 @@ interface WhereInterface
      *
      * @param string|\Closure $cond The WHERE condition.
      *
-     * @param array $bind Values to be bound to placeholders.
+     * @param array<int|string, mixed> $bind Values to be bound to
+     * placeholders.
      *
      * @return $this
      *
@@ -40,7 +41,8 @@ interface WhereInterface
      *
      * @param string|\Closure $cond The WHERE condition.
      *
-     * @param array $bind Values to be bound to placeholders.
+     * @param array<int|string, mixed> $bind Values to be bound to
+     * placeholders.
      *
      * @return $this
      *

--- a/src/Common/WhereTrait.php
+++ b/src/Common/WhereTrait.php
@@ -23,7 +23,8 @@ trait WhereTrait
      *
      * @param string|\Closure $cond The WHERE condition.
      *
-     * @param array $bind Values to be bound to placeholders
+     * @param array<int|string, mixed> $bind Values to be bound to
+     * placeholders
      *
      * @return $this
      *
@@ -42,7 +43,8 @@ trait WhereTrait
      *
      * @param string|\Closure $cond The WHERE condition.
      *
-     * @param array $bind Values to be bound to placeholders
+     * @param array<int|string, mixed> $bind Values to be bound to
+     * placeholders
      *
      * @return $this
      *

--- a/src/Common/WithInterface.php
+++ b/src/Common/WithInterface.php
@@ -25,7 +25,8 @@ interface WithInterface
      *
      * @param string|SelectInterface $spec The CTE specification.
      *
-     * @param array $cols Optional column list for the CTE.
+     * @param array<array-key, string> $cols Optional column list for the
+     * CTE.
      *
      * @return $this
      *
@@ -40,7 +41,8 @@ interface WithInterface
      *
      * @param string|SelectInterface $spec The CTE specification.
      *
-     * @param array $cols Optional column list for the CTE.
+     * @param array<array-key, string> $cols Optional column list for the
+     * CTE.
      *
      * @return $this
      *

--- a/src/Common/WithTrait.php
+++ b/src/Common/WithTrait.php
@@ -24,7 +24,7 @@ trait WithTrait
      *
      * The common table expressions, already rendered, keyed by name.
      *
-     * @var array
+     * @var array<string, string>
      *
      */
     protected $with = [];
@@ -55,7 +55,8 @@ trait WithTrait
      *
      * @param string|SelectInterface $spec The CTE specification.
      *
-     * @param array $cols Optional column list for the CTE.
+     * @param array<array-key, string> $cols Optional column list for the
+     * CTE.
      *
      * @return $this
      *
@@ -137,7 +138,8 @@ trait WithTrait
      *
      * @param string|SelectInterface $spec The CTE specification.
      *
-     * @param array $cols Optional column list for the CTE.
+     * @param array<array-key, string> $cols Optional column list for the
+     * CTE.
      *
      * @return $this
      *

--- a/src/Pgsql/BuildReturningTrait.php
+++ b/src/Pgsql/BuildReturningTrait.php
@@ -21,7 +21,7 @@ trait BuildReturningTrait
      *
      * Builds the `RETURNING` clause of the statement.
      *
-     * @param array $returning Return these columns.
+     * @param list<string> $returning Return these columns.
      *
      * @return string
      *

--- a/src/Pgsql/ReturningInterface.php
+++ b/src/Pgsql/ReturningInterface.php
@@ -24,7 +24,8 @@ interface ReturningInterface
      * Multiple calls to returning() will append to the list of columns, not
      * overwrite the previous columns.
      *
-     * @param array $cols The column(s) to add to the query.
+     * @param array<array-key, string> $cols The column(s) to add to the
+     * query.
      *
      * @return $this
      *

--- a/src/Pgsql/ReturningTrait.php
+++ b/src/Pgsql/ReturningTrait.php
@@ -21,7 +21,7 @@ trait ReturningTrait
      *
      * The columns to be returned.
      *
-     * @var array
+     * @var list<string>
      *
      */
     protected $returning = [];
@@ -33,7 +33,8 @@ trait ReturningTrait
      * Multiple calls to returning() will append to the list of columns, not
      * overwrite the previous columns.
      *
-     * @param array $cols The column(s) to add to the query.
+     * @param array<array-key, string> $cols The column(s) to add to the
+     * query.
      *
      * @return $this
      *


### PR DESCRIPTION
Stacked on #263 -- review that one first.

Docblock-only. Shapes the WHERE, WITH, ORDER BY, table-list, LATERAL and
Pgsql RETURNING seams. Each is taken end to end -- interface, trait or
property, and the builder method that consumes it -- because a shape given
on only one side of a seam reads as a disagreement rather than as a missing
type.

The `$bind` params carry `array<int|string, mixed>` down from #263, which is
where that key type is established. `$with` is `array<string, string>`,
`$returning` and `$where` are `list<string>`, `$flags` is
`array<string, true>`, and the public setters that callers hand arbitrary
arrays to take `array<array-key, string>`.

Level 6 across `src` drops from 145 errors to 109. Unlike the property
shapes in #263, these are checked: retyping `buildWhere()`'s param to
`list<int>` reports 3 errors at level 5.

No behaviour changes. Unit, integration, doc examples and analyse all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified PHPDoc annotations for query-building parameters and return values.
  - Documented accepted array key and value types for filtering, bindings, ordering, common table expressions, joins, and column lists.
  - Added more precise type information for PostgreSQL `RETURNING` values.
  - Improved documentation consistency across query-building interfaces and traits.
  - No runtime behavior or public method signatures were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->