### PR TITLE
Say what the column-value arrays hold, from setter through to builder

### DIFF
--- a/src/AbstractDmlQuery.php
+++ b/src/AbstractDmlQuery.php
@@ -26,7 +26,7 @@ abstract class AbstractDmlQuery extends AbstractQuery
      * Column values for INSERT or UPDATE queries; the key is the column name and the
      * value is the column value.
      *
-     * @var array
+     * @var array<string, string>
      *
      */
     protected $col_values = [];
@@ -69,7 +69,7 @@ abstract class AbstractDmlQuery extends AbstractQuery
      *
      * @param string $col The column name.
      *
-     * @param array $value Value of the column
+     * @param mixed ...$value Value of the column
      *
      * @return $this
      *
@@ -90,9 +90,9 @@ abstract class AbstractDmlQuery extends AbstractQuery
      * pair, the key is treated as the column name and the value is bound to
      * that column.
      *
-     * @param array $cols A list of column names, optionally as key-value
-     * pairs where the key is a column name and the value is a bind value for
-     * that column.
+     * @param array<int|string, mixed> $cols A list of column names,
+     * optionally as key-value pairs where the key is a column name and the
+     * value is a bind value for that column.
      *
      * @return $this
      *

--- a/src/Common/BuildOnConflictTrait.php
+++ b/src/Common/BuildOnConflictTrait.php
@@ -23,9 +23,10 @@ trait BuildOnConflictTrait
      *
      * Builds the `ON CONFLICT` clause of the statement.
      *
-     * @param string|array $target The conflict target.
-     * @param array $update_values The columns and values to update.
-     * @param array $where Optional WHERE conditions.
+     * @param string|null $target The conflict target.
+     * @param array<string, string> $update_values The columns and values
+     * to update.
+     * @param list<string> $where Optional WHERE conditions.
      * @param bool $ignore Whether the ignore clause is enabled.
      * @return string
      * @throws Exception\LogicException
@@ -66,7 +67,7 @@ trait BuildOnConflictTrait
      *
      * Builds the conflict update values.
      *
-     * @param array $update_values
+     * @param array<string, string> $update_values
      * @return string
      *
      */
@@ -83,7 +84,7 @@ trait BuildOnConflictTrait
      *
      * Builds the conflict update WHERE clause.
      *
-     * @param array $where
+     * @param list<string> $where
      * @return string
      *
      */

--- a/src/Common/Insert.php
+++ b/src/Common/Insert.php
@@ -54,7 +54,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * This is used to look up the right last-insert-id name for a given table
      * and column. Generally useful only for extended tables in Postgres.
      *
-     * @var array
+     * @var array<string, string>|null
      *
      */
     protected $last_insert_id_names;
@@ -73,7 +73,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * A collection of `$col_values` for previous rows in bulk inserts.
      *
-     * @var array
+     * @var array<int, array<string, string>>
      *
      */
     protected $col_values_bulk = [];
@@ -82,7 +82,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * A collection of `$bind_values` for previous rows in bulk inserts.
      *
-     * @var array
+     * @var array<string, mixed>
      *
      */
     protected $bind_values_bulk = [];
@@ -94,7 +94,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * merges them, so `$bind_sources` cannot record them and this stands in
      * for it.
      *
-     * @var array
+     * @var array<string, string>
      *
      */
     protected $bind_sources_bulk = [];
@@ -104,7 +104,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * The order in which columns will be bulk-inserted; this is taken from the
      * very first inserted row.
      *
-     * @var array
+     * @var list<string>
      *
      */
     protected $col_order = [];
@@ -114,7 +114,10 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * Sets the map of fully-qualified `table.column` names to last-insert-id
      * names. Generally useful only for extended tables in Postgres.
      *
-     * @param array $last_insert_id_names The list of ID names.
+     * @param array<string, string> $last_insert_id_names The list of ID
+     * names.
+     *
+     * @return void
      *
      */
     public function setLastInsertIdNames(array $last_insert_id_names)
