### PR TITLE
Say what the SELECT arrays hold, from setter through to builder

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -38,7 +38,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * An array of union SELECT statements.
      *
-     * @var array
+     * @var list<string>
      *
      */
     protected $union = [];
@@ -85,7 +85,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * The columns to be selected.
      *
-     * @var array
+     * @var array<int|string, string>
      *
      */
     protected $cols = [];
@@ -94,7 +94,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Select from these tables; includes JOIN clauses.
      *
-     * @var array
+     * @var list<list<string>>
      *
      */
     protected $from = [];
@@ -112,7 +112,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Tracks which JOIN clauses are attached to which FROM tables.
      *
-     * @var array
+     * @var array<int, list<string>>
      *
      */
     protected $join = [];
@@ -121,7 +121,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * GROUP BY these columns.
      *
-     * @var array
+     * @var list<string>
      *
      */
     protected $group_by = [];
@@ -130,7 +130,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * The list of HAVING conditions.
      *
-     * @var array
+     * @var list<string>
      *
      */
     protected $having = [];
@@ -157,7 +157,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Tracks table references to avoid duplicate identifiers.
      *
-     * @var array
+     * @var array<string, string>
      *
      */
     protected $table_refs = [];
@@ -321,8 +321,9 @@ class Select extends AbstractQuery implements SelectInterface
      * Multiple calls to cols() will append to the list of columns, not
      * overwrite the previous columns.
      *
-     * @param array $cols The column(s) to add to the query. The elements can be
-     * any mix of these: `array("col", "col AS alias", "col" => "alias")`
+     * @param array<int|string, string> $cols The column(s) to add to the
+     * query. The elements can be any mix of these:
+     * `array("col", "col AS alias", "col" => "alias")`
      *
      * @return $this
      *
@@ -503,7 +504,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Returns a list of columns.
      *
-     * @return array
+     * @return array<int|string, string>
      *
      */
     public function getCols()
@@ -635,7 +636,8 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string|null $cond Join on this condition.
      *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
+     * @param array<int|string, mixed> $bind Values to bind to
+     * ?-placeholders in the condition.
      *
      * @return $this
      *
@@ -659,7 +661,8 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string|null $cond Join on this condition.
      *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
+     * @param array<int|string, mixed> $bind Values to bind to
+     * ?-placeholders in the condition.
      *
      * @return string
      *
@@ -692,7 +695,8 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string|null $cond Join on this condition.
      *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
+     * @param array<int|string, mixed> $bind Values to bind to
+     * ?-placeholders in the condition.
      *
      * @return $this
      *
@@ -712,7 +716,8 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string|null $cond Join on this condition.
      *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
+     * @param array<int|string, mixed> $bind Values to bind to
+     * ?-placeholders in the condition.
      *
      * @return $this
      *
@@ -738,7 +743,8 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string|null $cond Join on this condition.
      *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
+     * @param array<int|string, mixed> $bind Values to bind to
+     * ?-placeholders in the condition.
      *
      * @return $this
      *
@@ -779,7 +785,7 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Adds grouping to the query.
      *
-     * @param array $spec The column(s) to group by.
+     * @param array<array-key, string> $spec The column(s) to group by.
      *
      * @return $this
      *
@@ -798,7 +804,8 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string|\Closure $cond The HAVING condition.
      *
-     * @param array $bind arguments to bind to placeholders
+     * @param array<int|string, mixed> $bind arguments to bind to
+     * placeholders
      *
      * @return $this
      *
@@ -815,7 +822,8 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * @param string|\Closure $cond The HAVING condition.
      *
-     * @param array $bind arguments to bind to placeholders
+     * @param array<int|string, mixed> $bind arguments to bind to
+     * placeholders
      *
      * @return $this
      *
@@ -1343,7 +1351,8 @@ class Select extends AbstractQuery implements SelectInterface
      *
      * Adds a column order to the query.
      *
-     * @param array $spec The columns and direction to order by.
+     * @param array<array-key, string> $spec The columns and direction to
+     * order by.
      *
      * @return $this
      *

--- a/src/Common/SelectBuilder.php
+++ b/src/Common/SelectBuilder.php
@@ -23,7 +23,7 @@ class SelectBuilder extends AbstractBuilder
      *
      * Builds the columns portion of the SELECT.
      *