@@ -186,7 +189,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * @param string $col The column name.
      *
-     * @param array $value Optional: a value to bind to the placeholder.
+     * @param mixed ...$value Optional: a value to bind to the placeholder.
      *
      * @return $this
      *
@@ -202,9 +205,9 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * pair, the key is treated as the column name and the value is bound to
      * that column.
      *
-     * @param array $cols A list of column names, optionally as key-value
-     * pairs where the key is a column name and the value is a bind value for
-     * that column.
+     * @param array<int|string, mixed> $cols A list of column names,
+     * optionally as key-value pairs where the key is a column name and the
+     * value is a bind value for that column.
      *
      * @return $this
      *
@@ -235,7 +238,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * Gets the values to bind to placeholders.
      *
-     * @return array
+     * @return array<int|string, mixed>
      *
      */
     public function getBindValues()
@@ -263,8 +266,9 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * Adds multiple rows for bulk insert.
      *
-     * @param array $rows An array of rows, where each element is an array of
-     * column key-value pairs. The values are bound to placeholders.
+     * @param array<array-key, array<int|string, mixed>> $rows An array of
+     * rows, where each element is an array of column key-value pairs. The
+     * values are bound to placeholders.
      *
      * @return $this
      *
@@ -291,8 +295,8 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * `set()` to work with the newly-added row. Calling `addRow()` again will
      * finish off the current row and start a new one.
      *
-     * @param array $cols An array of column key-value pairs; the values are
-     * bound to placeholders.
+     * @param array<int|string, mixed> $cols An array of column key-value
+     * pairs; the values are bound to placeholders.
      *
      * @return $this
      *
@@ -347,7 +351,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * Sets the conflict target column(s) or constraint name.
      *
-     * @param string|array $target
+     * @param string|array<array-key, string> $target
      * @throws BadMethodCallException
      * @return static
      *
@@ -363,7 +367,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * Sets one column value placeholder for the UPDATE on conflict.
      *
      * @param string $col
-     * @param array $value
+     * @param mixed ...$value
      * @throws BadMethodCallException
      * @return static
      *
@@ -378,7 +382,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      *
      * Sets multiple column value placeholders for the UPDATE on conflict.
      *
-     * @param array $cols
+     * @param array<int|string, mixed> $cols
      * @throws BadMethodCallException
      * @return static
      *
@@ -410,7 +414,7 @@ class Insert extends AbstractDmlQuery implements InsertInterface
      * Adds a WHERE condition for the UPDATE on conflict.
      *
      * @param string $condition
-     * @param array $bind
+     * @param array<int|string, mixed> ...$bind
      * @throws BadMethodCallException
      * @return static
      *

--- a/src/Common/InsertBuilder.php
+++ b/src/Common/InsertBuilder.php
@@ -36,7 +36,7 @@ class InsertBuilder extends AbstractBuilder
      *
      * Builds the inserted columns and values of the statement.
      *
-     * @param array $col_values The column names and values.
+     * @param array<string, string> $col_values The column names and values.
      *
      * @return string
      *
@@ -58,10 +58,10 @@ class InsertBuilder extends AbstractBuilder
      *
      * Builds the bulk-inserted columns and values of the statement.
      *
-     * @param array $col_order The column names to insert, in order.
+     * @param list<string> $col_order The column names to insert, in order.
      *
-     * @param array $col_values_bulk The bulk-insert values, in the same order
-     * the column names.
+     * @param array<int, array<string, string>> $col_values_bulk The
+     * bulk-insert values, in the same order the column names.
      *
      * @return string
      *

--- a/src/Common/InsertInterface.php
+++ b/src/Common/InsertInterface.php
@@ -35,7 +35,10 @@ interface InsertInterface extends QueryInterface, ValuesInterface, WithInterface
      * Sets the map of fully-qualified `table.column` names to last-insert-id
      * names. Generally useful only for extended tables in Postgres.
      *
-     * @param array $last_insert_id_names The list of ID names.
+     * @param array<string, string> $last_insert_id_names The list of ID
+     * names.
+     *
+     * @return void
      *
      */
     public function setLastInsertIdNames(array $last_insert_id_names);
@@ -56,8 +59,9 @@ interface InsertInterface extends QueryInterface, ValuesInterface, WithInterface
      *
      * Adds multiple rows for bulk insert.
      *
-     * @param array $rows An array of rows, where each element is an array of
-     * column key-value pairs. The values are bound to placeholders.
+     * @param array<array-key, array<int|string, mixed>> $rows An array of
+     * rows, where each element is an array of column key-value pairs. The
+     * values are bound to placeholders.
      *
      * @return $this
      *
@@ -75,8 +79,8 @@ interface InsertInterface extends QueryInterface, ValuesInterface, WithInterface
      * `set()` to work with the newly-added row. Calling `addRow()` again will
      * finish off the current row and start a new one.
      *
-     * @param array $cols An array of column key-value pairs; the values are
-     * bound to placeholders.
+     * @param array<int|string, mixed> $cols An array of column key-value
+     * pairs; the values are bound to placeholders.
      *
      * @return $this
      *

--- a/src/Common/OnConflictUpdateInterface.php
+++ b/src/Common/OnConflictUpdateInterface.php
@@ -21,7 +21,8 @@ interface OnConflictUpdateInterface
      *
      * Sets the conflict target column(s) or constraint name.
      *
-     * @param string|array $target The conflict target column(s) or constraint name.
+     * @param string|array<array-key, string> $target The conflict target
+     * column(s) or constraint name.
      *
      * @return $this
      *
@@ -35,7 +36,7 @@ interface OnConflictUpdateInterface
      *
      * @param string $col The column name.
      *
-     * @param array $value Optional: a value to bind to the placeholder.
+     * @param mixed ...$value Optional: a value to bind to the placeholder.
      *
      * @return $this
      *
@@ -48,9 +49,9 @@ interface OnConflictUpdateInterface
      * is a key-value pair, the key is treated as the column name and the value is bound
      * to that column.
      *
-     * @param array $cols A list of column names, optionally as key-value
-     * pairs where the key is a column name and the value is a bind value for
-     * that column.
+     * @param array<int|string, mixed> $cols A list of column names,
+     * optionally as key-value pairs where the key is a column name and the
+     * value is a bind value for that column.
      *
      * @return $this
      *
@@ -77,7 +78,8 @@ interface OnConflictUpdateInterface
      *
      * @param string $condition The WHERE condition.
      *
-     * @param array $bind Optional: values to bind to the condition.
+     * @param array<int|string, mixed> ...$bind Optional: values to bind to
+     * the condition.
      *
      * @return $this
      *

--- a/src/Common/OnConflictUpdateTrait.php
+++ b/src/Common/OnConflictUpdateTrait.php
@@ -34,9 +34,10 @@ trait OnConflictUpdateTrait
 
     /**
      *
-     * The conflict target column(s) or constraint name.
+     * The conflict target column(s) or constraint name, rendered ready for
+     * the clause.
      *
-     * @var string|array
+     * @var string|null
      *
      */
     protected $conflict_target;
@@ -45,7 +46,7 @@ trait OnConflictUpdateTrait
      *
      * Column values for UPDATE on conflict.
      *
-     * @var array
+     * @var array<string, string>
      *
      */
     protected $conflict_update_values = [];
@@ -54,7 +55,7 @@ trait OnConflictUpdateTrait
      *
      * WHERE conditions for UPDATE on conflict.
      *
-     * @var array
+     * @var list<string>
      *
      */
     protected $conflict_where = [];
@@ -63,7 +64,8 @@ trait OnConflictUpdateTrait
      *
      * Sets the conflict target column(s) or constraint name.
      *