-     * @param array $cols The columns.
+     * @param list<string> $cols The columns.
      *
      * @return string
      *
@@ -42,9 +42,9 @@ class SelectBuilder extends AbstractBuilder
      *
      * Builds the FROM clause.
      *
-     * @param array $from The FROM elements.
+     * @param list<list<string>> $from The FROM elements.
      *
-     * @param array $join The JOIN elements.
+     * @param array<int, list<string>> $join The JOIN elements.
      *
      * @return string
      *
@@ -69,7 +69,7 @@ class SelectBuilder extends AbstractBuilder
      *
      * Builds the GROUP BY clause.
      *
-     * @param array $group_by The GROUP BY elements.
+     * @param list<string> $group_by The GROUP BY elements.
      *
      * @return string
      *
@@ -87,7 +87,7 @@ class SelectBuilder extends AbstractBuilder
      *
      * Builds the HAVING clause.
      *
-     * @param array $having The HAVING elements.
+     * @param list<string> $having The HAVING elements.
      *
      * @return string
      *

--- a/src/Common/SelectInterface.php
+++ b/src/Common/SelectInterface.php
@@ -79,7 +79,8 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      * Multiple calls to cols() will append to the list of columns, not
      * overwrite the previous columns.
      *
-     * @param array $cols The column(s) to add to the query.
+     * @param array<int|string, string> $cols The column(s) to add to the
+     * query.
      *
      * @return $this
      *
@@ -121,7 +122,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * Returns a list of columns.
      *
-     * @return array
+     * @return array<int|string, string>
      *
      */
     public function getCols();
@@ -186,7 +187,8 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @param string|null $cond Join on this condition.
      *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
+     * @param array<int|string, mixed> $bind Values to bind to
+     * ?-placeholders in the condition.
      *
      * @return $this
      *
@@ -203,7 +205,8 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @param string|null $cond Join on this condition.
      *
-     * @param array $bind Values to bind to ?-placeholders in the condition.
+     * @param array<int|string, mixed> $bind Values to bind to
+     * ?-placeholders in the condition.
      *
      * @return $this
      *
@@ -235,7 +238,7 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * Adds grouping to the query.
      *
-     * @param array $spec The column(s) to group by.
+     * @param array<array-key, string> $spec The column(s) to group by.
      *
      * @return $this
      *
@@ -248,7 +251,8 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @param string|\Closure $cond The HAVING condition.
      *
-     * @param array $bind Values to be bound to placeholders.
+     * @param array<int|string, mixed> $bind Values to be bound to
+     * placeholders.
      *
      * @return $this
      *
@@ -261,7 +265,8 @@ interface SelectInterface extends QueryInterface, WhereInterface, OrderByInterfa
      *
      * @param string|\Closure $cond The HAVING condition.
      *
-     * @param array $bind Values to be bound to placeholders.
+     * @param array<int|string, mixed> $bind Values to be bound to
+     * placeholders.
      *
      * @return $this
      *


### PR DESCRIPTION
Stacked on #264, which is stacked on #263 -- review those first.

Docblock-only. Shapes the seven array properties of Select, the methods that
fill them, and the SelectBuilder methods that consume them.

The one worth reading is `$cols`, which is keyed `int|string`: a plain column
lands under an integer key via `$cols[] = $spec`, an aliased one under its
alias via `$cols[$val] = $key`, and `build()` tells the two apart with
`is_int($key)` to decide whether to write `AS`. `$from` is
`list<list<string>>` and `$join` is `array<int, list<string>>` -- parallel
arrays sharing a key, which is what `buildFrom()` merges. `$union`,
`$group_by` and `$having` are `list<string>`, `$table_refs` is
`array<string, string>`, and the `$bind` params carry the
`array<int|string, mixed>` from #263.

Level 6 across `src` drops from 109 errors to 79.

These are checked, not just documentation: retyping `$from` to `list<string>`
or `$cols` to `array<string, string>` each report an error at level 5.

No behaviour changes. Unit, integration, doc examples and analyse all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved inline documentation for query-building data structures, including columns, joins, grouping, filtering, and ordering.
  * Clarified expected array and list formats for query builder inputs.
  * No changes to runtime behavior or public method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->