-     * @param string|array $target The conflict target column(s) or constraint name.
+     * @param string|array<array-key, string> $target The conflict target
+     * column(s) or constraint name.
      *
      * @return $this
      *
@@ -144,7 +146,7 @@ trait OnConflictUpdateTrait
      *
      * @param string $col The column name.
      *
-     * @param array $value Optional: a value to bind to the placeholder.
+     * @param mixed ...$value Optional: a value to bind to the placeholder.
      *
      * @return $this
      *
@@ -168,9 +170,9 @@ trait OnConflictUpdateTrait
      * is a key-value pair, the key is treated as the column name and the value is bound
      * to that column.
      *
-     * @param array $cols A list of column names, optionally as key-value
-     * pairs where the key is a column name and the value is a bind value for
-     * that column.
+     * @param array<int|string, mixed> $cols A list of column names,
+     * optionally as key-value pairs where the key is a column name and the
+     * value is a bind value for that column.
      *
      * @return $this
      *
@@ -216,7 +218,8 @@ trait OnConflictUpdateTrait
      *
      * @param string $condition The WHERE condition.
      *
-     * @param array $bind Optional: values to bind to the condition.
+     * @param array<int|string, mixed> ...$bind Optional: values to bind to
+     * the condition.
      *
      * @return $this
      *

--- a/src/Common/Update.php
+++ b/src/Common/Update.php
@@ -132,7 +132,7 @@ class Update extends AbstractDmlQuery implements UpdateInterface
      *
      * @param string $col The column name.
      *
-     * @param array $value
+     * @param mixed ...$value
      *
      * @return $this
      */
@@ -147,9 +147,9 @@ class Update extends AbstractDmlQuery implements UpdateInterface
      * pair, the key is treated as the column name and the value is bound to
      * that column.
      *
-     * @param array $cols A list of column names, optionally as key-value
-     * pairs where the key is a column name and the value is a bind value for
-     * that column.
+     * @param array<int|string, mixed> $cols A list of column names,
+     * optionally as key-value pairs where the key is a column name and the
+     * value is a bind value for that column.
      *
      * @return $this
      *

--- a/src/Common/UpdateBuilder.php
+++ b/src/Common/UpdateBuilder.php
@@ -35,7 +35,7 @@ class UpdateBuilder extends AbstractBuilder
      *
      * Builds the columns and values for the statement.
      *
-     * @param array $col_values The columns and values.
+     * @param array<string, string> $col_values The columns and values.
      *
      * @return string
      *

--- a/src/Common/ValuesInterface.php
+++ b/src/Common/ValuesInterface.php
@@ -24,7 +24,7 @@ interface ValuesInterface
      *
      * @param string $col The column name.
      *
-     * @param array $value
+     * @param mixed ...$value
      *
      * @return $this
      */
@@ -36,9 +36,9 @@ interface ValuesInterface
      * pair, the key is treated as the column name and the value is bound to
      * that column.
      *
-     * @param array $cols A list of column names, optionally as key-value
-     * pairs where the key is a column name and the value is a bind value for
-     * that column.
+     * @param array<int|string, mixed> $cols A list of column names,
+     * optionally as key-value pairs where the key is a column name and the
+     * value is a bind value for that column.
      *
      * @return $this
      *

--- a/src/Mysql/Insert.php
+++ b/src/Mysql/Insert.php
@@ -43,7 +43,7 @@ class Insert extends Common\Insert
      * Column values for ON DUPLICATE KEY UPDATE section of query; the key is
      * the column name and the value is the column value.
      *
-     * @var array|null
+     * @var array<string, string>|null
      *
      */
     protected $col_on_update_values;
@@ -132,7 +132,7 @@ class Insert extends Common\Insert
      *
      * @param string $col The column name.
      *
-     * @param array $value Optional: a value to bind to the placeholder.
+     * @param mixed ...$value Optional: a value to bind to the placeholder.
      *
      * @return $this
      *
@@ -154,9 +154,9 @@ class Insert extends Common\Insert
      * section. If an element is a key-value pair, the key is treated as the
      * column name and the value is bound to that column.
      *
-     * @param array $cols A list of column names, optionally as key-value
-     * pairs where the key is a column name and the value is a bind value for
-     * that column.
+     * @param array<int|string, mixed> $cols A list of column names,
+     * optionally as key-value pairs where the key is a column name and the
+     * value is a bind value for that column.
      *
      * @return $this
      *
@@ -283,7 +283,7 @@ class Insert extends Common\Insert
      *
      * @param string|Common\SelectInterface $spec The CTE specification.
      *
-     * @param array $cols Optional column list for the CTE.
+     * @param array<array-key, string> $cols Optional column list for the CTE.
      *
      * @return $this
      *

--- a/src/Mysql/InsertBuilder.php
+++ b/src/Mysql/InsertBuilder.php
@@ -25,7 +25,7 @@ class InsertBuilder extends Common\InsertBuilder
      * not support `DEFAULT VALUES`, so an insert with no columns uses the
      * empty-list form instead.
      *
-     * @param array $col_values The column names and values.
+     * @param array<string, string> $col_values The column names and values.
      *
      * @return string
      *
@@ -43,8 +43,8 @@ class InsertBuilder extends Common\InsertBuilder
      *
      * Builds the UPDATE ON DUPLICATE KEY part of the statement.
      *
-     * @param array $col_on_update_values Columns and values to use for
-     * ON DUPLICATE KEY UPDATE.
+     * @param array<string, string>|null $col_on_update_values Columns and
+     * values to use for ON DUPLICATE KEY UPDATE.
      *
      * @return string
      *

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -44,7 +44,7 @@ class QueryFactory
      *
      * A map of `table.col` names to last-insert-id names.
      *
-     * @var array
+     * @var array<string, string>
      *
      */
     protected $last_insert_id_names = [];
@@ -78,8 +78,8 @@ class QueryFactory
      *
      * Sets the last-insert-id names to be used for Insert queries..
      *
-     * @param array $last_insert_id_names A map of `table.col` names to
-     * last-insert-id names.
+     * @param array<string, string> $last_insert_id_names A map of `table.col`
+     * names to last-insert-id names.
      *
      * @return void
      *


### PR DESCRIPTION
Continues the array-shape series (#263, #264, #265) with the column-values seam: `$col_values` and everything it feeds, from the setters on the interfaces through to the builders.

- `AbstractDmlQuery::$col_values` is `array<string, string>` -- quoted column name to placeholder or quoted expression -- so `buildValuesForInsert()`, `buildValuesForUpdate()` and the MySQL overrides take that same shape.
- The bulk-insert banks: `$col_values_bulk` is `array<int, array<string, string>>` keyed by row number, `$bind_values_bulk` is `array<string, mixed>`, `$bind_sources_bulk` is `array<string, string>`, and `$col_order` is `list<string>`.
- The upsert seam: `$conflict_update_values` is `array<string, string>`, `$conflict_where` is `list<string>`, and `$conflict_target` is `string|null` -- the docblock said `string|array`, but every write to it is a rendered string, so `buildOnConflict()` takes `string|null` too.
- `$last_insert_id_names` is `array<string, string>` on the query, the interface and the QueryFactory that hands it over.
- The variadic `...$value` / `...$bind` params were documented as `@param array`, which PHPStan reads as the type of each argument rather than of the collected array. They now say `mixed ...$value` and `array<int|string, mixed> ...$bind`.

Docblocks only, no behaviour change. Level 6 across `src` goes 77 -> 10; the remaining ones are the Quoter and orderBy seams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved PHPDoc annotations throughout query-building and insert/update APIs.
  * Added more precise descriptions for arrays, nullable values, variadic parameters, and return types.
  * Clarified supported value and column formats for conflict handling and bulk operations.
  * No runtime behavior or public method signatures changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->